### PR TITLE
feat(admin): bloquear días pasados en calendario de días especiales

### DIFF
--- a/backend/app/Console/Commands/AutoCancelarCitasPasadas.php
+++ b/backend/app/Console/Commands/AutoCancelarCitasPasadas.php
@@ -13,14 +13,15 @@ class AutoCancelarCitasPasadas extends Command
 
     public function handle(): void
     {
-        $now = Carbon::now();
+        // Grace period 15 min: la cita se marca como "no asistió" 15 min después de la hora agendada
+        $cutoff = Carbon::now()->subMinutes(15);
 
         $affected = Cita::where('estatus', 'programada')
-            ->where(function ($query) use ($now) {
-                $query->where('fecha_cita', '<', $now->toDateString())
-                    ->orWhere(function ($sub) use ($now) {
-                        $sub->where('fecha_cita', $now->toDateString())
-                            ->where('hora_cita', '<=', $now->format('H:i'));
+            ->where(function ($query) use ($cutoff) {
+                $query->where('fecha_cita', '<', $cutoff->toDateString())
+                    ->orWhere(function ($sub) use ($cutoff) {
+                        $sub->where('fecha_cita', $cutoff->toDateString())
+                            ->where('hora_cita', '<=', $cutoff->format('H:i'));
                     });
             })
             ->update(['estatus' => 'no_asistio']);

--- a/backend/app/Http/Controllers/AdminController.php
+++ b/backend/app/Http/Controllers/AdminController.php
@@ -4,11 +4,51 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\User;
+use App\Models\Cita;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 class AdminController extends Controller
 {
+    // ===== STATS =====
+
+    public function getStats()
+    {
+        $hoy = now()->toDateString();
+        $hace30 = now()->subDays(30)->toDateString();
+
+        $totalAlumnos  = User::where('tipo', 'alumno')->count();
+        $totalDoctores = User::where('tipo', 'doctor')->count();
+
+        $citasHoy          = Cita::whereDate('fecha_cita', $hoy)->count();
+        $citasCompletadas  = Cita::whereDate('fecha_cita', $hoy)->where('estatus', 'atendida')->count();
+        $citasPendientes   = Cita::whereDate('fecha_cita', $hoy)->whereIn('estatus', ['programada', 'pendiente'])->count();
+
+        $alumnosActivos = Cita::where('fecha_cita', '>=', $hace30)
+            ->whereNotNull('alumno_id')
+            ->distinct('alumno_id')
+            ->count('alumno_id');
+
+        $ultimoToken = DB::table('personal_access_tokens')
+            ->join('users', 'tokenable_id', '=', 'users.id')
+            ->orderByDesc('personal_access_tokens.created_at')
+            ->select('personal_access_tokens.created_at', 'users.email')
+            ->first();
+
+        return response()->json([
+            'total_usuarios'        => $totalAlumnos + $totalDoctores,
+            'total_alumnos'         => $totalAlumnos,
+            'total_doctores'        => $totalDoctores,
+            'citas_hoy'             => $citasHoy,
+            'citas_completadas_hoy' => $citasCompletadas,
+            'citas_pendientes_hoy'  => $citasPendientes,
+            'alumnos_activos'       => $alumnosActivos,
+            'ultimo_acceso_hora'    => $ultimoToken ? \Carbon\Carbon::parse($ultimoToken->created_at)->format('H:i') : null,
+            'ultimo_acceso_email'   => $ultimoToken?->email,
+        ]);
+    }
+
     // ===== ALUMNOS =====
 
     public function indexAlumnos(Request $request)

--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -4,23 +4,19 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use App\Models\TwoFactorCode;
-use App\Models\TrustedDevice;
-use App\Mail\TwoFactorCodeMail;
+use App\Services\Auth2FAService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Validation\ValidationException;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
 
 class AuthController extends Controller
 {
-    const CODE_DURATION = 10;
-    const DEVICE_TRUST_DAYS = 30;
-    const MAX_LOGIN_ATTEMPTS = 5;
-    const LOCKOUT_MINUTES = 15;
+    private const MAX_ATTEMPTS    = 5;
+    private const LOCKOUT_MINUTES = 15;
+
+    public function __construct(private Auth2FAService $twoFA) {}
 
     public function login(Request $request)
     {
@@ -32,93 +28,52 @@ class AuthController extends Controller
             'recordar_por'  => 'nullable|integer|in:1440,2880,7200,10080,20160,43200',
         ]);
 
-        $tipoUsuario  = $request->tipo_usuario;
+        $tipo          = $request->tipo_usuario;
         $identificador = $request->identificador;
-        $password      = $request->password;
-
-        // Verificar bloqueo temporal por intentos fallidos
-        $lockKey = "login_lockout_{$tipoUsuario}_{$identificador}";
-        $attemptsKey = "login_attempts_{$tipoUsuario}_{$identificador}";
+        $lockKey       = "login_lockout_{$tipo}_{$identificador}";
+        $attemptsKey   = "login_attempts_{$tipo}_{$identificador}";
 
         if (Cache::has($lockKey)) {
-            $minutosRestantes = (int) ceil(Cache::get($lockKey, 0) / 60);
+            $minutos = (int) ceil(Cache::get($lockKey, 0) / 60);
             return response()->json([
-                'message' => "Cuenta bloqueada temporalmente por demasiados intentos fallidos. Intenta de nuevo en {$minutosRestantes} minuto(s).",
-                'locked' => true,
-                'retry_after' => $minutosRestantes,
+                'message'     => "Cuenta bloqueada. Intenta de nuevo en {$minutos} minuto(s).",
+                'locked'      => true,
+                'retry_after' => $minutos,
             ], 429);
         }
 
-        // Buscar usuario según tipo
-        if ($tipoUsuario === 'alumno') {
-            $user = User::where('numero_control', $identificador)->where('tipo', 'alumno')->first();
-            if (!$user || !Hash::check($password, $user->nip)) {
-                return $this->handleFailedLogin($attemptsKey, $lockKey);
-            }
-        } elseif ($tipoUsuario === 'admin') {
-            $user = User::where('username', $identificador)->where('tipo', 'admin')->first();
-            if (!$user || !Hash::check($password, $user->password)) {
-                return $this->handleFailedLogin($attemptsKey, $lockKey);
-            }
-        } else {
-            $user = User::where('username', $identificador)->where('tipo', 'doctor')->first();
-            if (!$user || !Hash::check($password, $user->password)) {
-                return $this->handleFailedLogin($attemptsKey, $lockKey);
-            }
+        $user = match ($tipo) {
+            'alumno' => User::where('numero_control', $identificador)->where('tipo', 'alumno')->first(),
+            'admin'  => User::where('username', $identificador)->where('tipo', 'admin')->first(),
+            default  => User::where('username', $identificador)->where('tipo', 'doctor')->first(),
+        };
+
+        $campoPassword = ($tipo === 'alumno') ? 'nip' : 'password';
+
+        if (!$user || !Hash::check($request->password, $user->{$campoPassword})) {
+            return $this->handleFailedLogin($attemptsKey, $lockKey);
         }
 
-        // Login exitoso: limpiar intentos fallidos
         Cache::forget($attemptsKey);
+        $recordarPor = $request->input('recordar_por', 1440);
 
-        $recordarPor = $request->input('recordar_por', 1440); // minutos, default 1 día
-
-        // Alumnos: nunca requieren 2FA
-        if ($tipoUsuario === 'alumno' || config('app.env') === 'local') {
+        if ($tipo === 'alumno' || config('app.env') === 'local') {
             return $this->successResponse($user, $recordarPor);
         }
 
-        // Doctores y admins en producción: verificar dispositivo de confianza
-        $deviceToken = $request->device_token;
-        if ($deviceToken) {
-            $trusted = TrustedDevice::where('user_id', $user->id)
-                ->where('device_token', $deviceToken)
-                ->where('expires_at', '>', Carbon::now())
-                ->first();
-
-            if ($trusted) {
-                // Renovar expiración y devolver token directamente
-                $trusted->update(['expires_at' => Carbon::now()->addDays(self::DEVICE_TRUST_DAYS)]);
-                return $this->successResponse($user, $recordarPor);
-            }
+        if ($this->twoFA->isTrustedDevice($user, $request->device_token)) {
+            return $this->successResponse($user, $recordarPor);
         }
 
-        // Guardar duración elegida para usarla al verificar 2FA
         Cache::put("pending_recordar_{$user->id}", $recordarPor, 600);
-
-        // Sin dispositivo de confianza: enviar código 2FA
-        $code = str_pad(random_int(0, 999999), 6, '0', STR_PAD_LEFT);
-
-        TwoFactorCode::create([
-            'user_id'    => $user->id,
-            'code'       => Hash::make($code),
-            'expires_at' => Carbon::now()->addMinutes(self::CODE_DURATION),
-            'used'       => false,
-        ]);
-
-        try {
-            Mail::to($user->email)->send(new TwoFactorCodeMail($code, $user->nombre));
-            \Log::info('Email 2FA enviado', ['user_id' => $user->id]);
-        } catch (\Exception $e) {
-            \Log::error('SMTP ERROR 2FA: ' . $e->getMessage());
-            error_log('SMTP ERROR 2FA: ' . $e->getMessage());
-        }
+        $emailEnmascarado = $this->twoFA->sendCode($user);
 
         return response()->json([
             'message'      => 'Código de verificación enviado',
             'requires_2fa' => true,
             'user_id'      => $user->id,
-            'email_masked' => $this->maskEmail($user->email),
-        ], 200);
+            'email_masked' => $emailEnmascarado,
+        ]);
     }
 
     public function verifyTwoFactor(Request $request)
@@ -133,53 +88,20 @@ class AuthController extends Controller
             return response()->json(['message' => 'Usuario no encontrado'], 404);
         }
 
-        $twoFactorCode = null;
-        $pendingCodes = TwoFactorCode::where('user_id', $user->id)
-            ->where('used', false)
-            ->where('expires_at', '>', Carbon::now())
-            ->get();
-
-        foreach ($pendingCodes as $pending) {
-            if (Hash::check($request->code, $pending->code)) {
-                $twoFactorCode = $pending;
-                break;
-            }
-        }
+        $twoFactorCode = $this->twoFA->verifyCode($user, $request->code);
 
         if (!$twoFactorCode) {
-            $this->logFailed2FA($user, $request->code);
+            Log::warning('2FA fallido', ['user_id' => $user->id, 'ip' => $request->ip()]);
             return response()->json(['message' => 'Código inválido o expirado', 'requires_2fa' => true], 401);
         }
 
-        $twoFactorCode->update(['used' => true]);
+        $deviceToken = $this->twoFA->confirmAndCreateDevice($twoFactorCode, $user);
+        $recordarPor = Cache::pull("pending_recordar_{$user->id}", 1440);
 
-        // Limpiar códigos viejos
-        TwoFactorCode::where('user_id', $user->id)
-            ->where('created_at', '<', Carbon::now()->subHour())
-            ->delete();
-
-        // Generar device_token de confianza (30 días)
-        $deviceToken = Str::random(64);
-        TrustedDevice::create([
-            'user_id'      => $user->id,
-            'device_token' => $deviceToken,
-            'expires_at'   => Carbon::now()->addDays(self::DEVICE_TRUST_DAYS),
-        ]);
-
-        // Limpiar dispositivos viejos del usuario
-        TrustedDevice::where('user_id', $user->id)
-            ->where('expires_at', '<', Carbon::now())
-            ->delete();
-
-        // Recuperar duración del token de la sesión pendiente (guardada en caché)
-        $recordarPor = Cache::get("pending_recordar_{$user->id}", 1440);
-        Cache::forget("pending_recordar_{$user->id}");
-
-        $response = $this->successResponse($user, $recordarPor);
-        $data = $response->getData(true);
+        $data = $this->successResponse($user, $recordarPor)->getData(true);
         $data['device_token'] = $deviceToken;
 
-        return response()->json($data, 200);
+        return response()->json($data);
     }
 
     public function resendTwoFactor(Request $request)
@@ -191,50 +113,36 @@ class AuthController extends Controller
             return response()->json(['message' => 'Usuario no encontrado'], 404);
         }
 
-        $cacheKey = "2fa_resend_{$user->id}";
+        $cacheKey    = "2fa_resend_{$user->id}";
         $resendCount = Cache::get($cacheKey, 0);
 
         if ($resendCount >= 3) {
             return response()->json(['message' => 'Demasiados intentos. Espera 10 minutos.'], 429);
         }
 
-        $code = str_pad(random_int(0, 999999), 6, '0', STR_PAD_LEFT);
-
-        TwoFactorCode::create([
-            'user_id'    => $user->id,
-            'code'       => Hash::make($code),
-            'expires_at' => Carbon::now()->addMinutes(self::CODE_DURATION),
-            'used'       => false,
-        ]);
-
         Cache::put($cacheKey, $resendCount + 1, 600);
-
-        try {
-            Mail::to($user->email)->send(new TwoFactorCodeMail($code, $user->nombre));
-        } catch (\Exception $e) {
-            \Log::error('Error reenviando email 2FA: ' . $e->getMessage());
-        }
+        $emailEnmascarado = $this->twoFA->sendCode($user);
 
         return response()->json([
             'message'      => 'Nuevo código enviado',
-            'email_masked' => $this->maskEmail($user->email),
-        ], 200);
+            'email_masked' => $emailEnmascarado,
+        ]);
     }
 
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
-        return response()->json(['message' => 'Sesión cerrada exitosamente'], 200);
+        return response()->json(['message' => 'Sesión cerrada exitosamente']);
     }
 
     public function me(Request $request)
     {
-        return response()->json(['user' => $request->user()], 200);
+        return response()->json(['user' => $request->user()]);
     }
 
-    private function successResponse(User $user, int $minutosExpiracion = 1440)
+    private function successResponse(User $user, int $minutos = 1440)
     {
-        $token = $user->createToken('auth_token', ['*'], Carbon::now()->addMinutes($minutosExpiracion))->plainTextToken;
+        $token = $user->createToken('auth_token', ['*'], Carbon::now()->addMinutes($minutos))->plainTextToken;
 
         return response()->json([
             'message' => 'Inicio de sesión exitoso',
@@ -249,20 +157,7 @@ class AuthController extends Controller
             ],
             'token' => $token,
             'tipo'  => $user->tipo,
-        ], 200);
-    }
-
-    private function maskEmail(string $email): string
-    {
-        $parts = explode('@', $email);
-        $name  = $parts[0];
-        $domain = $parts[1] ?? '';
-
-        $maskedName = substr($name, 0, 2) . str_repeat('*', max(0, strlen($name) - 2));
-        $domainParts = explode('.', $domain);
-        $maskedDomain = substr($domainParts[0], 0, 1) . str_repeat('*', max(0, strlen($domainParts[0]) - 1));
-
-        return $maskedName . '@' . $maskedDomain . '.' . ($domainParts[1] ?? 'com');
+        ]);
     }
 
     private function handleFailedLogin(string $attemptsKey, string $lockKey)
@@ -270,36 +165,24 @@ class AuthController extends Controller
         $attempts = Cache::get($attemptsKey, 0) + 1;
         Cache::put($attemptsKey, $attempts, self::LOCKOUT_MINUTES * 60);
 
-        if ($attempts >= self::MAX_LOGIN_ATTEMPTS) {
+        if ($attempts >= self::MAX_ATTEMPTS) {
             $lockSeconds = self::LOCKOUT_MINUTES * 60;
             Cache::put($lockKey, $lockSeconds, $lockSeconds);
             Cache::forget($attemptsKey);
 
-            \Log::warning('Cuenta bloqueada por intentos fallidos', [
-                'ip' => request()->ip(),
-                'attempts' => $attempts,
-            ]);
+            Log::warning('Cuenta bloqueada', ['ip' => request()->ip(), 'attempts' => $attempts]);
 
             return response()->json([
-                'message' => 'Cuenta bloqueada temporalmente por demasiados intentos fallidos. Intenta de nuevo en ' . self::LOCKOUT_MINUTES . ' minuto(s).',
-                'locked' => true,
+                'message'     => 'Cuenta bloqueada por demasiados intentos. Intenta en ' . self::LOCKOUT_MINUTES . ' minuto(s).',
+                'locked'      => true,
                 'retry_after' => self::LOCKOUT_MINUTES,
             ], 429);
         }
 
-        $restantes = self::MAX_LOGIN_ATTEMPTS - $attempts;
-
+        $restantes = self::MAX_ATTEMPTS - $attempts;
         return response()->json([
-            'message' => "Las credenciales son incorrectas. Te quedan {$restantes} intento(s) antes del bloqueo temporal.",
+            'message'            => "Credenciales incorrectas. Te quedan {$restantes} intento(s).",
             'attempts_remaining' => $restantes,
         ], 422);
-    }
-
-    private function logFailed2FA(User $user, string $code): void
-    {
-        \Log::warning('2FA fallido', [
-            'user_id' => $user->id,
-            'ip'      => request()->ip(),
-        ]);
     }
 }

--- a/backend/app/Http/Controllers/BitacoraController.php
+++ b/backend/app/Http/Controllers/BitacoraController.php
@@ -37,14 +37,10 @@ class BitacoraController extends Controller
         return response()->json(['bitacoras' => $bitacoras], 200);
     }
 
-    // Crear bitácora (solo doctor)
+    // Crear bitácora (solo doctor — protegido por role:doctor middleware)
     public function store(Request $request)
     {
         $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
 
         $validated = $request->validate([
             'cita_id' => 'required|exists:citas,id',
@@ -70,7 +66,7 @@ class BitacoraController extends Controller
     }
 
     // Ver bitácora
-    public function show(Request $request, $id)
+    public function show(Request $request, int $id)
     {
         $user = $request->user();
         $bitacora = Bitacora::with(['cita', 'alumno', 'doctor'])->findOrFail($id);
@@ -83,15 +79,9 @@ class BitacoraController extends Controller
         return response()->json($bitacora, 200);
     }
 
-    // Actualizar bitácora (solo doctor)
-    public function update(Request $request, $id)
+    // Actualizar bitácora (solo doctor — protegido por role:doctor middleware)
+    public function update(Request $request, int $id)
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-
         $bitacora = Bitacora::findOrFail($id);
 
         $validated = $request->validate([

--- a/backend/app/Http/Controllers/BitacoraController.php
+++ b/backend/app/Http/Controllers/BitacoraController.php
@@ -14,8 +14,8 @@ class BitacoraController extends Controller
         $user = $request->user();
 
         $query = $user->esAlumno()
-            ? Bitacora::where('alumno_id', $user->id)->with(['cita', 'doctor'])
-            : Bitacora::with(['cita', 'alumno']);
+            ? Bitacora::where('alumno_id', $user->id)->with(['cita:id,fecha_cita,hora_cita,motivo', 'doctor:id,nombre,apellido'])
+            : Bitacora::with(['cita:id,fecha_cita,hora_cita,motivo,alumno_id', 'alumno:id,nombre,apellido,numero_control']);
 
         if ($request->filled('fecha_desde')) {
             $query->whereDate('created_at', '>=', $request->fecha_desde);

--- a/backend/app/Http/Controllers/BitacoraController.php
+++ b/backend/app/Http/Controllers/BitacoraController.php
@@ -66,7 +66,7 @@ class BitacoraController extends Controller
     }
 
     // Ver bitácora
-    public function show(Request $request, int $id)
+    public function show(Request $request, $id)
     {
         $user = $request->user();
         $bitacora = Bitacora::with(['cita', 'alumno', 'doctor'])->findOrFail($id);
@@ -80,7 +80,7 @@ class BitacoraController extends Controller
     }
 
     // Actualizar bitácora (solo doctor — protegido por role:doctor middleware)
-    public function update(Request $request, int $id)
+    public function update(Request $request, $id)
     {
         $bitacora = Bitacora::findOrFail($id);
 

--- a/backend/app/Http/Controllers/CalendarioAdminController.php
+++ b/backend/app/Http/Controllers/CalendarioAdminController.php
@@ -29,9 +29,11 @@ class CalendarioAdminController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'fecha'   => 'required|date',
+            'fecha'   => 'required|date|after_or_equal:today',
             'tipo'    => 'required|in:holiday,vacation,reduced',
             'etiqueta' => 'nullable|string|max:200',
+        ], [
+            'fecha.after_or_equal' => 'No se pueden registrar días especiales en fechas pasadas.',
         ]);
 
         $dia = DiaEspecial::updateOrCreate(

--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -99,7 +99,7 @@ class CitaController extends Controller
         return response()->json(['message' => 'Cita agendada exitosamente', 'cita' => $cita], 201);
     }
 
-    public function show(Request $request, int $id)
+    public function show(Request $request, $id)
     {
         $user = $request->user();
         $cita = Cita::with(['alumno', 'doctor', 'bitacora', 'receta'])->findOrFail($id);
@@ -111,7 +111,7 @@ class CitaController extends Controller
         return response()->json($cita);
     }
 
-    public function cancelar(Request $request, int $id)
+    public function cancelar(Request $request, $id)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($id);
@@ -142,7 +142,7 @@ class CitaController extends Controller
     }
 
     // Solo doctor — ruta protegida por role:doctor middleware
-    public function atender(Request $request, int $id)
+    public function atender(Request $request, $id)
     {
         $cita = Cita::findOrFail($id);
         $cita->update([
@@ -155,7 +155,7 @@ class CitaController extends Controller
     }
 
     // Solo doctor — ruta protegida por role:doctor middleware
-    public function reprogramar(Request $request, int $id)
+    public function reprogramar(Request $request, $id)
     {
         $cita = Cita::findOrFail($id);
 
@@ -196,7 +196,7 @@ class CitaController extends Controller
     }
 
     // Solo doctor — ruta protegida por role:doctor middleware
-    public function noAsistio(Request $request, int $id)
+    public function noAsistio($id)
     {
         $cita = Cita::findOrFail($id);
 

--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -24,12 +24,12 @@ class CitaController extends Controller
 
         if ($user->esAlumno()) {
             $citas = Cita::where('alumno_id', $user->id)
-                        ->with(['doctor'])
+                        ->with(['doctor:id,nombre,apellido,username'])
                         ->orderBy('fecha_cita', 'desc')
                         ->orderBy('hora_cita', 'desc')
                         ->get();
         } else {
-            $citas = Cita::with(['alumno'])
+            $citas = Cita::with(['alumno:id,nombre,apellido,numero_control'])
                         ->orderBy('fecha_cita', 'desc')
                         ->orderBy('hora_cita', 'desc')
                         ->get();
@@ -51,62 +51,43 @@ class CitaController extends Controller
         $start = Carbon::create($year, $month, 1)->startOfMonth();
         $end = (clone $start)->endOfMonth();
 
-        $citas = Cita::whereBetween('fecha_cita', [$start->toDateString(), $end->toDateString()])
-            ->where('estatus', 'programada')
-            ->get();
+        $days = Cache::remember("disp_{$year}_{$month}", 900, function () use ($start, $end, $year, $month) {
+            $citas = Cita::whereBetween('fecha_cita', [$start->toDateString(), $end->toDateString()])
+                ->where('estatus', 'programada')
+                ->select('fecha_cita', 'hora_cita')
+                ->get();
 
-        $grouped = [];
-        foreach ($citas as $cita) {
-            // "fecha_cita" está casteada como Carbon en el modelo, así que
-            // la normalizamos a string (Y-m-d) para usarla como llave de arreglo.
-            $dateKey = $cita->fecha_cita instanceof Carbon
-                ? $cita->fecha_cita->toDateString()
-                : (string) $cita->fecha_cita;
+            $grouped = [];
+            foreach ($citas as $cita) {
+                $dateKey = $cita->fecha_cita instanceof Carbon
+                    ? $cita->fecha_cita->toDateString()
+                    : (string) $cita->fecha_cita;
 
-            $normalizedHour = Carbon::parse($cita->hora_cita)->format('H:i');
-            $grouped[$dateKey][] = $normalizedHour;
-        }
+                $grouped[$dateKey][] = Carbon::parse($cita->hora_cita)->format('H:i');
+            }
 
-        $types = config('clinic.types', []);
+            $types = config('clinic.types', []);
+            $result = [];
+            foreach ($grouped as $date => $slots) {
+                $result[$date] = ['date' => $date, 'taken_slots' => array_values(array_unique($slots)), 'special' => null];
+            }
 
-        $days = [];
-        foreach ($grouped as $date => $slots) {
-            $uniqueSlots = array_values(array_unique($slots));
-            $days[$date] = [
-                'date' => $date,
-                'taken_slots' => $uniqueSlots,
-                'special' => null,
-            ];
-        }
+            foreach (DiaEspecial::whereYear('fecha', $year)->whereMonth('fecha', $month)->get() as $dia) {
+                $date = $dia->fecha->toDateString();
+                $result[$date] = array_merge($result[$date] ?? ['date' => $date, 'taken_slots' => [], 'special' => null], [
+                    'special' => [
+                        'type'   => $dia->tipo,
+                        'label'  => $dia->etiqueta,
+                        'status' => $types[$dia->tipo]['status'] ?? 'full',
+                        'color'  => $types[$dia->tipo]['color'] ?? '#ef5350',
+                    ],
+                ]);
+            }
 
-        // Leer días especiales de la BD (en lugar del config estático)
-        $diasEspeciales = DiaEspecial::whereYear('fecha', $year)
-            ->whereMonth('fecha', $month)
-            ->get();
+            return array_values($result);
+        });
 
-        foreach ($diasEspeciales as $dia) {
-            $date = $dia->fecha->toDateString();
-            $type = $dia->tipo;
-
-            $days[$date] = array_merge($days[$date] ?? [
-                'date' => $date,
-                'taken_slots' => [],
-                'special' => null,
-            ], [
-                'special' => [
-                    'type' => $type,
-                    'label' => $dia->etiqueta,
-                    'status' => $types[$type]['status'] ?? 'full',
-                    'color' => $types[$type]['color'] ?? '#ef5350',
-                ],
-            ]);
-        }
-
-        return response()->json([
-            'month' => $month,
-            'year' => $year,
-            'days' => array_values($days),
-        ]);
+        return response()->json(['month' => $month, 'year' => $year, 'days' => $days]);
     }
 
     // Crear cita
@@ -177,7 +158,9 @@ class CitaController extends Controller
             ], 422);
         }
 
-        $cita->load(['alumno', 'doctor']);
+        $cita->load(['alumno:id,nombre,apellido,numero_control,fcm_token', 'doctor:id,nombre,apellido']);
+        $fechaCita = Carbon::parse($cita->fecha_cita);
+        Cache::forget("disp_{$fechaCita->year}_{$fechaCita->month}");
 
         // Notificación push al alumno
         if ($cita->alumno?->fcm_token) {
@@ -226,7 +209,9 @@ class CitaController extends Controller
             ], 400);
         }
 
+        $mes = Carbon::parse($cita->fecha_cita);
         $cita->update(['estatus' => 'cancelada']);
+        Cache::forget("disp_{$mes->year}_{$mes->month}");
         $cita->load('alumno');
 
         // Notificación push al alumno
@@ -307,11 +292,15 @@ class CitaController extends Controller
             return response()->json(['message' => 'El horario seleccionado ya no está disponible.'], 422);
         }
 
+        $mesAnterior = Carbon::parse($cita->fecha_cita);
         $cita->update([
             'fecha_cita' => $validated['fecha_cita'],
             'hora_cita'  => $validated['hora_cita'],
         ]);
-        $cita->load(['alumno', 'doctor']);
+        $mesNuevo = Carbon::parse($validated['fecha_cita']);
+        Cache::forget("disp_{$mesAnterior->year}_{$mesAnterior->month}");
+        Cache::forget("disp_{$mesNuevo->year}_{$mesNuevo->month}");
+        $cita->load(['alumno:id,nombre,apellido,numero_control,fcm_token', 'doctor:id,nombre,apellido']);
 
         if ($cita->alumno?->fcm_token) {
             (new FcmService())->send(

--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -17,6 +17,9 @@ class CitaController extends Controller
 
     public function index(Request $request)
     {
+        // Lazy fallback al scheduler (Render free tier no ejecuta cron)
+        $this->citaService->marcarPasadasComoNoAsistio();
+
         $user = $request->user();
 
         $citas = $user->esAlumno()

--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -5,164 +5,88 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\Cita;
 use App\Models\User;
-use App\Models\DiaEspecial;
+use App\Services\CitaService;
 use App\Services\FcmService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
 
-/**
- * Controlador para gestionar citas
- */
 class CitaController extends Controller
 {
-    // Listar citas
+    public function __construct(private CitaService $citaService) {}
+
     public function index(Request $request)
     {
         $user = $request->user();
 
-        if ($user->esAlumno()) {
-            $citas = Cita::where('alumno_id', $user->id)
-                        ->with(['doctor:id,nombre,apellido,username'])
-                        ->orderBy('fecha_cita', 'desc')
-                        ->orderBy('hora_cita', 'desc')
-                        ->get();
-        } else {
-            $citas = Cita::with(['alumno:id,nombre,apellido,numero_control'])
-                        ->orderBy('fecha_cita', 'desc')
-                        ->orderBy('hora_cita', 'desc')
-                        ->get();
-        }
+        $citas = $user->esAlumno()
+            ? Cita::where('alumno_id', $user->id)
+                ->with(['doctor:id,nombre,apellido,username'])
+                ->orderBy('fecha_cita', 'desc')->orderBy('hora_cita', 'desc')->get()
+            : Cita::with(['alumno:id,nombre,apellido,numero_control'])
+                ->orderBy('fecha_cita', 'desc')->orderBy('hora_cita', 'desc')->get();
 
-        return response()->json(['citas' => $citas], 200);
+        return response()->json(['citas' => $citas]);
     }
 
     public function availability(Request $request)
     {
         $request->validate([
             'month' => 'nullable|integer|min:1|max:12',
-            'year' => 'nullable|integer|min:2000|max:2100',
+            'year'  => 'nullable|integer|min:2000|max:2100',
         ]);
 
         $month = $request->input('month', now()->month);
-        $year = $request->input('year', now()->year);
-
-        $start = Carbon::create($year, $month, 1)->startOfMonth();
-        $end = (clone $start)->endOfMonth();
-
-        $days = Cache::remember("disp_{$year}_{$month}", 900, function () use ($start, $end, $year, $month) {
-            $citas = Cita::whereBetween('fecha_cita', [$start->toDateString(), $end->toDateString()])
-                ->where('estatus', 'programada')
-                ->select('fecha_cita', 'hora_cita')
-                ->get();
-
-            $grouped = [];
-            foreach ($citas as $cita) {
-                $dateKey = $cita->fecha_cita instanceof Carbon
-                    ? $cita->fecha_cita->toDateString()
-                    : (string) $cita->fecha_cita;
-
-                $grouped[$dateKey][] = Carbon::parse($cita->hora_cita)->format('H:i');
-            }
-
-            $types = config('clinic.types', []);
-            $result = [];
-            foreach ($grouped as $date => $slots) {
-                $result[$date] = ['date' => $date, 'taken_slots' => array_values(array_unique($slots)), 'special' => null];
-            }
-
-            foreach (DiaEspecial::whereYear('fecha', $year)->whereMonth('fecha', $month)->get() as $dia) {
-                $date = $dia->fecha->toDateString();
-                $result[$date] = array_merge($result[$date] ?? ['date' => $date, 'taken_slots' => [], 'special' => null], [
-                    'special' => [
-                        'type'   => $dia->tipo,
-                        'label'  => $dia->etiqueta,
-                        'status' => $types[$dia->tipo]['status'] ?? 'full',
-                        'color'  => $types[$dia->tipo]['color'] ?? '#ef5350',
-                    ],
-                ]);
-            }
-
-            return array_values($result);
-        });
+        $year  = $request->input('year', now()->year);
+        $days  = $this->citaService->getAvailability($month, $year);
 
         return response()->json(['month' => $month, 'year' => $year, 'days' => $days]);
     }
 
-    // Crear cita
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'fecha_cita' => 'required|date|after_or_equal:today',
-            'hora_cita' => 'required|date_format:H:i',
-            'motivo' => 'nullable|string|max:500',
-            'numero_control' => 'nullable|string|exists:users,numero_control',
+            'fecha_cita'      => 'required|date|after_or_equal:today',
+            'hora_cita'       => 'required|date_format:H:i',
+            'motivo'          => 'nullable|string|max:500',
+            'numero_control'  => 'nullable|string|exists:users,numero_control',
         ], [
-            'fecha_cita.required' => 'La fecha de la cita es obligatoria.',
-            'fecha_cita.date' => 'Ingresa una fecha de cita válida.',
+            'fecha_cita.required'       => 'La fecha de la cita es obligatoria.',
+            'fecha_cita.date'           => 'Ingresa una fecha de cita válida.',
             'fecha_cita.after_or_equal' => 'La fecha de la cita debe ser hoy o una fecha futura.',
-            'hora_cita.required' => 'La hora de la cita es obligatoria.',
-            'hora_cita.date_format' => 'La hora de la cita debe tener el formato HH:MM.',
-            'numero_control.exists' => 'No se encontró un alumno con ese número de control. Verifica los datos ingresados.',
+            'hora_cita.required'        => 'La hora de la cita es obligatoria.',
+            'hora_cita.date_format'     => 'La hora de la cita debe tener el formato HH:MM.',
+            'numero_control.exists'     => 'No se encontró un alumno con ese número de control.',
         ]);
 
-        // Validar que no sea domingo
-        $diaSemana = Carbon::parse($validated['fecha_cita'])->dayOfWeek;
-        if ($diaSemana === 0) {
-            return response()->json([
-                'message' => 'No se pueden agendar citas los domingos.',
-            ], 422);
-        }
-
-        // Validar horario de atención: 08:00 a 16:45 (último slot antes de las 17:00)
-        $hora = $validated['hora_cita'];
-        if ($hora < '08:00' || $hora > '16:45') {
-            return response()->json([
-                'message' => 'El horario de atención es de 08:00 a 16:45.',
-            ], 422);
+        if ($error = $this->citaService->validarHorario($validated['fecha_cita'], $validated['hora_cita'])) {
+            return response()->json(['message' => $error], 422);
         }
 
         $user = $request->user();
 
-        // Usar transacción con lockForUpdate para prevenir double-booking
-        $cita = DB::transaction(function () use ($validated, $user, $request) {
-            $slotOcupado = Cita::where('fecha_cita', $validated['fecha_cita'])
-                ->where('hora_cita', $validated['hora_cita'])
-                ->where('estatus', 'programada')
-                ->lockForUpdate()
-                ->exists();
+        if ($user->esAlumno()) {
+            $alumnoId = $user->id;
+        } elseif ($request->filled('numero_control')) {
+            $alumnoId = User::where('numero_control', $request->numero_control)->firstOrFail()->id;
+        } else {
+            $alumnoId = $request->alumno_id;
+        }
 
-            if ($slotOcupado) {
-                return null;
-            }
-
-            // Generar clave única
-            $validated['clave_cita'] = Cita::generarClaveCita();
-            if ($user->esAlumno()) {
-                $validated['alumno_id'] = $user->id;
-            } elseif ($request->filled('numero_control')) {
-                $alumno = User::where('numero_control', $request->numero_control)->firstOrFail();
-                $validated['alumno_id'] = $alumno->id;
-            } else {
-                $validated['alumno_id'] = $request->alumno_id;
-            }
-            $validated['estatus'] = 'programada';
-
-            return Cita::create($validated);
-        });
+        $cita = $this->citaService->reservarSlot(
+            $validated['fecha_cita'],
+            $validated['hora_cita'],
+            $validated['motivo'] ?? null,
+            $alumnoId
+        );
 
         if (!$cita) {
-            return response()->json([
-                'message' => 'El horario seleccionado ya no está disponible. Elige otra hora.',
-            ], 422);
+            return response()->json(['message' => 'El horario seleccionado ya no está disponible. Elige otra hora.'], 422);
         }
 
         $cita->load(['alumno:id,nombre,apellido,numero_control,fcm_token', 'doctor:id,nombre,apellido']);
-        $fechaCita = Carbon::parse($cita->fecha_cita);
-        Cache::forget("disp_{$fechaCita->year}_{$fechaCita->month}");
+        Cache::forget("disp_{$cita->fecha_cita->year}_{$cita->fecha_cita->month}");
 
-        // Notificación push al alumno
         if ($cita->alumno?->fcm_token) {
             (new FcmService())->send(
                 $cita->alumno->fcm_token,
@@ -172,41 +96,32 @@ class CitaController extends Controller
             );
         }
 
-        return response()->json([
-            'message' => 'Cita agendada exitosamente',
-            'cita' => $cita
-        ], 201);
+        return response()->json(['message' => 'Cita agendada exitosamente', 'cita' => $cita], 201);
     }
 
-    // Ver una cita
-    public function show(Request $request, $id)
+    public function show(Request $request, int $id)
     {
         $user = $request->user();
         $cita = Cita::with(['alumno', 'doctor', 'bitacora', 'receta'])->findOrFail($id);
 
-        // Verificar permisos
         if ($user->esAlumno() && $cita->alumno_id !== $user->id) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
-        return response()->json($cita, 200);
+        return response()->json($cita);
     }
 
-    // Cancelar cita
-    public function cancelar(Request $request, $id)
+    public function cancelar(Request $request, int $id)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($id);
 
-        // Verificar permisos
         if ($user->esAlumno() && $cita->alumno_id !== $user->id) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
         if (in_array($cita->estatus, ['atendida', 'no_asistio'])) {
-            return response()->json([
-                'message' => 'No se puede cancelar una cita que ya fue procesada.'
-            ], 400);
+            return response()->json(['message' => 'No se puede cancelar una cita que ya fue procesada.'], 400);
         }
 
         $mes = Carbon::parse($cita->fecha_cita);
@@ -214,7 +129,6 @@ class CitaController extends Controller
         Cache::forget("disp_{$mes->year}_{$mes->month}");
         $cita->load('alumno');
 
-        // Notificación push al alumno
         if ($cita->alumno?->fcm_token) {
             (new FcmService())->send(
                 $cita->alumno->fcm_token,
@@ -224,44 +138,25 @@ class CitaController extends Controller
             );
         }
 
-        return response()->json([
-            'message' => 'Cita cancelada exitosamente',
-            'cita' => $cita
-        ], 200);
+        return response()->json(['message' => 'Cita cancelada exitosamente', 'cita' => $cita]);
     }
 
-    // Marcar como atendida (solo doctor)
-    public function atender(Request $request, $id)
+    // Solo doctor — ruta protegida por role:doctor middleware
+    public function atender(Request $request, int $id)
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-
         $cita = Cita::findOrFail($id);
-
         $cita->update([
-            'estatus' => 'atendida',
-            'doctor_id' => $user->id,
+            'estatus'            => 'atendida',
+            'doctor_id'          => $request->user()->id,
             'fecha_hora_atencion' => now(),
         ]);
 
-        return response()->json([
-            'message' => 'Cita marcada como atendida',
-            'cita' => $cita
-        ], 200);
+        return response()->json(['message' => 'Cita marcada como atendida', 'cita' => $cita]);
     }
 
-    // Reprogramar cita (solo doctor)
-    public function reprogramar(Request $request, $id)
+    // Solo doctor — ruta protegida por role:doctor middleware
+    public function reprogramar(Request $request, int $id)
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'Solo el doctor puede reprogramar citas'], 403);
-        }
-
         $cita = Cita::findOrFail($id);
 
         if ($cita->estatus !== 'programada') {
@@ -273,30 +168,16 @@ class CitaController extends Controller
             'hora_cita'  => 'required|date_format:H:i',
         ]);
 
-        $diaSemana = Carbon::parse($validated['fecha_cita'])->dayOfWeek;
-        if ($diaSemana === 0) {
-            return response()->json(['message' => 'No se pueden agendar citas los domingos.'], 422);
+        if ($error = $this->citaService->validarHorario($validated['fecha_cita'], $validated['hora_cita'])) {
+            return response()->json(['message' => $error], 422);
         }
 
-        if ($validated['hora_cita'] < '08:00' || $validated['hora_cita'] > '16:45') {
-            return response()->json(['message' => 'El horario de atención es de 08:00 a 16:45.'], 422);
-        }
-
-        $slotOcupado = Cita::where('fecha_cita', $validated['fecha_cita'])
-            ->where('hora_cita', $validated['hora_cita'])
-            ->where('estatus', 'programada')
-            ->where('id', '!=', $id)
-            ->exists();
-
-        if ($slotOcupado) {
+        if (!$this->citaService->slotDisponible($validated['fecha_cita'], $validated['hora_cita'], $id)) {
             return response()->json(['message' => 'El horario seleccionado ya no está disponible.'], 422);
         }
 
         $mesAnterior = Carbon::parse($cita->fecha_cita);
-        $cita->update([
-            'fecha_cita' => $validated['fecha_cita'],
-            'hora_cita'  => $validated['hora_cita'],
-        ]);
+        $cita->update(['fecha_cita' => $validated['fecha_cita'], 'hora_cita' => $validated['hora_cita']]);
         $mesNuevo = Carbon::parse($validated['fecha_cita']);
         Cache::forget("disp_{$mesAnterior->year}_{$mesAnterior->month}");
         Cache::forget("disp_{$mesNuevo->year}_{$mesNuevo->month}");
@@ -311,21 +192,12 @@ class CitaController extends Controller
             );
         }
 
-        return response()->json([
-            'message' => 'Cita reprogramada exitosamente',
-            'cita'    => $cita
-        ], 200);
+        return response()->json(['message' => 'Cita reprogramada exitosamente', 'cita' => $cita]);
     }
 
-    // Marcar como no asistió (solo doctor, manual)
-    public function noAsistio(Request $request, $id)
+    // Solo doctor — ruta protegida por role:doctor middleware
+    public function noAsistio(Request $request, int $id)
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-
         $cita = Cita::findOrFail($id);
 
         if ($cita->estatus !== 'programada') {
@@ -333,11 +205,6 @@ class CitaController extends Controller
         }
 
         $cita->update(['estatus' => 'no_asistio']);
-
-        return response()->json([
-            'message' => 'Cita marcada como no asistida',
-            'cita' => $cita
-        ], 200);
+        return response()->json(['message' => 'Cita marcada como no asistida', 'cita' => $cita]);
     }
 }
-

--- a/backend/app/Http/Controllers/EstadisticasController.php
+++ b/backend/app/Http/Controllers/EstadisticasController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Cita;
 use App\Models\Bitacora;
 use Carbon\Carbon;
@@ -10,13 +9,9 @@ use Illuminate\Support\Facades\Cache;
 
 class EstadisticasController extends Controller
 {
-    public function index(Request $request)
+    // Solo doctor — protegido por role:doctor middleware
+    public function index()
     {
-        $user = $request->user();
-        if ($user->tipo !== 'doctor') {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-
         $data = Cache::remember('estadisticas', 1800, fn () => $this->calcular());
 
         return response()->json($data);

--- a/backend/app/Http/Controllers/EstadisticasController.php
+++ b/backend/app/Http/Controllers/EstadisticasController.php
@@ -4,44 +4,45 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Cita;
+use App\Models\Bitacora;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 class EstadisticasController extends Controller
 {
     public function index(Request $request)
     {
-        // Solo doctores pueden ver estadísticas
         $user = $request->user();
         if ($user->tipo !== 'doctor') {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
-        // Citas por mes (últimos 6 meses)
-        $citasPorMes = [];
-        for ($i = 5; $i >= 0; $i--) {
-            $mes = Carbon::now()->subMonths($i)->startOfMonth();
-            $fin = $mes->copy()->endOfMonth();
+        $data = Cache::remember('estadisticas', 1800, fn () => $this->calcular());
 
-            $citas = Cita::whereBetween('fecha_cita', [$mes->toDateString(), $fin->toDateString()])->get();
+        return response()->json($data);
+    }
 
-            $citasPorMes[] = [
-                'mes'        => $mes->format('Y-m'),
-                'label'      => ucfirst($mes->locale('es')->isoFormat('MMM YYYY')),
-                'total'      => $citas->count(),
-                'atendidas'  => $citas->where('estatus', 'atendida')->count(),
-                'canceladas' => $citas->where('estatus', 'cancelada')->count(),
-                'no_asistio' => $citas->where('estatus', 'no_asistio')->count(),
-                'programadas' => $citas->where('estatus', 'programada')->count(),
-            ];
-        }
+    private function calcular(): array
+    {
+        $desde = Carbon::now()->subMonths(5)->startOfMonth()->toDateString();
 
-        // Resumen total por estado
-        $todas = Cita::all();
+        // 1 query: citas de los últimos 6 meses por mes y estatus
+        $rawCitas = Cita::where('fecha_cita', '>=', $desde)
+            ->selectRaw("to_char(fecha_cita, 'YYYY-MM') as mes, estatus, COUNT(*) as total")
+            ->groupBy('mes', 'estatus')
+            ->get()
+            ->groupBy('mes');
+
+        // 1 query: resumen histórico total por estatus
+        $resumenRaw = Cita::selectRaw("estatus, COUNT(*) as total")
+            ->groupBy('estatus')
+            ->pluck('total', 'estatus');
+
         $resumenEstados = [
-            'programada' => $todas->where('estatus', 'programada')->count(),
-            'atendida'   => $todas->where('estatus', 'atendida')->count(),
-            'cancelada'  => $todas->where('estatus', 'cancelada')->count(),
-            'no_asistio' => $todas->where('estatus', 'no_asistio')->count(),
+            'programada' => (int) ($resumenRaw['programada'] ?? 0),
+            'atendida'   => (int) ($resumenRaw['atendida'] ?? 0),
+            'cancelada'  => (int) ($resumenRaw['cancelada'] ?? 0),
+            'no_asistio' => (int) ($resumenRaw['no_asistio'] ?? 0),
         ];
 
         $totalCerradas = $resumenEstados['atendida'] + $resumenEstados['cancelada'] + $resumenEstados['no_asistio'];
@@ -49,11 +50,46 @@ class EstadisticasController extends Controller
             ? round(($resumenEstados['atendida'] / $totalCerradas) * 100, 1)
             : 0;
 
-        return response()->json([
-            'citas_por_mes'   => $citasPorMes,
-            'resumen_estados' => $resumenEstados,
-            'tasa_asistencia' => $tasaAsistencia,
-            'total_citas'     => $todas->count(),
+        $citasPorMes = [];
+        for ($i = 5; $i >= 0; $i--) {
+            $mes = Carbon::now()->subMonths($i)->startOfMonth();
+            $mesKey = $mes->format('Y-m');
+            $mesCitas = $rawCitas->get($mesKey, collect());
+            $desglose  = $mesCitas->pluck('total', 'estatus');
+
+            $citasPorMes[] = [
+                'mes'         => $mesKey,
+                'label'       => ucfirst($mes->locale('es')->isoFormat('MMM YYYY')),
+                'total'       => (int) $mesCitas->sum('total'),
+                'atendidas'   => (int) ($desglose['atendida'] ?? 0),
+                'canceladas'  => (int) ($desglose['cancelada'] ?? 0),
+                'no_asistio'  => (int) ($desglose['no_asistio'] ?? 0),
+                'programadas' => (int) ($desglose['programada'] ?? 0),
+            ];
+        }
+
+        // 1 query: top 5 diagnósticos + total general via window function
+        $dxRows = Bitacora::whereNotNull('diagnostico')
+            ->where('diagnostico', '!=', '')
+            ->selectRaw("diagnostico, COUNT(*) as total, SUM(COUNT(*)) OVER () as grand_total")
+            ->groupBy('diagnostico')
+            ->orderByDesc('total')
+            ->limit(5)
+            ->get();
+
+        $totalBitacoras = (int) ($dxRows->first()?->grand_total ?? 0);
+        $diagnosticosFrecuentes = $dxRows->map(fn ($d) => [
+            'diagnostico' => $d->diagnostico,
+            'total'       => (int) $d->total,
+            'pct'         => $totalBitacoras > 0 ? (int) round($d->total / $totalBitacoras * 100) : 0,
         ]);
+
+        return [
+            'citas_por_mes'           => $citasPorMes,
+            'resumen_estados'         => $resumenEstados,
+            'tasa_asistencia'         => $tasaAsistencia,
+            'total_citas'             => (int) $resumenRaw->sum(),
+            'diagnosticos_frecuentes' => $diagnosticosFrecuentes,
+        ];
     }
 }

--- a/backend/app/Http/Controllers/IASymptomController.php
+++ b/backend/app/Http/Controllers/IASymptomController.php
@@ -8,10 +8,6 @@ use App\Models\Cita;
 use App\Models\PreEvaluacionIA;
 use Illuminate\Http\Request;
 
-/**
- * Controlador para la IA 2: Pre-evaluación de Síntomas
- * Interactivo con el alumno después de agendar cita
- */
 class IASymptomController extends Controller
 {
     private IAService $iaService;
@@ -21,183 +17,115 @@ class IASymptomController extends Controller
         $this->iaService = new IAService();
     }
 
-    /**
-     * Inicia el cuestionario de pre-evaluación
-     * POST /api/ia/symptoms/iniciar/{citaId}
-     */
+    // POST /api/ia/symptoms/iniciar/{citaId}
     public function iniciar(Request $request, int $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);
 
-        // Verificar que el alumno es dueño de la cita o es doctor
         if ($user->esAlumno() && $cita->alumno_id !== $user->id) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
-        // Verificar que la cita está programada
         if ($cita->estatus !== 'programada') {
-            return response()->json([
-                'message' => 'No se puede hacer pre-evaluación. La cita no está programada.'
-            ], 400);
+            return response()->json(['message' => 'No se puede hacer pre-evaluación. La cita no está programada.'], 400);
         }
 
-        // Iniciar pre-evaluación
-        $resultado = $this->iaService->iniciarPreEvaluacion($citaId);
-
-        return response()->json($resultado, 200);
+        return response()->json($this->iaService->iniciarPreEvaluacion($citaId));
     }
 
-    /**
-     * Envía respuestas y obtiene diagnóstico preliminar
-     * POST /api/ia/symptoms/evaluar/{citaId}
-     */
+    // POST /api/ia/symptoms/evaluar/{citaId}
     public function evaluar(Request $request, int $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);
 
-        // Verificar permisos
         if ($user->esAlumno() && $cita->alumno_id !== $user->id) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
-        // Validar respuestas
         $validated = $request->validate([
-            'respuestas' => 'required|array',
-            'respuestas.*.pregunta_id' => 'nullable|integer',
+            'respuestas'                       => 'required|array',
+            'respuestas.*.pregunta_id'         => 'nullable|integer',
             'respuestas.*.sintoma_relacionado' => 'nullable|string',
-            'respuestas.*.respuesta' => 'required|string',
+            'respuestas.*.respuesta'           => 'required|string',
         ]);
 
-        // Procesar respuestas
-        $resultado = $this->iaService->procesarRespuestasPreEvaluacion(
-            $citaId, 
-            $validated['respuestas']
+        return response()->json(
+            $this->iaService->procesarRespuestasPreEvaluacion($citaId, $validated['respuestas'])
         );
-
-        // Si necesita más preguntas
-        if ($resultado['fase'] === 'preguntas_adicionales') {
-            return response()->json($resultado, 200);
-        }
-
-        // Evaluación completada
-        return response()->json($resultado, 200);
     }
 
-    /**
-     * Obtiene los resultados de una pre-evaluación guardada
-     * GET /api/ia/symptoms/resultado/{citaId}
-     */
+    // GET /api/ia/symptoms/resultado/{citaId}
     public function obtenerResultado(Request $request, int $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);
 
-        // Verificar permisos
         if ($user->esAlumno() && $cita->alumno_id !== $user->id) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
-        $preEvaluacion = PreEvaluacionIA::where('cita_id', $citaId)->first();
-
-        if (!$preEvaluacion) {
-            return response()->json([
-                'message' => 'No hay pre-evaluación registrada para esta cita'
-            ], 404);
+        $pre = PreEvaluacionIA::where('cita_id', $citaId)->first();
+        if (!$pre) {
+            return response()->json(['message' => 'No hay pre-evaluación registrada para esta cita'], 404);
         }
 
-        // Si es doctor, mostrar análisis completo
         if ($user->esDoctor()) {
             return response()->json([
-                'cita_id' => $citaId,
-                'alumno' => [
-                    'id' => $cita->alumno->id,
-                    'nombre' => $cita->alumno->name,
-                ],
-                'pre_evaluacion' => $preEvaluacion,
-                'sintomas_detectados' => $preEvaluacion->sintomas_detectados,
-                'posibles_diagnosticos' => $preEvaluacion->posibles_enfermedades,
-                'confianza_ia' => $preEvaluacion->confianza,
-                'respuestas_brutas' => $preEvaluacion->respuestas,
-                'validado_por_doctor' => $preEvaluacion->doctorValidador ? [
-                    'id' => $preEvaluacion->doctorValidador->id,
-                    'nombre' => $preEvaluacion->doctorValidador->name,
-                ] : null,
-            ], 200);
+                'cita_id'               => $citaId,
+                'alumno'                => ['id' => $cita->alumno->id, 'nombre' => $cita->alumno->nombre],
+                'pre_evaluacion'        => $pre,
+                'sintomas_detectados'   => $pre->sintomas_detectados,
+                'posibles_diagnosticos' => $pre->posibles_enfermedades,
+                'confianza_ia'          => $pre->confianza,
+                'respuestas_brutas'     => $pre->respuestas,
+                'validado_por_doctor'   => $pre->doctorValidador
+                    ? ['id' => $pre->doctorValidador->id, 'nombre' => $pre->doctorValidador->nombre]
+                    : null,
+            ]);
         }
 
-        // Si es alumno, mostrar versión simplificada
         return response()->json([
-            'cita_id' => $citaId,
-            'sintomas_reportados' => $preEvaluacion->sintomas_detectados,
-            'posibles_causas' => array_slice($preEvaluacion->posibles_enfermedades ?? [], 0, 3),
-            'mensaje' => '⚠️ Recuerda: solo el doctor puede dar un diagnóstico oficial.',
-        ], 200);
+            'cita_id'           => $citaId,
+            'sintomas_reportados' => $pre->sintomas_detectados,
+            'posibles_causas'   => array_slice($pre->posibles_enfermedades ?? [], 0, 3),
+            'mensaje'           => 'Recuerda: solo el doctor puede dar un diagnóstico oficial.',
+        ]);
     }
 
-    /**
-     * El doctor valida/ajusta la pre-evaluación
-     * POST /api/ia/symptoms/validar/{preEvaluacionId}
-     */
+    // POST /api/ia/symptoms/validar/{preEvaluacionId} — solo doctor (role:doctor middleware)
     public function validar(Request $request, int $preEvaluacionId)
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json([
-                'message' => 'Solo doctores pueden validar pre-evaluaciones'
-            ], 403);
-        }
-
         $validated = $request->validate([
             'diagnostico_correcto' => 'nullable|string',
-            'es_acertado' => 'required|boolean',
-            'observaciones' => 'nullable|string',
+            'es_acertado'          => 'required|boolean',
+            'observaciones'        => 'nullable|string',
         ]);
 
-        $preEvaluacion = PreEvaluacionIA::findOrFail($preEvaluacionId);
-
-        $preEvaluacion->update([
-            'es_acertado' => $validated['es_acertado'],
-            'diagnostico_correcto' => $validated['diagnostico_correcto'],
-            'observaciones_doctor' => $validated['observaciones'],
-            'validado_por' => $user->id,
-            'fecha_validacion' => now(),
+        $pre = PreEvaluacionIA::findOrFail($preEvaluacionId);
+        $pre->update([
+            'es_acertado'           => $validated['es_acertado'],
+            'diagnostico_correcto'  => $validated['diagnostico_correcto'],
+            'observaciones_doctor'  => $validated['observaciones'],
+            'validado_por'          => $request->user()->id,
+            'fecha_validacion'      => now(),
         ]);
 
-        return response()->json([
-            'message' => 'Pre-evaluación validada correctamente',
-            'pre_evaluacion' => $preEvaluacion,
-        ], 200);
+        return response()->json(['message' => 'Pre-evaluación validada correctamente', 'pre_evaluacion' => $pre]);
     }
 
-    /**
-     * Lista todas las pre-evaluaciones (solo doctores)
-     * GET /api/ia/symptoms/listado
-     */
-    public function listado(Request $request)
+    // GET /api/ia/symptoms/listado — solo doctor (role:doctor middleware)
+    public function listado()
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-
         $preEvaluaciones = PreEvaluacionIA::with(['cita', 'alumno', 'doctorValidador'])
             ->orderBy('created_at', 'desc')
             ->paginate(20);
 
-        return response()->json([
-            'message' => 'Listado de pre-evaluaciones',
-            'data' => $preEvaluaciones,
-        ], 200);
+        return response()->json(['message' => 'Listado de pre-evaluaciones', 'data' => $preEvaluaciones]);
     }
 
-    /**
-     * Reinicia/cancela una pre-evaluación
-     * DELETE /api/ia/symptoms/{citaId}
-     */
+    // DELETE /api/ia/symptoms/{citaId}
     public function cancelar(Request $request, int $citaId)
     {
         $user = $request->user();
@@ -208,9 +136,6 @@ class IASymptomController extends Controller
         }
 
         PreEvaluacionIA::where('cita_id', $citaId)->delete();
-
-        return response()->json([
-            'message' => 'Pre-evaluación cancelada. Puedes iniciar una nueva cuando lo desees.',
-        ], 200);
+        return response()->json(['message' => 'Pre-evaluación cancelada. Puedes iniciar una nueva cuando lo desees.']);
     }
 }

--- a/backend/app/Http/Controllers/IASymptomController.php
+++ b/backend/app/Http/Controllers/IASymptomController.php
@@ -18,7 +18,7 @@ class IASymptomController extends Controller
     }
 
     // POST /api/ia/symptoms/iniciar/{citaId}
-    public function iniciar(Request $request, int $citaId)
+    public function iniciar(Request $request, $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);
@@ -35,7 +35,7 @@ class IASymptomController extends Controller
     }
 
     // POST /api/ia/symptoms/evaluar/{citaId}
-    public function evaluar(Request $request, int $citaId)
+    public function evaluar(Request $request, $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);
@@ -57,7 +57,7 @@ class IASymptomController extends Controller
     }
 
     // GET /api/ia/symptoms/resultado/{citaId}
-    public function obtenerResultado(Request $request, int $citaId)
+    public function obtenerResultado(Request $request, $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);
@@ -95,7 +95,7 @@ class IASymptomController extends Controller
     }
 
     // POST /api/ia/symptoms/validar/{preEvaluacionId} — solo doctor (role:doctor middleware)
-    public function validar(Request $request, int $preEvaluacionId)
+    public function validar(Request $request, $preEvaluacionId)
     {
         $validated = $request->validate([
             'diagnostico_correcto' => 'nullable|string',
@@ -126,7 +126,7 @@ class IASymptomController extends Controller
     }
 
     // DELETE /api/ia/symptoms/{citaId}
-    public function cancelar(Request $request, int $citaId)
+    public function cancelar(Request $request, $citaId)
     {
         $user = $request->user();
         $cita = Cita::findOrFail($citaId);

--- a/backend/app/Http/Controllers/PreEvaluacionIAController.php
+++ b/backend/app/Http/Controllers/PreEvaluacionIAController.php
@@ -4,207 +4,127 @@ namespace App\Http\Controllers;
 
 use App\Models\PreEvaluacionIA;
 use App\Models\Cita;
+use App\Services\PreEvaluacionService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Validator;
-
 
 class PreEvaluacionIAController extends Controller
 {
-    /**
-     * Obtener preguntas para la pre-evaluación
-     */
+    public function __construct(private PreEvaluacionService $service) {}
+
     public function getPreguntas()
     {
-        $configPath = base_path('../IA/enfermedades_config.json');
-        
-        if (!file_exists($configPath)) {
-            return response()->json([
-                'message' => 'Configuración no encontrada'
-            ], 500);
+        $preguntas = $this->service->getPreguntas();
+        if (empty($preguntas)) {
+            return response()->json(['message' => 'Configuración no encontrada'], 500);
         }
-        
-        $config = json_decode(file_get_contents($configPath), true);
-        
-        return response()->json([
-            'preguntas' => $config['preguntas'] ?? []
-        ]);
+        return response()->json(['preguntas' => $preguntas]);
     }
 
-    /**
-     * Crear una nueva pre-evaluación IA (alumno)
-     */
     public function store(Request $request)
     {
         $user = $request->user();
-        
-        // Solo alumnos pueden crear pre-evaluaciones
+
         if (!$user->esAlumno()) {
             return response()->json(['message' => 'Solo alumnos pueden crear pre-evaluaciones'], 403);
         }
-        
-        $validator = Validator::make($request->all(), [
-            'cita_id' => 'required|exists:citas,id',
+
+        $request->validate([
+            'cita_id'   => 'required|exists:citas,id',
             'respuestas' => 'required|array',
         ]);
-        
-        if ($validator->fails()) {
-            return response()->json(['errors' => $validator->errors()], 422);
-        }
-        
-        // Verificar que la cita pertenece al alumno
-        $cita = Cita::where('id', $request->cita_id)
-                    ->where('alumno_id', $user->id)
-                    ->first();
-        
+
+        $cita = Cita::where('id', $request->cita_id)->where('alumno_id', $user->id)->first();
         if (!$cita) {
             return response()->json(['message' => 'Cita no encontrada o no pertenece al alumno'], 404);
         }
-        
-        // Verificar que no existe pre-evaluación previa para esta cita
-        $existe = PreEvaluacionIA::where('cita_id', $request->cita_id)->exists();
-        if ($existe) {
+
+        if (PreEvaluacionIA::where('cita_id', $request->cita_id)->exists()) {
             return response()->json(['message' => 'Ya existe una pre-evaluación para esta cita'], 400);
         }
-        
-        // Procesar con IA
-        $resultadoIA = $this->procesarConIA($request->respuestas);
-        
-        if (!$resultadoIA['success']) {
-            return response()->json([
-                'message' => 'Error al procesar la evaluación con IA',
-                'error' => $resultadoIA['error'] ?? 'Error desconocido'
-            ], 500);
+
+        $resultadoIA = $this->service->callIAPredict($request->respuestas);
+
+        if (!($resultadoIA['success'] ?? false)) {
+            return response()->json(['message' => 'Error al procesar la evaluación con IA'], 500);
         }
-        
-        // Crear registro
+
         $preEvaluacion = PreEvaluacionIA::create([
-            'cita_id' => $request->cita_id,
-            'alumno_id' => $user->id,
-            'respuestas' => $request->respuestas,
+            'cita_id'              => $request->cita_id,
+            'alumno_id'            => $user->id,
+            'respuestas'           => $request->respuestas,
             'diagnostico_sugerido' => $resultadoIA['diagnostico_principal'],
-            'confianza' => $resultadoIA['confianza'],
-            'sintomas_detectados' => $resultadoIA['sintomas_detectados'],
-            'estatus_validacion' => 'pendiente',
+            'confianza'            => $resultadoIA['confianza'],
+            'sintomas_detectados'  => $resultadoIA['sintomas_detectados'],
+            'estatus_validacion'   => 'pendiente',
         ]);
-        
+
         return response()->json([
-            'message' => 'Pre-evaluación creada exitosamente',
+            'message'        => 'Pre-evaluación creada exitosamente',
             'pre_evaluacion' => $preEvaluacion,
-            'resultado_ia' => $resultadoIA
+            'resultado_ia'   => $resultadoIA,
         ], 201);
     }
 
-    /**
-     * Ver pre-evaluaciones del alumno
-     */
     public function index(Request $request)
     {
         $user = $request->user();
-        
-        if ($user->esAlumno()) {
-            $preEvaluaciones = PreEvaluacionIA::with(['cita', 'doctorValidador'])
-                ->where('alumno_id', $user->id)
-                ->orderBy('created_at', 'desc')
-                ->get();
-        } else {
-            // Doctores ven todas las pendientes y las de sus citas
-            $preEvaluaciones = PreEvaluacionIA::with(['cita.alumno', 'alumno'])
-                ->orderBy('created_at', 'desc')
-                ->get();
-        }
-        
-        return response()->json([
-            'pre_evaluaciones' => $preEvaluaciones
-        ]);
+
+        $preEvaluaciones = $user->esAlumno()
+            ? PreEvaluacionIA::with(['cita', 'doctorValidador'])->where('alumno_id', $user->id)->orderBy('created_at', 'desc')->get()
+            : PreEvaluacionIA::with(['cita.alumno', 'alumno'])->orderBy('created_at', 'desc')->get();
+
+        return response()->json(['pre_evaluaciones' => $preEvaluaciones]);
     }
 
-    /**
-     * Ver una pre-evaluación específica
-     */
-    public function show(Request $request, $id)
+    public function show(Request $request, int $id)
     {
-        $user = $request->user();
-        
+        $user          = $request->user();
         $preEvaluacion = PreEvaluacionIA::with(['cita', 'alumno', 'doctorValidador'])->findOrFail($id);
-        
-        // Verificar permisos
+
         if ($user->esAlumno() && $preEvaluacion->alumno_id !== $user->id) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
-        
-        return response()->json([
-            'pre_evaluacion' => $preEvaluacion
-        ]);
+
+        return response()->json(['pre_evaluacion' => $preEvaluacion]);
     }
 
-    /**
-     * Validar o descartar diagnóstico IA (solo doctores)
-     */
-    public function validar(Request $request, $id)
+    // Solo doctor — ruta protegida por role:doctor middleware
+    public function validar(Request $request, int $id)
     {
-        $user = $request->user();
-        
-        // Solo doctores pueden validar
-        if (!$user->esDoctor() && !$user->esAdmin()) {
-            return response()->json(['message' => 'Solo doctores pueden validar diagnósticos'], 403);
-        }
-        
-        $validator = Validator::make($request->all(), [
-            'accion' => 'required|in:validar,descartar',
+        $request->validate([
+            'accion'     => 'required|in:validar,descartar',
             'comentario' => 'nullable|string|max:1000',
         ]);
-        
-        if ($validator->fails()) {
-            return response()->json(['errors' => $validator->errors()], 422);
-        }
-        
+
         $preEvaluacion = PreEvaluacionIA::findOrFail($id);
-        
         $estatus = $request->accion === 'validar' ? 'validado' : 'descartado';
-        
+
         $preEvaluacion->update([
             'estatus_validacion' => $estatus,
-            'validado_por' => $user->id,
-            'comentario_doctor' => $request->comentario,
-            'fecha_validacion' => now(),
+            'validado_por'       => $request->user()->id,
+            'comentario_doctor'  => $request->comentario,
+            'fecha_validacion'   => now(),
         ]);
-        
-        $mensaje = $request->accion === 'validar' 
-            ? 'Diagnóstico validado exitosamente' 
-            : 'Diagnóstico descartado exitosamente';
-        
+
+        $mensaje = $request->accion === 'validar' ? 'Diagnóstico validado exitosamente' : 'Diagnóstico descartado exitosamente';
+
         return response()->json([
-            'message' => $mensaje,
-            'pre_evaluacion' => $preEvaluacion->fresh(['doctorValidador'])
+            'message'        => $mensaje,
+            'pre_evaluacion' => $preEvaluacion->fresh(['doctorValidador']),
         ]);
     }
 
-    /**
-     * Obtener pre-evaluaciones pendientes (para doctores)
-     */
-    public function pendientes(Request $request)
+    // Solo doctor — ruta protegida por role:doctor middleware
+    public function pendientes()
     {
-        $user = $request->user();
-        
-        if (!$user->esDoctor() && !$user->esAdmin()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-        
         $pendientes = PreEvaluacionIA::with(['cita.alumno', 'alumno'])
             ->where('estatus_validacion', 'pendiente')
             ->orderBy('created_at', 'desc')
             ->get();
 
-        return response()->json([
-            'pendientes' => $pendientes,
-            'total' => $pendientes->count(),
-        ]);
+        return response()->json(['pendientes' => $pendientes, 'total' => $pendientes->count()]);
     }
 
-    /**
-     * Chat conversacional con IA para pre-evaluación (Ollama)
-     */
     public function chat(Request $request)
     {
         $user = $request->user();
@@ -213,152 +133,34 @@ class PreEvaluacionIAController extends Controller
             return response()->json(['message' => 'Solo alumnos pueden usar la pre-evaluación'], 403);
         }
 
-        $validator = Validator::make($request->all(), [
-            'cita_id'          => 'required|exists:citas,id',
-            'messages'         => 'required|array|min:1',
-            'messages.*.role'  => 'required|in:user,assistant',
-            'messages.*.content' => 'required|string|max:2000',
+        $request->validate([
+            'cita_id'              => 'required|exists:citas,id',
+            'messages'             => 'required|array|min:1',
+            'messages.*.role'      => 'required|in:user,assistant',
+            'messages.*.content'   => 'required|string|max:2000',
         ]);
 
-        if ($validator->fails()) {
-            return response()->json(['errors' => $validator->errors()], 422);
-        }
-
-        $cita = Cita::where('id', $request->cita_id)
-                    ->where('alumno_id', $user->id)
-                    ->first();
-
+        $cita = Cita::where('id', $request->cita_id)->where('alumno_id', $user->id)->first();
         if (!$cita) {
             return response()->json(['message' => 'Cita no encontrada o no pertenece al alumno'], 404);
         }
 
         try {
-            $iaUrl = getenv('IA_SERVICE_URL') ?: env('IA_SERVICE_URL', 'https://yoltec-production.up.railway.app');
+            $data = $this->service->callIAChat($request->messages);
 
-            $response = Http::timeout(20)->post("{$iaUrl}/chat", [
-                'messages' => $request->messages,
-            ]);
-
-            if (!$response->successful()) {
-                return response()->json([
-                    'message' => 'Error del servicio IA',
-                    'detail'  => $response->json('detail') ?? $response->body()
-                ], 502);
-            }
-
-            $data = $response->json();
-
-            // Si terminó con diagnóstico, guardar pre-evaluación automáticamente
             if (!empty($data['finished']) && !empty($data['diagnostico'])) {
                 $existe = PreEvaluacionIA::where('cita_id', $request->cita_id)->first();
-
-                if (!$existe) {
-                    $diagnostico = $data['diagnostico'];
-                    $preEvaluacion = PreEvaluacionIA::create([
-                        'cita_id'              => $request->cita_id,
-                        'alumno_id'            => $user->id,
-                        'respuestas'           => ['chat_messages' => $request->messages],
-                        'diagnostico_sugerido' => $diagnostico['diagnostico_principal'] ?? 'Sin diagnóstico claro',
-                        'confianza'            => $diagnostico['confianza'] ?? 0.5,
-                        'sintomas_detectados'  => $diagnostico['sintomas_detectados'] ?? [],
-                        'estatus_validacion'   => 'pendiente',
-                    ]);
-                    $data['pre_evaluacion'] = $preEvaluacion;
-                } else {
-                    $data['pre_evaluacion'] = $existe;
-                }
+                $data['pre_evaluacion'] = $existe ?? $this->service->saveFromChat(
+                    $request->cita_id,
+                    $user->id,
+                    $request->messages,
+                    $data['diagnostico']
+                );
             }
 
             return response()->json($data);
-
         } catch (\Exception $e) {
-            return response()->json([
-                'message' => 'Servicio IA no disponible: ' . $e->getMessage()
-            ], 503);
+            return response()->json(['message' => 'Servicio IA no disponible: ' . $e->getMessage()], 503);
         }
-    }
-
-    /**
-     * Procesar respuestas con IA via microservicio HTTP
-     */
-    private function procesarConIA(array $respuestas): array
-    {
-        try {
-            $iaUrl = getenv('IA_SERVICE_URL') ?: env('IA_SERVICE_URL', 'https://yoltec-production.up.railway.app');
-
-            $response = Http::timeout(15)->post("{$iaUrl}/predict", [
-                'respuestas' => $respuestas,
-            ]);
-
-            if ($response->successful()) {
-                return $response->json();
-            }
-
-            \Log::error('IA service error: ' . $response->body());
-            return $this->simularRespuestaIA($respuestas);
-
-        } catch (\Exception $e) {
-            \Log::warning('IA service no disponible, usando fallback: ' . $e->getMessage());
-            return $this->simularRespuestaIA($respuestas);
-        }
-    }
-
-    /**
-     * Simular respuesta IA cuando el script no está disponible
-     */
-    private function simularRespuestaIA(array $respuestas): array
-    {
-        // Lógica simple de fallback
-        $tieneFiebre = isset($respuestas['fiebre']) && !str_contains($respuestas['fiebre'], 'No');
-        $tieneTos = isset($respuestas['tos']) && !str_contains($respuestas['tos'], 'No');
-        $tieneDolorCabeza = isset($respuestas['dolor_cabeza']) && !str_contains($respuestas['dolor_cabeza'], 'No');
-        $tieneCongestion = isset($respuestas['congestion_nasal']) && !str_contains($respuestas['congestion_nasal'], 'No');
-        $tieneNauseas = isset($respuestas['nauseas']) && !str_contains($respuestas['nauseas'], 'No');
-        
-        if ($tieneFiebre && $tieneTos && $tieneDolorCabeza) {
-            return [
-                'success' => true,
-                'diagnostico_principal' => 'Gripe',
-                'confianza' => 0.75,
-                'sintomas_detectados' => ['Fiebre', 'Tos', 'Dolor de cabeza'],
-                'posibles_enfermedades' => [
-                    ['enfermedad' => 'Gripe', 'confianza' => 0.75],
-                    ['enfermedad' => 'Resfriado Común', 'confianza' => 0.45],
-                ],
-                'recomendacion' => 'Probabilidad moderada de Gripe. Se recomienda consulta médica.'
-            ];
-        } elseif ($tieneCongestion && $tieneTos) {
-            return [
-                'success' => true,
-                'diagnostico_principal' => 'Resfriado Común',
-                'confianza' => 0.65,
-                'sintomas_detectados' => ['Congestión nasal', 'Tos'],
-                'posibles_enfermedades' => [
-                    ['enfermedad' => 'Resfriado Común', 'confianza' => 0.65],
-                    ['enfermedad' => 'Alergias', 'confianza' => 0.40],
-                ],
-                'recomendacion' => 'Posible Resfriado Común. Monitorear síntomas.'
-            ];
-        } elseif ($tieneNauseas) {
-            return [
-                'success' => true,
-                'diagnostico_principal' => 'Infección Gastrointestinal',
-                'confianza' => 0.55,
-                'sintomas_detectados' => ['Náuseas'],
-                'posibles_enfermedades' => [
-                    ['enfermedad' => 'Infección Gastrointestinal', 'confianza' => 0.55],
-                ],
-                'recomendacion' => 'Síntomas no concluyentes. Se recomienda consulta médica.'
-            ];
-        }
-        
-        return [
-            'success' => true,
-            'diagnostico_principal' => 'Sin diagnóstico claro',
-            'confianza' => 0.20,
-            'sintomas_detectados' => [],
-            'posibles_enfermedades' => [],
-            'recomendacion' => 'Los síntomas no son concluyentes. Se recomienda consulta médica.'
-        ];
     }
 }

--- a/backend/app/Http/Controllers/PreEvaluacionIAController.php
+++ b/backend/app/Http/Controllers/PreEvaluacionIAController.php
@@ -76,7 +76,7 @@ class PreEvaluacionIAController extends Controller
         return response()->json(['pre_evaluaciones' => $preEvaluaciones]);
     }
 
-    public function show(Request $request, int $id)
+    public function show(Request $request, $id)
     {
         $user          = $request->user();
         $preEvaluacion = PreEvaluacionIA::with(['cita', 'alumno', 'doctorValidador'])->findOrFail($id);
@@ -89,7 +89,7 @@ class PreEvaluacionIAController extends Controller
     }
 
     // Solo doctor — ruta protegida por role:doctor middleware
-    public function validar(Request $request, int $id)
+    public function validar(Request $request, $id)
     {
         $request->validate([
             'accion'     => 'required|in:validar,descartar',

--- a/backend/app/Http/Controllers/RecetaController.php
+++ b/backend/app/Http/Controllers/RecetaController.php
@@ -19,7 +19,8 @@ class RecetaController extends Controller
                             ->orderBy('fecha_emision', 'desc')
                             ->get();
         } else {
-            $recetas = Receta::with(['cita', 'alumno'])
+            $recetas = Receta::with(['cita.alumno', 'alumno'])
+                            ->where('doctor_id', $user->id)
                             ->orderBy('fecha_emision', 'desc')
                             ->get();
         }

--- a/backend/app/Http/Controllers/RecetaController.php
+++ b/backend/app/Http/Controllers/RecetaController.php
@@ -75,7 +75,7 @@ class RecetaController extends Controller
     }
 
     // Ver receta
-    public function show(Request $request, int $id)
+    public function show(Request $request, $id)
     {
         $user = $request->user();
         $receta = Receta::with(['cita', 'alumno', 'doctor'])->findOrFail($id);
@@ -89,7 +89,7 @@ class RecetaController extends Controller
     }
 
     // Actualizar receta (solo doctor — protegido por role:doctor middleware)
-    public function update(Request $request, int $id)
+    public function update(Request $request, $id)
     {
         $user   = $request->user();
         $receta = Receta::findOrFail($id);

--- a/backend/app/Http/Controllers/RecetaController.php
+++ b/backend/app/Http/Controllers/RecetaController.php
@@ -8,7 +8,7 @@ use App\Models\Cita;
 use Illuminate\Http\Request;
 class RecetaController extends Controller
 {
-    // Listar recetas
+    // Listar recetas — alumno recibe array plano, doctor recibe paginación (15/pag)
     public function index(Request $request)
     {
         $user = $request->user();
@@ -18,29 +18,28 @@ class RecetaController extends Controller
                             ->with(['cita', 'doctor'])
                             ->orderBy('fecha_emision', 'desc')
                             ->get();
-        } else {
-            $search = trim($request->input('search', ''));
-            $query = Receta::with([
-                               'cita:id,fecha_cita,hora_cita,alumno_id',
-                               'cita.alumno:id,nombre,apellido,numero_control',
-                               'alumno:id,nombre,apellido,numero_control',
-                           ])
-                           ->where('doctor_id', $user->id);
-
-            if ($search) {
-                $query->where(function ($q) use ($search) {
-                    $q->whereHas('alumno', fn ($u) =>
-                        $u->where('nombre', 'ILIKE', "%{$search}%")
-                          ->orWhere('apellido', 'ILIKE', "%{$search}%")
-                          ->orWhere('numero_control', 'ILIKE', "%{$search}%")
-                    )->orWhere('medicamentos', 'ILIKE', "%{$search}%");
-                });
-            }
-
-            $recetas = $query->orderBy('fecha_emision', 'desc')->get();
+            return response()->json($recetas, 200);
         }
 
-        return response()->json($recetas, 200);
+        $search = trim($request->input('search', ''));
+        $query = Receta::with([
+                           'cita:id,fecha_cita,hora_cita,alumno_id',
+                           'cita.alumno:id,nombre,apellido,numero_control',
+                           'alumno:id,nombre,apellido,numero_control',
+                       ])
+                       ->where('doctor_id', $user->id);
+
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->whereHas('alumno', fn ($u) =>
+                    $u->where('nombre', 'ILIKE', "%{$search}%")
+                      ->orWhere('apellido', 'ILIKE', "%{$search}%")
+                      ->orWhere('numero_control', 'ILIKE', "%{$search}%")
+                )->orWhere('medicamentos', 'ILIKE', "%{$search}%");
+            });
+        }
+
+        return response()->json($query->orderBy('fecha_emision', 'desc')->paginate(15), 200);
     }
 
     // Crear receta (solo doctor — protegido por role:doctor middleware)

--- a/backend/app/Http/Controllers/RecetaController.php
+++ b/backend/app/Http/Controllers/RecetaController.php
@@ -43,14 +43,10 @@ class RecetaController extends Controller
         return response()->json($recetas, 200);
     }
 
-    // Crear receta (solo doctor)
+    // Crear receta (solo doctor — protegido por role:doctor middleware)
     public function store(Request $request)
     {
         $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
 
         $validated = $request->validate([
             'cita_id' => 'required|exists:citas,id',
@@ -79,7 +75,7 @@ class RecetaController extends Controller
     }
 
     // Ver receta
-    public function show(Request $request, $id)
+    public function show(Request $request, int $id)
     {
         $user = $request->user();
         $receta = Receta::with(['cita', 'alumno', 'doctor'])->findOrFail($id);
@@ -92,15 +88,10 @@ class RecetaController extends Controller
         return response()->json($receta, 200);
     }
 
-    // Actualizar receta (solo doctor)
-    public function update(Request $request, $id)
+    // Actualizar receta (solo doctor — protegido por role:doctor middleware)
+    public function update(Request $request, int $id)
     {
-        $user = $request->user();
-
-        if (!$user->esDoctor()) {
-            return response()->json(['message' => 'No autorizado'], 403);
-        }
-
+        $user   = $request->user();
         $receta = Receta::findOrFail($id);
 
         if ($receta->doctor_id !== $user->id) {

--- a/backend/app/Http/Controllers/RecetaController.php
+++ b/backend/app/Http/Controllers/RecetaController.php
@@ -19,10 +19,25 @@ class RecetaController extends Controller
                             ->orderBy('fecha_emision', 'desc')
                             ->get();
         } else {
-            $recetas = Receta::with(['cita.alumno', 'alumno'])
-                            ->where('doctor_id', $user->id)
-                            ->orderBy('fecha_emision', 'desc')
-                            ->get();
+            $search = trim($request->input('search', ''));
+            $query = Receta::with([
+                               'cita:id,fecha_cita,hora_cita,alumno_id',
+                               'cita.alumno:id,nombre,apellido,numero_control',
+                               'alumno:id,nombre,apellido,numero_control',
+                           ])
+                           ->where('doctor_id', $user->id);
+
+            if ($search) {
+                $query->where(function ($q) use ($search) {
+                    $q->whereHas('alumno', fn ($u) =>
+                        $u->where('nombre', 'ILIKE', "%{$search}%")
+                          ->orWhere('apellido', 'ILIKE', "%{$search}%")
+                          ->orWhere('numero_control', 'ILIKE', "%{$search}%")
+                    )->orWhere('medicamentos', 'ILIKE', "%{$search}%");
+                });
+            }
+
+            $recetas = $query->orderBy('fecha_emision', 'desc')->get();
         }
 
         return response()->json($recetas, 200);

--- a/backend/app/Http/Middleware/CheckRole.php
+++ b/backend/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CheckRole
+{
+    // Verifica que el usuario autenticado tenga el rol requerido
+    public function handle(Request $request, Closure $next, string $rol): mixed
+    {
+        if (!$request->user() || $request->user()->tipo !== $rol) {
+            return response()->json(['message' => 'No autorizado'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/IA/Models/PriorityClassifier.php
+++ b/backend/app/IA/Models/PriorityClassifier.php
@@ -1,4 +1,4 @@
-33<?php
+<?php
 
 namespace App\IA\Models;
 

--- a/backend/app/Models/Receta.php
+++ b/backend/app/Models/Receta.php
@@ -19,7 +19,7 @@ class Receta extends Model
     ];
 
     protected $casts = [
-        'fecha_emision' => 'date',
+        'fecha_emision' => 'date:Y-m-d',
     ];
 
     // Relaciones

--- a/backend/app/Services/Auth2FAService.php
+++ b/backend/app/Services/Auth2FAService.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\TwoFactorCodeMail;
+use App\Models\TrustedDevice;
+use App\Models\TwoFactorCode;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+class Auth2FAService
+{
+    private const CODE_MINUTES   = 10;
+    private const TRUST_DAYS     = 30;
+
+    // Genera código 2FA, lo guarda y envía por email. Retorna email enmascarado.
+    public function sendCode(User $user): string
+    {
+        $code = str_pad(random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+
+        TwoFactorCode::create([
+            'user_id'    => $user->id,
+            'code'       => Hash::make($code),
+            'expires_at' => Carbon::now()->addMinutes(self::CODE_MINUTES),
+            'used'       => false,
+        ]);
+
+        try {
+            Mail::to($user->email)->send(new TwoFactorCodeMail($code, $user->nombre));
+        } catch (\Exception $e) {
+            \Log::error('SMTP ERROR 2FA: ' . $e->getMessage());
+        }
+
+        return $this->maskEmail($user->email);
+    }
+
+    // Busca código válido y no usado. Retorna el registro si coincide, null si no.
+    public function verifyCode(User $user, string $code): ?TwoFactorCode
+    {
+        $pending = TwoFactorCode::where('user_id', $user->id)
+            ->where('used', false)
+            ->where('expires_at', '>', Carbon::now())
+            ->get();
+
+        foreach ($pending as $record) {
+            if (Hash::check($code, $record->code)) {
+                return $record;
+            }
+        }
+
+        return null;
+    }
+
+    // Marca código usado, limpia viejos y registra dispositivo de confianza. Retorna device_token.
+    public function confirmAndCreateDevice(TwoFactorCode $twoFactorCode, User $user): string
+    {
+        $twoFactorCode->update(['used' => true]);
+
+        TwoFactorCode::where('user_id', $user->id)
+            ->where('created_at', '<', Carbon::now()->subHour())
+            ->delete();
+
+        $deviceToken = Str::random(64);
+        TrustedDevice::create([
+            'user_id'      => $user->id,
+            'device_token' => $deviceToken,
+            'expires_at'   => Carbon::now()->addDays(self::TRUST_DAYS),
+        ]);
+
+        TrustedDevice::where('user_id', $user->id)
+            ->where('expires_at', '<', Carbon::now())
+            ->delete();
+
+        return $deviceToken;
+    }
+
+    // Verifica si el device_token es de confianza y lo renueva.
+    public function isTrustedDevice(User $user, ?string $deviceToken): bool
+    {
+        if (!$deviceToken) {
+            return false;
+        }
+
+        $trusted = TrustedDevice::where('user_id', $user->id)
+            ->where('device_token', $deviceToken)
+            ->where('expires_at', '>', Carbon::now())
+            ->first();
+
+        if ($trusted) {
+            $trusted->update(['expires_at' => Carbon::now()->addDays(self::TRUST_DAYS)]);
+            return true;
+        }
+
+        return false;
+    }
+
+    public function maskEmail(string $email): string
+    {
+        [$name, $domain] = array_pad(explode('@', $email, 2), 2, '');
+        $maskedName   = substr($name, 0, 2) . str_repeat('*', max(0, strlen($name) - 2));
+        $domainParts  = explode('.', $domain);
+        $maskedDomain = substr($domainParts[0], 0, 1) . str_repeat('*', max(0, strlen($domainParts[0]) - 1));
+
+        return $maskedName . '@' . $maskedDomain . '.' . ($domainParts[1] ?? 'com');
+    }
+}

--- a/backend/app/Services/CitaService.php
+++ b/backend/app/Services/CitaService.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Cita;
+use App\Models\DiaEspecial;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class CitaService
+{
+    // Retorna disponibilidad del mes con días especiales — cacheado 15 min
+    public function getAvailability(int $month, int $year): array
+    {
+        return Cache::remember("disp_{$year}_{$month}", 900, function () use ($month, $year) {
+            $start = Carbon::create($year, $month, 1)->startOfMonth();
+            $end   = (clone $start)->endOfMonth();
+
+            $citas = Cita::whereBetween('fecha_cita', [$start->toDateString(), $end->toDateString()])
+                ->where('estatus', 'programada')
+                ->select('fecha_cita', 'hora_cita')
+                ->get();
+
+            $grouped = [];
+            foreach ($citas as $cita) {
+                $dateKey = $cita->fecha_cita instanceof Carbon
+                    ? $cita->fecha_cita->toDateString()
+                    : (string) $cita->fecha_cita;
+                $grouped[$dateKey][] = Carbon::parse($cita->hora_cita)->format('H:i');
+            }
+
+            $types  = config('clinic.types', []);
+            $result = [];
+            foreach ($grouped as $date => $slots) {
+                $result[$date] = ['date' => $date, 'taken_slots' => array_values(array_unique($slots)), 'special' => null];
+            }
+
+            foreach (DiaEspecial::whereYear('fecha', $year)->whereMonth('fecha', $month)->get() as $dia) {
+                $date = $dia->fecha->toDateString();
+                $result[$date] = array_merge($result[$date] ?? ['date' => $date, 'taken_slots' => [], 'special' => null], [
+                    'special' => [
+                        'type'   => $dia->tipo,
+                        'label'  => $dia->etiqueta,
+                        'status' => $types[$dia->tipo]['status'] ?? 'full',
+                        'color'  => $types[$dia->tipo]['color'] ?? '#ef5350',
+                    ],
+                ]);
+            }
+
+            return array_values($result);
+        });
+    }
+
+    // Valida día y hora. Retorna null si OK, string de error si inválido.
+    public function validarHorario(string $fecha, string $hora): ?string
+    {
+        if (Carbon::parse($fecha)->dayOfWeek === 0) {
+            return 'No se pueden agendar citas los domingos.';
+        }
+        if ($hora < '08:00' || $hora > '16:45') {
+            return 'El horario de atención es de 08:00 a 16:45.';
+        }
+        return null;
+    }
+
+    // Reserva slot en transacción con lockForUpdate. Retorna Cita o null si ocupado.
+    public function reservarSlot(string $fecha, string $hora, ?string $motivo, int $alumnoId): ?Cita
+    {
+        return DB::transaction(function () use ($fecha, $hora, $motivo, $alumnoId) {
+            $ocupado = Cita::where('fecha_cita', $fecha)
+                ->where('hora_cita', $hora)
+                ->where('estatus', 'programada')
+                ->lockForUpdate()
+                ->exists();
+
+            if ($ocupado) {
+                return null;
+            }
+
+            return Cita::create([
+                'fecha_cita' => $fecha,
+                'hora_cita'  => $hora,
+                'motivo'     => $motivo,
+                'alumno_id'  => $alumnoId,
+                'clave_cita' => Cita::generarClaveCita(),
+                'estatus'    => 'programada',
+            ]);
+        });
+    }
+
+    // Comprueba si un slot está disponible, excluyendo opcionalmente una cita (reprogramar).
+    public function slotDisponible(string $fecha, string $hora, ?int $exceptId = null): bool
+    {
+        return !Cita::where('fecha_cita', $fecha)
+            ->where('hora_cita', $hora)
+            ->where('estatus', 'programada')
+            ->when($exceptId, fn($q) => $q->where('id', '!=', $exceptId))
+            ->exists();
+    }
+}

--- a/backend/app/Services/CitaService.php
+++ b/backend/app/Services/CitaService.php
@@ -98,4 +98,26 @@ class CitaService
             ->when($exceptId, fn($q) => $q->where('id', '!=', $exceptId))
             ->exists();
     }
+
+    // Marca como "no asistió" citas vencidas (grace 15 min). Throttled a 1 ejecución/5min vía caché
+    // para evitar update masivo en cada request. Fallback al scheduler cuando éste no corre (Render).
+    public function marcarPasadasComoNoAsistio(): void
+    {
+        if (Cache::has('auto_no_asistio_lock')) {
+            return;
+        }
+        Cache::put('auto_no_asistio_lock', true, 300);
+
+        $cutoff = Carbon::now()->subMinutes(15);
+
+        Cita::where('estatus', 'programada')
+            ->where(function ($query) use ($cutoff) {
+                $query->where('fecha_cita', '<', $cutoff->toDateString())
+                    ->orWhere(function ($sub) use ($cutoff) {
+                        $sub->where('fecha_cita', $cutoff->toDateString())
+                            ->where('hora_cita', '<=', $cutoff->format('H:i'));
+                    });
+            })
+            ->update(['estatus' => 'no_asistio']);
+    }
 }

--- a/backend/app/Services/PreEvaluacionService.php
+++ b/backend/app/Services/PreEvaluacionService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PreEvaluacionIA;
+use Illuminate\Support\Facades\Http;
+
+class PreEvaluacionService
+{
+    // Carga preguntas desde el JSON de configuración IA
+    public function getPreguntas(): array
+    {
+        $configPath = base_path('../IA/enfermedades_config.json');
+        if (!file_exists($configPath)) {
+            return [];
+        }
+
+        $config = json_decode(file_get_contents($configPath), true);
+        return $config['preguntas'] ?? [];
+    }
+
+    // Llama al microservicio IA /predict. Usa fallback si no está disponible.
+    public function callIAPredict(array $respuestas): array
+    {
+        try {
+            $iaUrl    = env('IA_SERVICE_URL', 'https://yoltec-ia.onrender.com');
+            $response = Http::timeout(15)->post("{$iaUrl}/predict", ['respuestas' => $respuestas]);
+
+            if ($response->successful()) {
+                return $response->json();
+            }
+
+            \Log::error('IA predict error: ' . $response->body());
+        } catch (\Exception $e) {
+            \Log::warning('IA no disponible, usando fallback: ' . $e->getMessage());
+        }
+
+        return $this->fallbackDiagnostico($respuestas);
+    }
+
+    // Llama al microservicio IA /chat. Lanza excepción si falla.
+    public function callIAChat(array $messages): array
+    {
+        $iaUrl    = env('IA_SERVICE_URL', 'https://yoltec-ia.onrender.com');
+        $response = Http::timeout(20)->post("{$iaUrl}/chat", ['messages' => $messages]);
+
+        if (!$response->successful()) {
+            throw new \RuntimeException($response->json('detail') ?? $response->body());
+        }
+
+        return $response->json();
+    }
+
+    // Guarda pre-evaluación desde resultado de chat (solo si no existe una previa).
+    public function saveFromChat(int $citaId, int $alumnoId, array $messages, array $diagnostico): PreEvaluacionIA
+    {
+        return PreEvaluacionIA::create([
+            'cita_id'              => $citaId,
+            'alumno_id'            => $alumnoId,
+            'respuestas'           => ['chat_messages' => $messages],
+            'diagnostico_sugerido' => $diagnostico['diagnostico_principal'] ?? 'Sin diagnóstico claro',
+            'confianza'            => $diagnostico['confianza'] ?? 0.5,
+            'sintomas_detectados'  => $diagnostico['sintomas_detectados'] ?? [],
+            'estatus_validacion'   => 'pendiente',
+        ]);
+    }
+
+    // Diagnóstico de respaldo basado en síntomas clave cuando IA no responde
+    private function fallbackDiagnostico(array $respuestas): array
+    {
+        $si = fn(string $k) => isset($respuestas[$k]) && !str_contains($respuestas[$k], 'No');
+
+        if ($si('fiebre') && $si('tos') && $si('dolor_cabeza')) {
+            return [
+                'success' => true, 'diagnostico_principal' => 'Gripe', 'confianza' => 0.75,
+                'sintomas_detectados'   => ['Fiebre', 'Tos', 'Dolor de cabeza'],
+                'posibles_enfermedades' => [['enfermedad' => 'Gripe', 'confianza' => 0.75], ['enfermedad' => 'Resfriado Común', 'confianza' => 0.45]],
+                'recomendacion'         => 'Probabilidad moderada de Gripe. Se recomienda consulta médica.',
+            ];
+        }
+
+        if ($si('congestion_nasal') && $si('tos')) {
+            return [
+                'success' => true, 'diagnostico_principal' => 'Resfriado Común', 'confianza' => 0.65,
+                'sintomas_detectados'   => ['Congestión nasal', 'Tos'],
+                'posibles_enfermedades' => [['enfermedad' => 'Resfriado Común', 'confianza' => 0.65], ['enfermedad' => 'Alergias', 'confianza' => 0.40]],
+                'recomendacion'         => 'Posible Resfriado Común. Monitorear síntomas.',
+            ];
+        }
+
+        if ($si('nauseas')) {
+            return [
+                'success' => true, 'diagnostico_principal' => 'Infección Gastrointestinal', 'confianza' => 0.55,
+                'sintomas_detectados'   => ['Náuseas'],
+                'posibles_enfermedades' => [['enfermedad' => 'Infección Gastrointestinal', 'confianza' => 0.55]],
+                'recomendacion'         => 'Síntomas no concluyentes. Se recomienda consulta médica.',
+            ];
+        }
+
+        return [
+            'success' => true, 'diagnostico_principal' => 'Sin diagnóstico claro', 'confianza' => 0.20,
+            'sintomas_detectados'   => [],
+            'posibles_enfermedades' => [],
+            'recomendacion'         => 'Los síntomas no son concluyentes. Se recomienda consulta médica.',
+        ];
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -26,7 +26,8 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(\App\Http\Middleware\SecurityHeaders::class);
 
         $middleware->alias([
-            'admin' => \App\Http\Middleware\EnsureIsAdmin::class,
+            'admin'      => \App\Http\Middleware\EnsureIsAdmin::class,
+            'role'       => \App\Http\Middleware\CheckRole::class,
         ]);
     })
     ->withSchedule(function (Schedule $schedule): void {

--- a/backend/database/migrations/2026_05_15_000001_add_cascade_fk_to_bitacoras_recetas.php
+++ b/backend/database/migrations/2026_05_15_000001_add_cascade_fk_to_bitacoras_recetas.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Limpiar registros huérfanos antes de agregar constraints
+        DB::statement("DELETE FROM bitacoras WHERE cita_id NOT IN (SELECT id FROM citas)");
+        DB::statement("DELETE FROM recetas WHERE cita_id NOT IN (SELECT id FROM citas)");
+
+        Schema::table('bitacoras', function (Blueprint $table) {
+            $table->foreign('cita_id')->references('id')->on('citas')->onDelete('cascade');
+        });
+
+        Schema::table('recetas', function (Blueprint $table) {
+            $table->foreign('cita_id')->references('id')->on('citas')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bitacoras', function (Blueprint $table) {
+            $table->dropForeign(['cita_id']);
+        });
+
+        Schema::table('recetas', function (Blueprint $table) {
+            $table->dropForeign(['cita_id']);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -91,11 +91,13 @@ Route::middleware('auth:sanctum')->group(function () {
     // Pre-evaluaciones IA
     Route::post('/pre-evaluacion/chat', [PreEvaluacionIAController::class, 'chat']);
     Route::get('/pre-evaluacion/preguntas', [PreEvaluacionIAController::class, 'getPreguntas']);
-    Route::get('/pre-evaluacion/pendientes', [PreEvaluacionIAController::class, 'pendientes']);
     Route::get('/pre-evaluacion', [PreEvaluacionIAController::class, 'index']);
     Route::post('/pre-evaluacion', [PreEvaluacionIAController::class, 'store']);
     Route::get('/pre-evaluacion/{id}', [PreEvaluacionIAController::class, 'show']);
-    Route::post('/pre-evaluacion/{id}/validar', [PreEvaluacionIAController::class, 'validar']);
+    Route::middleware('role:doctor')->group(function () {
+        Route::get('/pre-evaluacion/pendientes', [PreEvaluacionIAController::class, 'pendientes']);
+        Route::post('/pre-evaluacion/{id}/validar', [PreEvaluacionIAController::class, 'validar']);
+    });
 
     // Estadísticas — solo doctor
     Route::middleware('role:doctor')->get('/estadisticas', [EstadisticasController::class, 'index']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -94,6 +94,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Admin - CRUD alumnos y doctores
     Route::prefix('admin')->middleware('admin')->group(function () {
+        Route::get('/stats',             [AdminController::class, 'getStats']);
         Route::get('/calendario',        [CalendarioAdminController::class, 'index']);
         Route::post('/calendario',       [CalendarioAdminController::class, 'store']);
         Route::delete('/calendario/{id}', [CalendarioAdminController::class, 'destroy']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -88,16 +88,16 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::put('/recetas/{id}', [RecetaController::class, 'update']);
     });
 
-    // Pre-evaluaciones IA
+    // Pre-evaluaciones IA — rutas estáticas ANTES del wildcard {id}
     Route::post('/pre-evaluacion/chat', [PreEvaluacionIAController::class, 'chat']);
     Route::get('/pre-evaluacion/preguntas', [PreEvaluacionIAController::class, 'getPreguntas']);
     Route::get('/pre-evaluacion', [PreEvaluacionIAController::class, 'index']);
     Route::post('/pre-evaluacion', [PreEvaluacionIAController::class, 'store']);
-    Route::get('/pre-evaluacion/{id}', [PreEvaluacionIAController::class, 'show']);
     Route::middleware('role:doctor')->group(function () {
         Route::get('/pre-evaluacion/pendientes', [PreEvaluacionIAController::class, 'pendientes']);
         Route::post('/pre-evaluacion/{id}/validar', [PreEvaluacionIAController::class, 'validar']);
     });
+    Route::get('/pre-evaluacion/{id}', [PreEvaluacionIAController::class, 'show']);
 
     // Estadísticas — solo doctor
     Route::middleware('role:doctor')->get('/estadisticas', [EstadisticasController::class, 'index']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -26,8 +26,8 @@ Route::get('/health', function () {
 Route::middleware('throttle:5,1')->post('/login', [AuthController::class, 'login']); // Fix hallazgo #2: máx 5 intentos/min
 Route::middleware('throttle:5,10')->post('/forgot-password', [PasswordResetController::class, 'forgotPassword']);
 Route::middleware('throttle:5,10')->post('/reset-password', [PasswordResetController::class, 'resetPassword']);
-Route::post('/verify-2fa', [AuthController::class, 'verifyTwoFactor']);
-Route::post('/resend-2fa', [AuthController::class, 'resendTwoFactor']);
+Route::middleware('throttle:5,1')->post('/verify-2fa', [AuthController::class, 'verifyTwoFactor']);
+Route::middleware('throttle:5,1')->post('/resend-2fa', [AuthController::class, 'resendTwoFactor']);
 
 // Rutas protegidas (requieren autenticación)
 Route::middleware('auth:sanctum')->group(function () {
@@ -49,17 +49,21 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/sesiones', [PerfilController::class, 'sesiones']);
     Route::delete('/sesiones/{id}', [PerfilController::class, 'revocarSesion']);
 
-    // Citas
+    // Citas — rutas compartidas alumno/doctor
     Route::get('/citas', [CitaController::class, 'index']);
     Route::get('/citas/disponibilidad', [CitaController::class, 'availability']);
     Route::post('/citas', [CitaController::class, 'store']);
     Route::get('/citas/{id}', [CitaController::class, 'show']);
     Route::post('/citas/{id}/cancelar', [CitaController::class, 'cancelar']);
-    Route::put('/citas/{id}/reprogramar', [CitaController::class, 'reprogramar']);  // Solo doctor
-    Route::post('/citas/{id}/atender', [CitaController::class, 'atender']);       // Solo doctor
-    Route::post('/citas/{id}/no-asistio', [CitaController::class, 'noAsistio']); // Solo doctor
-    Route::post('/citas/{id}/consulta', [ConsultaController::class, 'store']);   // Solo doctor
-    Route::get('/citas/{id}/consulta', [ConsultaController::class, 'show']);
+
+    // Citas — solo doctor
+    Route::middleware('role:doctor')->group(function () {
+        Route::put('/citas/{id}/reprogramar', [CitaController::class, 'reprogramar']);
+        Route::post('/citas/{id}/atender', [CitaController::class, 'atender']);
+        Route::post('/citas/{id}/no-asistio', [CitaController::class, 'noAsistio']);
+        Route::post('/citas/{id}/consulta', [ConsultaController::class, 'store']);
+        Route::get('/citas/{id}/consulta', [ConsultaController::class, 'show']);
+    });
 
     // Perfil médico e historial
     Route::get('/perfil-medico', [PerfilMedicoController::class, 'show']);
@@ -70,15 +74,19 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Bitácoras
     Route::get('/bitacoras', [BitacoraController::class, 'index']);
-    Route::post('/bitacoras', [BitacoraController::class, 'store']); // Solo doctor
     Route::get('/bitacoras/{id}', [BitacoraController::class, 'show']);
-    Route::put('/bitacoras/{id}', [BitacoraController::class, 'update']); // Solo doctor
+    Route::middleware('role:doctor')->group(function () {
+        Route::post('/bitacoras', [BitacoraController::class, 'store']);
+        Route::put('/bitacoras/{id}', [BitacoraController::class, 'update']);
+    });
 
     // Recetas
     Route::get('/recetas', [RecetaController::class, 'index']);
-    Route::post('/recetas', [RecetaController::class, 'store']); // Solo doctor
     Route::get('/recetas/{id}', [RecetaController::class, 'show']);
-    Route::put('/recetas/{id}', [RecetaController::class, 'update']); // Solo doctor
+    Route::middleware('role:doctor')->group(function () {
+        Route::post('/recetas', [RecetaController::class, 'store']);
+        Route::put('/recetas/{id}', [RecetaController::class, 'update']);
+    });
 
     // Pre-evaluaciones IA
     Route::post('/pre-evaluacion/chat', [PreEvaluacionIAController::class, 'chat']);
@@ -89,8 +97,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/pre-evaluacion/{id}', [PreEvaluacionIAController::class, 'show']);
     Route::post('/pre-evaluacion/{id}/validar', [PreEvaluacionIAController::class, 'validar']);
 
-    // Estadísticas (solo doctores)
-    Route::get('/estadisticas', [EstadisticasController::class, 'index']);
+    // Estadísticas — solo doctor
+    Route::middleware('role:doctor')->get('/estadisticas', [EstadisticasController::class, 'index']);
 
     // Admin - CRUD alumnos y doctores
     Route::prefix('admin')->middleware('admin')->group(function () {
@@ -108,21 +116,24 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::delete('/doctores/{id}',  [AdminController::class, 'destroyDoctor']);
     });
 
-    // ===== IA 1: Clasificador de Prioridad (solo doctores) =====
-    Route::prefix('ia/priority')->group(function () {
+    // ===== IA 1: Clasificador de Prioridad — solo doctor =====
+    Route::middleware('role:doctor')->prefix('ia/priority')->group(function () {
         Route::get('/info', [IAPriorityController::class, 'infoModelos']);
         Route::get('/pendientes', [IAPriorityController::class, 'listarPendientesPorPrioridad']);
         Route::post('/clasificar/{citaId}', [IAPriorityController::class, 'clasificar']);
     });
 
-    // ===== IA 2: Pre-evaluación de Síntomas (alumnos y doctores) =====
+    // ===== IA 2: Pre-evaluación de Síntomas — alumno y doctor =====
     Route::prefix('ia/symptoms')->group(function () {
-        Route::get('/listado', [IASymptomController::class, 'listado']); // Solo doctores
         Route::post('/iniciar/{citaId}', [IASymptomController::class, 'iniciar']);
         Route::post('/evaluar/{citaId}', [IASymptomController::class, 'evaluar']);
         Route::get('/resultado/{citaId}', [IASymptomController::class, 'obtenerResultado']);
-        Route::post('/validar/{preEvaluacionId}', [IASymptomController::class, 'validar']); // Solo doctores
         Route::delete('/{citaId}', [IASymptomController::class, 'cancelar']);
+        // Solo doctor
+        Route::middleware('role:doctor')->group(function () {
+            Route::get('/listado', [IASymptomController::class, 'listado']);
+            Route::post('/validar/{preEvaluacionId}', [IASymptomController::class, 'validar']);
+        });
     });
 });
 

--- a/frontend/design-reference-dark/Agendar cita.html
+++ b/frontend/design-reference-dark/Agendar cita.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Agendar cita</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee;
+    --warn:#f59e0b; --warn-50:#fff7ed;
+    --danger:#dc2626; --danger-50:#fef2f2;
+    --bg:#ffffff; --soft:#f9fafb;
+    --border:#2d3144; --border-strong:#d1d5db;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;font-family:'Inter',system-ui,sans-serif;color:var(--text);background:#1a1d27;font-size:14px}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit;font-size:inherit}
+  textarea,input{font-family:inherit}
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar */
+  .sb{width:220px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
+  .sb nav{padding:14px 8px;display:flex;flex-direction:column;gap:2px;flex:1}
+  .sb nav a{padding:11px 14px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-radius:7px;cursor:pointer}
+  .sb nav a:hover{background:rgba(255,255,255,.05)}
+  .sb nav a.active{background:var(--primary-50);color:var(--primary);font-weight:600}
+  .sb nav a .ic{font-size:14px;width:16px;text-align:center}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px;font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;padding:32px;display:flex;gap:32px;align-items:flex-start}
+  .page-head{margin-bottom:18px}
+  .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.5px;font-weight:600;margin-bottom:6px}
+  h1{margin:0;font-size:22px;font-weight:700;letter-spacing:-.3px}
+
+  /* Calendar column */
+  .cal-col{width:480px;flex-shrink:0}
+  .sec-title{font-size:18px;font-weight:600;margin:0 0 14px}
+  .month-nav{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;background:var(--soft);border:1px solid var(--border);border-radius:10px;padding:10px 14px}
+  .month-nav b{font-size:15px;font-weight:600;letter-spacing:-.1px}
+  .nav-btn{width:32px;height:32px;border-radius:8px;background:#1a1d27;border:1px solid var(--border);display:inline-flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:14px;font-weight:600}
+  .nav-btn:hover{border-color:var(--primary);color:var(--primary)}
+
+  .dow{display:grid;grid-template-columns:repeat(6,1fr);gap:8px;margin-bottom:8px}
+  .dow span{text-align:center;font-size:11px;font-weight:700;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;padding:6px 0}
+  .grid{display:grid;grid-template-columns:repeat(6,1fr);gap:8px}
+  .day{height:56px;border-radius:8px;border:1px solid var(--border);background:#1a1d27;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:6px 0;cursor:pointer;position:relative;transition:transform .1s}
+  .day:hover{transform:translateY(-1px)}
+  .day .n{font-size:15px;font-weight:600;font-variant-numeric:tabular-nums;line-height:1}
+  .day .d{font-size:9.5px;font-weight:600;margin-top:3px;letter-spacing:.2px}
+  .day.good{border-color:var(--primary)}
+  .day.good .n{color:var(--primary)}
+  .day.good .d{color:var(--primary)}
+  .day.mid{border-color:var(--warn)}
+  .day.mid .n{color:var(--warn)}
+  .day.mid .d{color:var(--warn)}
+  .day.none{background:var(--danger-50);border-color:#fecaca;cursor:not-allowed}
+  .day.none .n{color:var(--danger)}
+  .day.none .d{color:var(--danger)}
+  .day.past{background:var(--soft);border-color:var(--border);cursor:not-allowed}
+  .day.past .n{color:var(--text-subtle)}
+  .day.selected{background:var(--primary-50);border:2px solid var(--primary)}
+  .day.selected .n{color:var(--primary);font-weight:700}
+  .day.selected .d{color:var(--primary);font-weight:700}
+  .day.today::after{content:'';position:absolute;bottom:6px;width:5px;height:5px;border-radius:50%;background:var(--primary)}
+
+  .legend{display:flex;flex-wrap:wrap;gap:14px;margin-top:18px;padding:14px;background:var(--soft);border:1px solid var(--border);border-radius:10px;font-size:12px;color:var(--text-muted)}
+  .legend .it{display:flex;align-items:center;gap:7px}
+  .legend .dot{width:10px;height:10px;border-radius:50%}
+  .legend .dot.g{background:var(--primary)}
+  .legend .dot.o{background:var(--warn)}
+  .legend .dot.r{background:var(--danger)}
+  .legend .dot.x{background:var(--text-subtle)}
+
+  /* Slots column */
+  .slot-col{flex:1;min-width:0}
+  .slot-head h2{margin:0 0 4px;font-size:18px;font-weight:600}
+  .slot-head .sub{color:var(--primary);font-size:14px;font-weight:600;margin-bottom:6px}
+  .slot-head .note{font-size:13px;color:var(--text-muted);margin-bottom:18px}
+  .slot-grid{display:grid;grid-template-columns:repeat(3,140px);gap:12px}
+  .slot{border:1px solid var(--border);border-radius:8px;padding:12px;background:#1a1d27;text-align:left;display:flex;flex-direction:column;cursor:pointer;transition:all .12s}
+  .slot:hover{border-color:var(--primary);background:var(--primary-50)}
+  .slot b{font-size:18px;font-weight:600;letter-spacing:-.3px;font-variant-numeric:tabular-nums}
+  .slot span{font-size:12px;color:var(--text-muted);margin-top:2px;font-variant-numeric:tabular-nums}
+  .slot.sel{background:var(--primary);border-color:var(--primary)}
+  .slot.sel b,.slot.sel span{color:#fff}
+  .slot.sel span{color:rgba(255,255,255,.8)}
+  .help{margin-top:18px;display:flex;align-items:flex-start;gap:8px;padding:12px 14px;background:var(--soft);border:1px solid var(--border);border-radius:8px;font-size:12.5px;color:var(--text-muted);max-width:460px}
+  .help b{color:var(--text);font-weight:600}
+
+  /* Modal */
+  .overlay{position:fixed;inset:0;background:rgba(17,24,39,.45);display:flex;align-items:center;justify-content:center;z-index:50;padding:20px}
+  .modal{width:440px;max-width:100%;background:#1a1d27;border-radius:14px;box-shadow:0 30px 80px rgba(0,0,0,.25);padding:24px;animation:pop .18s ease-out}
+  @keyframes pop{from{opacity:0;transform:translateY(8px) scale(.98)}}
+  .modal h3{margin:0 0 14px;font-size:18px;font-weight:700}
+  .resume{background:var(--primary-50);border:1px solid var(--primary);border-radius:8px;padding:12px 14px;margin-bottom:18px;display:flex;align-items:center;gap:11px;color:var(--primary);font-weight:600;font-size:14px}
+  .resume .ic{width:30px;height:30px;border-radius:7px;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-size:13px;flex-shrink:0}
+  .resume small{display:block;font-size:11.5px;font-weight:500;color:var(--primary-600);opacity:.85;letter-spacing:.1px;margin-top:1px}
+  label{display:block;font-size:13px;font-weight:600;margin-bottom:6px;color:var(--text)}
+  label .req{color:var(--danger);margin-left:2px}
+  textarea{width:100%;border:1px solid var(--border);border-radius:8px;padding:10px 12px;font-size:13.5px;color:var(--text);background:#1a1d27;outline:none;resize:vertical;min-height:72px;line-height:1.5}
+  textarea:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.12)}
+  .err{font-size:12px;color:var(--danger);margin-top:6px}
+  .mfoot{display:flex;justify-content:flex-end;gap:10px;margin-top:18px}
+  .btn{padding:10px 16px;border-radius:8px;font-size:13.5px;font-weight:600;display:inline-flex;align-items:center;justify-content:center;gap:7px;cursor:pointer;border:1px solid transparent;transition:background .15s,border-color .15s}
+  .btn.cancel{background:#1a1d27;color:var(--text-muted);border-color:var(--border-strong)}
+  .btn.cancel:hover{background:var(--soft)}
+  .btn.confirm{background:var(--primary);color:#fff;width:160px}
+  .btn.confirm:hover{background:var(--primary-600)}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div><div><b>Yoltec</b><span>Servicio médico</span></div></div>
+    <nav>
+      <a><span class="ic">▦</span>Inicio</a>
+      <a><span class="ic">⊞</span>Mis citas</a>
+      <a class="active"><span class="ic">＋</span>Agendar cita</a>
+      <a><span class="ic">◔</span>Pre-evaluación IA</a>
+      <a><span class="ic">℞</span>Recetas</a>
+      <a><span class="ic">◉</span>Mi perfil</a>
+    </nav>
+    <div class="user"><div class="av">NM</div><div><b>Nestor Castillo</b><span>22690495</span></div></div>
+  </aside>
+
+  <main class="main">
+    <div class="cal-col">
+      <div class="page-head">
+        <div class="crumb">Agendar cita</div>
+        <h1>Reserva tu consulta</h1>
+      </div>
+      <h2 class="sec-title">Selecciona un día</h2>
+      <div class="month-nav">
+        <button class="nav-btn" aria-label="Mes anterior">‹</button>
+        <b>Mayo 2026</b>
+        <button class="nav-btn" aria-label="Mes siguiente">›</button>
+      </div>
+      <div class="dow"><span>Lun</span><span>Mar</span><span>Mié</span><span>Jue</span><span>Vie</span><span>Sáb</span></div>
+      <div class="grid" id="grid"></div>
+      <div class="legend">
+        <div class="it"><span class="dot g"></span>Buena disponibilidad</div>
+        <div class="it"><span class="dot o"></span>Poca disponibilidad</div>
+        <div class="it"><span class="dot r"></span>Sin disponibilidad</div>
+        <div class="it"><span class="dot x"></span>No disponible</div>
+      </div>
+    </div>
+
+    <div class="slot-col">
+      <div class="slot-head">
+        <h2>Horarios disponibles</h2>
+        <div class="sub">Martes, 13 de mayo 2026</div>
+        <div class="note">Se muestran solo los horarios libres. Los horarios ocupados no aparecen.</div>
+      </div>
+      <div class="slot-grid" id="slots"></div>
+      <div class="help">
+        <span>ⓘ</span><span>Tu cita dura <b>15 minutos</b>. Llega 5 minutos antes al Edificio C, planta baja. Puedes cancelar hasta 2 horas antes desde <b>Mis citas</b>.</span>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="overlay" role="dialog" aria-modal="true">
+  <div class="modal">
+    <h3>Confirmar cita</h3>
+    <div class="resume">
+      <div class="ic">⊞</div>
+      <div>Martes 13 de mayo · 09:00 – 09:15<small>Servicio médico universitario · Consultorio 2</small></div>
+    </div>
+    <label>Motivo de la cita<span class="req">*</span></label>
+    <textarea placeholder="Describe brevemente el motivo de tu cita..."></textarea>
+    <div class="err">* Campo obligatorio</div>
+    <div class="mfoot">
+      <button class="btn cancel">Cancelar</button>
+      <button class="btn confirm">Confirmar cita</button>
+    </div>
+  </div>
+</div>
+
+<script>
+// Build May 2026 grid — Mon–Sat only (skip Sundays).
+// May 1, 2026 is a Friday. Layout calendar week starting Monday.
+const days = [
+  // [day, type, disp]  types: past, none, good, mid, today, selected
+  [null], [null], [null], [null],
+  [1,'mid',2], [2,'none','Sin disp'],                    // skip Sun
+  [4,'past'], [5,'past'], [6,'past'], [7,'past'], [8,'past'], [9,'past'],
+  [11,'past'], [12,'today',8], [13,'selected','6 disp'], [14,'good',7], [15,'good',9], [16,'mid',3],
+  [18,'good',10], [19,'mid',2], [20,'good',8], [21,'none','Sin disp'], [22,'good',7], [23,'good',9],
+  [25,'good',8], [26,'mid',1], [27,'good',6], [28,'none','Festivo'], [29,'good',8], [30,'mid',2],
+];
+const grid = document.getElementById('grid');
+days.forEach(([d,t,dp])=>{
+  const el = document.createElement(d===null?'div':'button');
+  if(d===null){ el.style.height='56px'; grid.appendChild(el); return; }
+  el.className = 'day ' + (t==='today'?'good today':t==='selected'?'good selected':t);
+  let disp='';
+  if(t==='good'||t==='today'||t==='selected') disp = typeof dp==='string'?dp:dp+' disp';
+  else if(t==='mid') disp = dp+' disp';
+  else if(t==='none') disp = dp;
+  el.innerHTML = '<span class="n">'+d+'</span>' + (disp?'<span class="d">'+disp+'</span>':'');
+  grid.appendChild(el);
+});
+
+// Slots
+const slots = [['08:00','08:15'],['08:15','08:30'],['08:30','08:45'],
+               ['09:00','09:15',true],['09:15','09:30'],
+               ['10:00','10:15'],['10:30','10:45'],['11:00','11:15']];
+const sc = document.getElementById('slots');
+slots.forEach(([from,to,sel])=>{
+  const b = document.createElement('button');
+  b.className = 'slot' + (sel?' sel':'');
+  b.innerHTML = '<b>'+from+'</b><span>– '+to+'</span>';
+  sc.appendChild(b);
+});
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Días Especiales Admin.html
+++ b/frontend/design-reference-dark/Días Especiales Admin.html
@@ -1,0 +1,307 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec Admin · Días especiales</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-300:#3a7d5c; --primary-50:#e8f5ee;
+    --bg:#f8fafc; --surface:#fff;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#eef2f0;
+    --fes-bg:#fee2e2; --fes:#b91c1c;
+    --red-bg:#fff7ed; --red:#c2410c;
+    --vac-bg:#dbeafe; --vac:#1d4ed8;
+    --danger:#dc2626;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar */
+  .side{width:220px;background:var(--primary);color:#fff;display:flex;flex-direction:column;flex-shrink:0;padding:22px 0}
+  .side .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px}
+  .side .brand .y{width:28px;height:28px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .side nav{display:flex;flex-direction:column;gap:2px;padding:0 12px;flex:1}
+  .side nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;text-decoration:none;cursor:pointer}
+  .side nav a svg{width:18px;height:18px;stroke-width:1.8;flex-shrink:0;opacity:.9}
+  .side nav a:hover{background:rgba(255,255,255,.06);color:#fff}
+  .side nav a.active{background:var(--primary-300);color:#fff;font-weight:600}
+  .side .user{padding:14px 16px;border-top:1px solid rgba(255,255,255,.12);margin:12px 12px 0;display:flex;align-items:center;gap:10px}
+  .side .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .side .user .nm{font-size:13px;font-weight:600;color:#fff;line-height:1.2}
+  .side .user .rl{font-size:11px;color:rgba(255,255,255,.65);margin-top:2px}
+
+  /* Main */
+  .main{flex:1;padding:28px 32px 48px;min-width:0}
+  .hd{margin-bottom:22px}
+  .hd h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .hd .sub{font-size:13px;color:var(--text-muted);margin-top:6px;font-weight:500}
+
+  .cols{display:grid;grid-template-columns:55% 45%;gap:20px;align-items:start}
+
+  /* Card */
+  .card{background:#fff;border-radius:12px;border:1px solid var(--border-soft);box-shadow:0 1px 2px rgba(15,23,42,.04)}
+  .card-hd{padding:16px 20px;border-bottom:1px solid var(--border-soft);display:flex;align-items:center;justify-content:space-between}
+  .card-hd h2{margin:0;font-size:15px;font-weight:600;letter-spacing:-.2px}
+  .card-bd{padding:20px}
+
+  /* Calendar */
+  .navmo{display:flex;align-items:center;gap:10px}
+  .navmo button{width:30px;height:30px;border:1px solid var(--border);background:#fff;border-radius:6px;color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center}
+  .navmo button:hover{background:#fafbfb}
+  .navmo .mo{font-size:15px;font-weight:700;letter-spacing:-.2px;min-width:120px;text-align:center;text-transform:capitalize}
+
+  .cal{display:grid;grid-template-columns:repeat(6,1fr);gap:6px}
+  .cal .dh{font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;text-align:center;padding:6px 0}
+  .cell{aspect-ratio:1;border:1px solid var(--border-soft);border-radius:8px;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-start;padding:7px 9px;cursor:pointer;background:#fff;position:relative;font-variant-numeric:tabular-nums}
+  .cell:hover{border-color:var(--primary)}
+  .cell .n{font-size:14px;font-weight:600;color:var(--text)}
+  .cell .tag{font-size:9.5px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;margin-top:auto;align-self:stretch;text-align:left;line-height:1.15}
+  .cell.mute{background:#fafbfb}
+  .cell.mute .n{color:var(--text-subtle)}
+  .cell.fes{background:var(--fes-bg);border-color:#fecaca}
+  .cell.fes .n{color:var(--fes)}
+  .cell.fes .tag{color:var(--fes)}
+  .cell.red{background:var(--red-bg);border-color:#fed7aa}
+  .cell.red .n{color:var(--red)}
+  .cell.red .tag{color:var(--red)}
+  .cell.vac{background:var(--vac-bg);border-color:#bfdbfe}
+  .cell.vac .n{color:var(--vac)}
+  .cell.vac .tag{color:var(--vac)}
+  .cell.sel{box-shadow:0 0 0 2px var(--primary);border-color:var(--primary)}
+
+  .legend{display:flex;gap:18px;margin-top:16px;font-size:12px;color:var(--text-muted);font-weight:500}
+  .legend .it{display:flex;align-items:center;gap:6px}
+  .legend .sw{width:12px;height:12px;border-radius:3px}
+  .sw.fes{background:var(--fes-bg);border:1px solid #fecaca}
+  .sw.red{background:var(--red-bg);border:1px solid #fed7aa}
+  .sw.vac{background:var(--vac-bg);border:1px solid #bfdbfe}
+
+  /* Form */
+  .picked{display:inline-flex;align-items:center;gap:8px;padding:7px 12px;border-radius:7px;background:var(--primary-50);color:var(--primary);font-size:13px;font-weight:600;margin-bottom:18px}
+  .picked svg{stroke-width:2}
+  .field{display:flex;flex-direction:column;gap:6px;margin-bottom:14px}
+  .field label{font-size:12.5px;font-weight:500;color:#374151}
+  .field input,.field select{height:40px;border:1px solid var(--border);border-radius:8px;background:#fff;padding:0 12px;font:500 13px 'Inter',sans-serif;color:var(--text);outline:none;width:100%}
+  .field select{appearance:none;background:#fff url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>") no-repeat right 12px center;padding-right:36px}
+  .field input:focus,.field select:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.12)}
+  .row-btn{display:flex;gap:10px;margin-top:6px}
+  .btn-pri{display:inline-flex;align-items:center;justify-content:center;gap:6px;background:var(--primary);color:#fff;font:600 13px 'Inter',sans-serif;padding:10px 18px;border:0;border-radius:7px;cursor:pointer;flex:1}
+  .btn-pri:hover{background:var(--primary-600)}
+  .btn-gh{display:inline-flex;align-items:center;justify-content:center;gap:6px;background:#fff;color:var(--text);font:500 13px 'Inter',sans-serif;padding:10px 18px;border:1px solid var(--border);border-radius:7px;cursor:pointer;flex:1}
+  .btn-gh:hover{background:#fafbfb}
+
+  /* Table */
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  th{text-align:left;padding:11px 20px;font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.4px;text-transform:uppercase;background:#fafbfb;border-bottom:1px solid var(--border-soft)}
+  td{padding:13px 20px;border-bottom:1px solid var(--border-soft);vertical-align:middle}
+  tr:last-child td{border-bottom:0}
+  .dt{font-weight:600;color:var(--text);font-size:13px;font-variant-numeric:tabular-nums}
+  .nm{font-size:13px;color:var(--text)}
+  .bd{display:inline-flex;font-size:11px;font-weight:600;padding:3px 8px;border-radius:5px}
+  .bd-f{background:var(--fes-bg);color:var(--fes)}
+  .bd-r{background:var(--red-bg);color:var(--red)}
+  .bd-v{background:var(--vac-bg);color:var(--vac)}
+  .del{font-size:12.5px;font-weight:500;color:var(--danger);cursor:pointer;text-decoration:none}
+  .del:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="side">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
+        Panel
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.5"/><path d="M2.5 20c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6"/><circle cx="17" cy="8" r="3"/><path d="M16 14c2.7.2 5 2.5 5 5.5"/></svg>
+        Usuarios
+      </a>
+      <a class="active">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/><circle cx="12" cy="15" r="1.5" fill="currentColor"/></svg>
+        Días especiales
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>
+        Auditoría
+      </a>
+    </nav>
+    <div class="user">
+      <div class="av">MA</div>
+      <div>
+        <div class="nm">Marco Admin</div>
+        <div class="rl">Administrador</div>
+      </div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="hd">
+      <h1>Días especiales</h1>
+      <div class="sub">Marca días sin atención, horarios reducidos y periodos vacacionales del consultorio</div>
+    </div>
+
+    <div class="cols">
+      <!-- Calendar -->
+      <section class="card">
+        <div class="card-hd">
+          <h2>Calendario</h2>
+          <div class="navmo">
+            <button aria-label="Mes anterior"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+            <span class="mo">Mayo 2026</span>
+            <button aria-label="Mes siguiente"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg></button>
+          </div>
+        </div>
+        <div class="card-bd">
+          <div class="cal">
+            <div class="dh">Lun</div><div class="dh">Mar</div><div class="dh">Mié</div><div class="dh">Jue</div><div class="dh">Vie</div><div class="dh">Sáb</div>
+
+            <div class="cell mute"><span class="n">27</span></div>
+            <div class="cell mute"><span class="n">28</span></div>
+            <div class="cell mute"><span class="n">29</span></div>
+            <div class="cell mute"><span class="n">30</span></div>
+            <div class="cell fes"><span class="n">1</span><span class="tag">Día del trabajo</span></div>
+            <div class="cell"><span class="n">2</span></div>
+
+            <div class="cell"><span class="n">4</span></div>
+            <div class="cell"><span class="n">5</span></div>
+            <div class="cell"><span class="n">6</span></div>
+            <div class="cell"><span class="n">7</span></div>
+            <div class="cell"><span class="n">8</span></div>
+            <div class="cell"><span class="n">9</span></div>
+
+            <div class="cell"><span class="n">11</span></div>
+            <div class="cell"><span class="n">12</span></div>
+            <div class="cell sel"><span class="n">13</span></div>
+            <div class="cell"><span class="n">14</span></div>
+            <div class="cell fes"><span class="n">15</span><span class="tag">Día del maestro</span></div>
+            <div class="cell"><span class="n">16</span></div>
+
+            <div class="cell"><span class="n">18</span></div>
+            <div class="cell"><span class="n">19</span></div>
+            <div class="cell"><span class="n">20</span></div>
+            <div class="cell"><span class="n">21</span></div>
+            <div class="cell red"><span class="n">22</span><span class="tag">Horario reducido</span></div>
+            <div class="cell"><span class="n">23</span></div>
+
+            <div class="cell"><span class="n">25</span></div>
+            <div class="cell"><span class="n">26</span></div>
+            <div class="cell"><span class="n">27</span></div>
+            <div class="cell"><span class="n">28</span></div>
+            <div class="cell"><span class="n">29</span></div>
+            <div class="cell"><span class="n">30</span></div>
+
+            <div class="cell mute"><span class="n">1</span></div>
+            <div class="cell mute"><span class="n">2</span></div>
+            <div class="cell mute"><span class="n">3</span></div>
+            <div class="cell mute"><span class="n">4</span></div>
+            <div class="cell mute"><span class="n">5</span></div>
+            <div class="cell mute"><span class="n">6</span></div>
+
+            <div class="cell vac" style="grid-column:1 / span 6"><span class="n">15 jun – 28 jul</span><span class="tag">Periodo vacacional de verano</span></div>
+          </div>
+          <div class="legend">
+            <div class="it"><span class="sw fes"></span>Festivo</div>
+            <div class="it"><span class="sw red"></span>Horario reducido</div>
+            <div class="it"><span class="sw vac"></span>Vacaciones</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Form + table -->
+      <div style="display:flex;flex-direction:column;gap:20px">
+        <section class="card">
+          <div class="card-hd"><h2>Agregar día especial</h2></div>
+          <div class="card-bd">
+            <div class="picked">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+              13 de mayo 2026
+            </div>
+            <div class="field">
+              <label>Tipo</label>
+              <select>
+                <option>Festivo (sin atención)</option>
+                <option>Horario reducido</option>
+                <option>Vacaciones</option>
+              </select>
+            </div>
+            <div class="field">
+              <label>Nombre o motivo</label>
+              <input placeholder="ej. Día del maestro">
+            </div>
+            <div class="row-btn">
+              <button class="btn-gh">Cancelar</button>
+              <button class="btn-pri">Guardar</button>
+            </div>
+          </div>
+        </section>
+
+        <section class="card">
+          <div class="card-hd"><h2>Días registrados</h2></div>
+          <table>
+            <thead>
+              <tr><th>Fecha</th><th>Nombre</th><th>Tipo</th><th></th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="dt">01 May 2026</td>
+                <td class="nm">Día del trabajo</td>
+                <td><span class="bd bd-f">Festivo</span></td>
+                <td style="text-align:right"><a class="del">Eliminar</a></td>
+              </tr>
+              <tr>
+                <td class="dt">15 May 2026</td>
+                <td class="nm">Día del maestro</td>
+                <td><span class="bd bd-f">Festivo</span></td>
+                <td style="text-align:right"><a class="del">Eliminar</a></td>
+              </tr>
+              <tr>
+                <td class="dt">22 May 2026</td>
+                <td class="nm">Junta académica</td>
+                <td><span class="bd bd-r">Reducido</span></td>
+                <td style="text-align:right"><a class="del">Eliminar</a></td>
+              </tr>
+              <tr>
+                <td class="dt">15 Jun – 28 Jul</td>
+                <td class="nm">Vacaciones de verano</td>
+                <td><span class="bd bd-v">Vacaciones</span></td>
+                <td style="text-align:right"><a class="del">Eliminar</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+  </main>
+</div>
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Inicio Alumno.html
+++ b/frontend/design-reference-dark/Inicio Alumno.html
@@ -1,0 +1,331 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Inicio</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec;
+    --warn:#f59e0b; --warn-50:#fef3e0;
+    --danger:#dc2626; --danger-50:#fde8e8;
+    --bg:#f7f9f8; --surface:#ffffff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body,#app{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar (same as agendar) */
+  .sb{width:232px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px;letter-spacing:-.5px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px;letter-spacing:.3px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;text-decoration:none;cursor:pointer}
+  .sb a:hover{background:rgba(255,255,255,.05)}
+  .sb a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb a .ic{font-size:14px;width:16px;text-align:center;opacity:.95}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px;flex-shrink:0}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px;font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;display:flex;flex-direction:column}
+  .header{padding:32px 36px 8px;background:#1a1d27;border-bottom:1px solid var(--border)}
+  .header .crumb{font-size:12px;color:var(--text-subtle);margin-bottom:6px;font-weight:500;text-transform:uppercase;letter-spacing:.4px}
+  .header h1{margin:0 0 6px;font-size:26px;font-weight:700;letter-spacing:-.5px}
+  .header h1 span{color:var(--primary)}
+  .header .date{font-size:13.5px;color:var(--text-muted);text-transform:capitalize}
+  .header .actions{position:absolute;right:36px;top:32px;display:flex;gap:10px}
+
+  .header-row{display:flex;justify-content:space-between;align-items:flex-start;gap:20px}
+  .btn{padding:10px 16px;border-radius:7px;font-size:13.5px;font-weight:600;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.secondary{background:#1a1d27;color:var(--primary);border:1px solid var(--primary)}
+  .btn.secondary:hover{background:var(--primary-50)}
+  .btn.ghost{color:var(--text-muted)}
+  .btn.ghost:hover{background:var(--bg)}
+  .btn.danger-ghost{color:var(--danger);background:transparent;padding:6px 10px;font-size:12.5px;font-weight:600;border-radius:6px}
+  .btn.danger-ghost:hover{background:var(--danger-50)}
+  .btn.sm{padding:6px 12px;font-size:12.5px}
+  .btn .plus{font-size:16px;font-weight:300;line-height:1}
+
+  .content{padding:24px 36px 60px;flex:1}
+
+  /* KPI cards */
+  .kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-bottom:28px}
+  .kpi{background:#1a1d27;border:1px solid var(--border);border-radius:10px;padding:20px 22px;display:flex;flex-direction:column;gap:8px;position:relative;box-shadow:0 2px 8px rgba(26,92,58,.04)}
+  .kpi .lbl{font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;display:flex;align-items:center;gap:8px}
+  .kpi .lbl .ic{width:24px;height:24px;border-radius:6px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-size:13px}
+  .kpi .v{font-size:34px;font-weight:700;line-height:1;letter-spacing:-.8px;color:var(--text)}
+  .kpi .v small{font-size:14px;color:var(--text-muted);font-weight:500;margin-left:6px}
+  .kpi .sub{font-size:12.5px;color:var(--text-subtle)}
+  .kpi .sub b{color:var(--text-muted);font-weight:600}
+  .kpi.accent{border-left:3px solid var(--primary)}
+
+  /* Sections */
+  .section{margin-bottom:28px}
+  .section-head{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:14px}
+  .section-head h2{margin:0;font-size:17px;font-weight:600;letter-spacing:-.2px}
+  .section-head .link{font-size:12.5px;color:var(--primary);font-weight:600}
+  .section-head .link:hover{text-decoration:underline}
+
+  .card{background:#1a1d27;border:1px solid var(--border);border-radius:10px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04)}
+
+  /* Table */
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  th{text-align:left;padding:13px 22px;font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;background:var(--bg);border-bottom:1px solid var(--border)}
+  td{padding:14px 22px;border-bottom:1px solid var(--border);vertical-align:middle}
+  tr:last-child td{border-bottom:none}
+  tr:hover td{background:var(--bg)}
+  .date-cell{display:flex;align-items:center;gap:11px}
+  .date-cell .d{flex-shrink:0;width:42px;text-align:center;background:var(--primary-50);border-radius:7px;padding:6px 0;color:var(--primary)}
+  .date-cell .d b{display:block;font-size:16px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums}
+  .date-cell .d span{display:block;font-size:9.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;margin-top:2px}
+  .date-cell .dow{font-size:11.5px;color:var(--text-subtle);text-transform:capitalize}
+  .date-cell .dow b{display:block;color:var(--text);font-size:13px;font-weight:500;text-transform:capitalize}
+  .hr{font-variant-numeric:tabular-nums;font-weight:600;color:var(--text)}
+  .motivo{color:var(--text-muted)}
+  .motivo b{display:block;color:var(--text);font-weight:500;font-size:13.5px;margin-bottom:2px}
+  .motivo span{font-size:12px;color:var(--text-subtle)}
+  .b{display:inline-flex;padding:3px 10px;border-radius:999px;font-size:11.5px;font-weight:600;align-items:center;gap:5px}
+  .b.ok{background:var(--primary-50);color:var(--primary)}
+  .b.warn{background:var(--warn-50);color:var(--warn)}
+  .b .pulse{width:6px;height:6px;border-radius:50%;background:currentColor}
+
+  /* Empty state */
+  .empty{padding:48px 32px;text-align:center}
+  .empty .ic{width:56px;height:56px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-size:24px;margin:0 auto 14px}
+  .empty h3{margin:0 0 6px;font-size:16px;font-weight:600}
+  .empty p{margin:0 0 18px;font-size:13.5px;color:var(--text-muted);max-width:380px;margin-left:auto;margin-right:auto;line-height:1.5}
+
+  /* Two-column lower: tips + recetas mini */
+  .row2{display:grid;grid-template-columns:1.4fr 1fr;gap:18px}
+  .panel-head{padding:16px 20px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center}
+  .panel-head h3{margin:0;font-size:15px;font-weight:600;letter-spacing:-.1px}
+  .recetas-list{padding:6px 0}
+  .receta-row{display:flex;align-items:center;gap:12px;padding:13px 20px;border-bottom:1px solid var(--border)}
+  .receta-row:last-child{border-bottom:none}
+  .receta-row .ic{width:36px;height:36px;border-radius:8px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px;flex-shrink:0}
+  .receta-row .info{flex:1;min-width:0}
+  .receta-row .info b{display:block;font-size:13.5px;font-weight:600;margin-bottom:2px}
+  .receta-row .info span{font-size:12px;color:var(--text-subtle)}
+  .receta-row .days{font-size:12px;color:var(--text-muted);font-weight:500;text-align:right;font-variant-numeric:tabular-nums}
+  .receta-row .days b{display:block;color:var(--primary);font-weight:700;font-size:13px}
+
+  /* Tip card */
+  .tip{padding:20px 22px;display:flex;gap:16px;align-items:flex-start}
+  .tip .ic-big{width:44px;height:44px;border-radius:10px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-size:20px;flex-shrink:0}
+  .tip h4{margin:0 0 6px;font-size:14.5px;font-weight:600}
+  .tip p{margin:0 0 12px;font-size:13px;color:var(--text-muted);line-height:1.55}
+  .tip .actions{display:flex;gap:8px}
+
+  /* Floating CTA */
+  .fab{position:fixed;right:32px;bottom:32px;background:var(--primary);color:#fff;border-radius:999px;padding:14px 22px;font-size:14px;font-weight:600;display:inline-flex;align-items:center;gap:8px;box-shadow:0 8px 24px rgba(26,92,58,.32);cursor:pointer;z-index:50;transition:all .15s}
+  .fab:hover{background:var(--primary-600);box-shadow:0 10px 28px rgba(26,92,58,.4);transform:translateY(-1px)}
+  .fab .plus{font-size:18px;font-weight:300;line-height:1}
+</style>
+</head>
+<body>
+<div id="app"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+const MONTHS=['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+const DOWS=['domingo','lunes','martes','miércoles','jueves','viernes','sábado'];
+const TODAY = new Date(2026,4,11); // 11 may 2026 — lunes
+
+function Sidebar(){
+  const items=[
+    ['inicio','Inicio','▦',true],
+    ['citas','Mis citas','⊞'],
+    ['ia','Pre-evaluación IA','◔'],
+    ['rec','Recetas','℞'],
+    ['perf','Mi perfil','◉'],
+  ];
+  return (
+    <aside className="sb">
+      <div className="brand">
+        <div className="y">Y</div>
+        <div><b>Yoltec</b><span>Servicio médico</span></div>
+      </div>
+      <nav>{items.map(([k,l,i,a])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}</a>))}</nav>
+      <div className="user">
+        <div className="av">AP</div>
+        <div><b>Ana Pérez García</b><span>22690495</span></div>
+      </div>
+    </aside>
+  );
+}
+
+function App({empty}){
+  const dateStr = `${DOWS[TODAY.getDay()]} ${TODAY.getDate()} de ${MONTHS[TODAY.getMonth()]} de ${TODAY.getFullYear()}`;
+  const citas=[
+    {d:13,m:'MAY',dow:'miércoles',hr:'10:30',motivo:'Control de presión',meta:'Dr. Omar Salas · Consultorio 2',estado:'ok',label:'Confirmada'},
+    {d:18,m:'MAY',dow:'lunes',hr:'09:15',motivo:'Revisión nutricional',meta:'Dra. Daniela Cruz · Consultorio 1',estado:'warn',label:'Pendiente'},
+    {d:25,m:'MAY',dow:'lunes',hr:'13:00',motivo:'Seguimiento migraña',meta:'Dr. Omar Salas · Consultorio 2',estado:'ok',label:'Confirmada'},
+  ];
+  const showEmpty = !!empty;
+
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <div className="header">
+          <div className="header-row">
+            <div>
+              <div className="crumb">Inicio</div>
+              <h1>Bienvenida, <span>Ana</span></h1>
+              <div className="date">{dateStr}</div>
+            </div>
+            <div style={{display:'flex',gap:10}}>
+              <button className="btn ghost">Notificaciones · 2</button>
+              <button className="btn primary"><span className="plus">＋</span>Nueva cita</button>
+            </div>
+          </div>
+        </div>
+
+        <div className="content">
+          <div className="kpis">
+            <div className="kpi accent">
+              <div className="lbl"><span className="ic">⊞</span>Próximas citas</div>
+              <div className="v">3<small>esta semana</small></div>
+              <div className="sub">Próxima: <b>miércoles 13 may, 10:30</b></div>
+            </div>
+            <div className="kpi">
+              <div className="lbl"><span className="ic">⚲</span>Última visita</div>
+              <div className="v">28<small>abr 2026</small></div>
+              <div className="sub">Faringitis aguda · <b>Atendida</b></div>
+            </div>
+            <div className="kpi">
+              <div className="lbl"><span className="ic">℞</span>Recetas activas</div>
+              <div className="v">2<small>vigentes</small></div>
+              <div className="sub">Próxima a vencer en <b>3 días</b></div>
+            </div>
+          </div>
+
+          <div className="section">
+            <div className="section-head">
+              <h2>Próximas citas</h2>
+              {!showEmpty && <a className="link">Ver todas →</a>}
+            </div>
+            <div className="card">
+              {showEmpty ? (
+                <div className="empty">
+                  <div className="ic">⊞</div>
+                  <h3>No tienes citas agendadas</h3>
+                  <p>Cuando agendes una consulta en el servicio médico aparecerá aquí con su fecha, hora y motivo.</p>
+                  <button className="btn primary"><span className="plus">＋</span>Agendar cita</button>
+                </div>
+              ) : (
+                <table>
+                  <thead><tr>
+                    <th style={{width:'26%'}}>Fecha</th>
+                    <th style={{width:'10%'}}>Hora</th>
+                    <th>Motivo</th>
+                    <th style={{width:'14%'}}>Estatus</th>
+                    <th style={{width:'14%',textAlign:'right'}}></th>
+                  </tr></thead>
+                  <tbody>
+                    {citas.map((c,i)=>(
+                      <tr key={i}>
+                        <td>
+                          <div className="date-cell">
+                            <div className="d"><b>{c.d}</b><span>{c.m}</span></div>
+                            <div className="dow"><b>{c.dow}</b>2026</div>
+                          </div>
+                        </td>
+                        <td className="hr">{c.hr}</td>
+                        <td className="motivo"><b>{c.motivo}</b><span>{c.meta}</span></td>
+                        <td><span className={'b '+c.estado}><span className="pulse"></span>{c.label}</span></td>
+                        <td style={{textAlign:'right'}}><button className="btn danger-ghost">Cancelar</button></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+
+          <div className="section">
+            <div className="row2">
+              <div className="card">
+                <div className="panel-head"><h3>Tu salud esta semana</h3></div>
+                <div className="tip">
+                  <div className="ic-big">♥</div>
+                  <div>
+                    <h4>Recordatorio: control de presión</h4>
+                    <p>Tu última toma fue hace 18 días. El doctor recomendó un control quincenal. Puedes agendar una cita rápida de 15 minutos.</p>
+                    <div className="actions">
+                      <button className="btn primary sm"><span className="plus">＋</span>Agendar control</button>
+                      <button className="btn ghost sm">Recordarme después</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="card">
+                <div className="panel-head">
+                  <h3>Recetas activas</h3>
+                  <a className="link">Ver todas →</a>
+                </div>
+                <div className="recetas-list">
+                  <div className="receta-row">
+                    <div className="ic">℞</div>
+                    <div className="info"><b>Paracetamol 500 mg</b><span>Cada 8 hrs · 5 días</span></div>
+                    <div className="days"><b>3 días</b>restantes</div>
+                  </div>
+                  <div className="receta-row">
+                    <div className="ic">℞</div>
+                    <div className="info"><b>Amoxicilina 500 mg</b><span>Cada 12 hrs · 7 días</span></div>
+                    <div className="days"><b>5 días</b>restantes</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button className="fab"><span className="plus">＋</span>Nueva cita</button>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(<App/>);
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Login Admin.html
+++ b/frontend/design-reference-dark/Login Admin.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec Admin · Acceso</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e;
+    --bg:#f1f5f9; --surface:#fff;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#94a3b8;
+    --border:#2d3144;
+    --danger:#dc2626; --danger-bg:#fef2f2;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:var(--bg)}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:40px 20px;min-height:100vh}
+
+  .wrap{display:flex;flex-direction:column;align-items:center;gap:24px;flex:1;justify-content:center;width:100%}
+
+  .brand{display:flex;align-items:center;gap:9px;color:var(--primary)}
+  .brand .y{width:26px;height:26px;border-radius:6px;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:15px;letter-spacing:-.5px}
+  .brand span{font-size:15px;font-weight:600;letter-spacing:-.2px}
+
+  .card{width:420px;max-width:100%;background:var(--surface);border-radius:16px;box-shadow:0 8px 28px rgba(15,23,42,.08),0 2px 8px rgba(15,23,42,.04);padding:40px}
+
+  .divider{height:1px;background:var(--border);margin-bottom:24px}
+
+  .title{font-size:22px;font-weight:700;text-align:center;letter-spacing:-.4px;margin:0}
+  .sub{font-size:13.5px;color:var(--text-muted);text-align:center;margin:6px 0 18px;font-weight:500}
+
+  .alert{display:flex;align-items:center;gap:8px;justify-content:center;background:var(--danger-bg);color:var(--danger);font-size:12px;font-weight:600;padding:9px 14px;border-radius:8px;margin-bottom:28px}
+  .alert svg{width:14px;height:14px;stroke-width:2}
+
+  .field{display:flex;flex-direction:column;gap:6px;margin-bottom:16px}
+  .field label{font-size:13px;font-weight:500;color:#374151}
+  .field .ctl{position:relative}
+  .field input{width:100%;height:44px;border:1px solid var(--border);border-radius:8px;padding:0 14px;font:500 14px 'Inter',sans-serif;color:var(--text);background:#1a1d27;outline:none;transition:border-color .15s,box-shadow .15s}
+  .field input:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.12)}
+  .field input.pw{padding-right:44px}
+  .toggle{position:absolute;top:50%;right:8px;transform:translateY(-50%);width:32px;height:32px;border:0;background:transparent;display:flex;align-items:center;justify-content:center;color:var(--text-subtle);cursor:pointer;border-radius:6px}
+  .toggle:hover{color:var(--text-muted);background:#0f1117}
+  .toggle svg{width:18px;height:18px;stroke-width:1.8}
+
+  .submit{width:100%;height:46px;border:0;border-radius:8px;background:var(--primary);color:#fff;font:600 14px 'Inter',sans-serif;cursor:pointer;margin-top:8px;letter-spacing:.1px;transition:background .15s}
+  .submit:hover{background:var(--primary-600)}
+
+  .auditline{font-size:11.5px;color:var(--text-subtle);text-align:center;margin-top:22px;font-weight:500}
+
+  .foot{font-size:11px;color:var(--text-subtle);text-align:center;padding-top:24px;font-weight:500}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <form class="card" onsubmit="event.preventDefault()">
+    <div class="brand"><div class="y">Y</div><span>Yoltec</span></div>
+    <div class="divider" style="margin-top:18px"></div>
+
+    <h1 class="title">Panel de administración</h1>
+    <p class="sub">Acceso restringido al personal autorizado</p>
+
+    <div class="alert">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.73 3h16.9a2 2 0 0 0 1.73-3L13.7 3.86a2 2 0 0 0-3.4 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      Área administrativa
+    </div>
+
+    <div class="field">
+      <label for="u">Usuario</label>
+      <div class="ctl"><input id="u" type="text" autocomplete="username"></div>
+    </div>
+
+    <div class="field">
+      <label for="p">Contraseña</label>
+      <div class="ctl">
+        <input id="p" class="pw" type="password" autocomplete="current-password">
+        <button type="button" class="toggle" aria-label="Mostrar contraseña" onclick="
+          const i=document.getElementById('p');
+          const isP=i.type==='password';
+          i.type=isP?'text':'password';
+          this.querySelector('svg').innerHTML = isP
+            ? '<path d=&quot;M2 2l20 20&quot;/><path d=&quot;M6.5 6.5C4 8.4 2.4 11 2 12c1.5 3 5.5 7 10 7 2 0 3.8-.6 5.3-1.5&quot;/><path d=&quot;M9.9 4.2C10.6 4.1 11.3 4 12 4c4.5 0 8.5 4 10 7-.5 1-1.5 2.4-3 3.8&quot;/><path d=&quot;M9.5 9.5a3.5 3.5 0 0 0 5 5&quot;/>'
+            : '<path d=&quot;M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z&quot;/><circle cx=&quot;12&quot; cy=&quot;12&quot; r=&quot;3&quot;/>';
+        ">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <button type="submit" class="submit">Ingresar</button>
+
+    <div class="auditline">Todos los accesos son registrados en bitácora de auditoría</div>
+  </form>
+</div>
+
+<div class="foot">Yoltec Admin · Acceso no autorizado será reportado</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Mi Perfil.html
+++ b/frontend/design-reference-dark/Mi Perfil.html
@@ -1,0 +1,498 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mi perfil</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec; --primary-100:#d1e3d8;
+    --warn:#f59e0b; --warn-50:#fef3e0;
+    --danger:#dc2626; --danger-50:#fde8e8;
+    --info:#0369a1; --info-50:#e0f2fe;
+    --bg:#f7f9f8; --surface:#fff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body,#app{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+  input,select,textarea{font-family:inherit;color:var(--text)}
+
+  .app{display:flex;min-height:100vh}
+
+  .sb{width:232px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;cursor:pointer}
+  .sb a:hover{background:rgba(255,255,255,.05)}
+  .sb a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb a .ic{font-size:14px;width:16px;text-align:center}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px;font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;display:flex;flex-direction:column}
+
+  /* Profile header */
+  .phead{background:#1a1d27;border-bottom:1px solid var(--border);padding:28px 36px 0}
+  .phead .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:500;margin-bottom:14px}
+  .pcard{display:flex;align-items:center;gap:24px;padding-bottom:24px}
+  .pavatar{position:relative;flex-shrink:0}
+  .pavatar .circle{width:92px;height:92px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:32px;letter-spacing:-1px;border:3px solid #fff;box-shadow:0 0 0 1px var(--border)}
+  .pavatar .change{position:absolute;bottom:-4px;right:-4px;background:#1a1d27;color:var(--primary);border:1px solid var(--primary);font-size:11px;font-weight:600;padding:5px 9px;border-radius:999px;box-shadow:0 2px 4px rgba(0,0,0,.06);display:inline-flex;align-items:center;gap:4px;white-space:nowrap}
+  .pavatar .change:hover{background:var(--primary-50)}
+  .pinfo{flex:1;min-width:0}
+  .pinfo h1{margin:0 0 4px;font-size:24px;font-weight:700;letter-spacing:-.5px;display:inline-flex;align-items:center;gap:12px}
+  .pinfo .ctrl{font-size:13px;color:var(--text-muted);font-variant-numeric:tabular-nums;margin-bottom:10px;font-weight:500}
+  .pinfo .ctrl b{color:var(--text);font-weight:600}
+  .pinfo .meta{display:flex;gap:24px;font-size:13px;color:var(--text-muted)}
+  .pinfo .meta div{display:flex;flex-direction:column;gap:2px}
+  .pinfo .meta span{font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .pinfo .meta b{color:var(--text);font-weight:600;font-size:13.5px}
+  .b{display:inline-flex;padding:3px 10px;border-radius:999px;font-size:11.5px;font-weight:600;align-items:center;gap:5px}
+  .b.ok{background:var(--primary-50);color:var(--primary)}
+  .b .pulse{width:6px;height:6px;border-radius:50%;background:currentColor}
+
+  .tabs{display:flex;gap:0;border-bottom:1px solid transparent;margin-bottom:-1px}
+  .tabs button{padding:13px 4px;margin-right:28px;font-size:14px;font-weight:500;color:var(--text-muted);border-bottom:2px solid transparent;display:flex;align-items:center;gap:8px}
+  .tabs button:hover{color:var(--text)}
+  .tabs button.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+  .tabs button .ct{background:var(--bg);color:var(--text-muted);padding:1px 8px;border-radius:999px;font-size:11.5px;font-weight:600}
+  .tabs button.active .ct{background:var(--primary-50);color:var(--primary)}
+
+  .content{padding:24px 36px 60px;flex:1}
+
+  /* Btn */
+  .btn{padding:9px 14px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.secondary{background:#1a1d27;color:var(--primary);border:1px solid var(--primary)}
+  .btn.secondary:hover{background:var(--primary-50)}
+  .btn.ghost{color:var(--text-muted)}
+  .btn.ghost:hover{background:var(--bg)}
+  .btn.gray{background:#1a1d27;color:var(--text-muted);border:1px solid var(--border-strong)}
+  .btn.gray:hover{background:var(--bg);border-color:var(--text-subtle)}
+  .btn.sm{padding:6px 11px;font-size:12.5px}
+
+  .card{background:#1a1d27;border:1px solid var(--border);border-radius:10px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04)}
+  .section-head{display:flex;justify-content:space-between;align-items:center;padding:16px 22px;border-bottom:1px solid var(--border)}
+  .section-head h2{margin:0;font-size:15.5px;font-weight:600;letter-spacing:-.1px}
+  .section-head .hint{font-size:12px;color:var(--text-subtle);margin-top:2px}
+  .section-head .left h2 + .hint{margin-top:2px}
+
+  /* Info grid */
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:18px 24px;padding:22px}
+  .grid2 .full{grid-column:1/-1}
+  .field{display:flex;flex-direction:column;gap:6px}
+  .field label{font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;display:flex;justify-content:space-between;align-items:baseline}
+  .field label .req{color:var(--danger)}
+  .field .ro{padding:10px 12px;background:var(--bg);border:1px solid var(--border);border-radius:7px;font-size:13.5px;color:var(--text);font-weight:500;min-height:38px;display:flex;align-items:center}
+  .field .ro.empty{color:var(--text-subtle);font-weight:400;font-style:italic}
+  .field .ro.medical{font-family:inherit;line-height:1.55;align-items:flex-start;padding-top:11px;min-height:auto;white-space:pre-wrap}
+  .field input,.field select,.field textarea{padding:10px 12px;border:1px solid var(--border-strong);border-radius:7px;font-size:13.5px;background:#1a1d27;outline:none;color:var(--text);transition:border-color .15s,box-shadow .15s}
+  .field input:focus,.field select:focus,.field textarea:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.1)}
+  .field textarea{min-height:84px;resize:vertical;line-height:1.55}
+  .field .below{font-size:11.5px;color:var(--text-subtle);margin-top:2px}
+
+  .editbar{display:flex;justify-content:space-between;align-items:center;padding:14px 22px;background:var(--bg);border-top:1px solid var(--border)}
+  .editbar .saved{font-size:12px;color:var(--text-subtle);display:flex;align-items:center;gap:6px}
+
+  /* Recetas list */
+  .receta{padding:18px 22px;border-bottom:1px solid var(--border)}
+  .receta:last-child{border-bottom:none}
+  .receta-row{display:flex;justify-content:space-between;align-items:flex-start;gap:24px}
+  .receta-head .date{display:flex;align-items:center;gap:11px}
+  .receta-head .d{flex-shrink:0;width:42px;text-align:center;background:var(--primary-50);border-radius:7px;padding:6px 0;color:var(--primary)}
+  .receta-head .d b{display:block;font-size:16px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums}
+  .receta-head .d span{display:block;font-size:9.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;margin-top:2px}
+  .receta-head .meta b{display:block;font-size:13px;font-weight:600;text-transform:capitalize}
+  .receta-head .meta span{font-size:11.5px;color:var(--text-subtle)}
+  .receta-doctor{font-size:13px;color:var(--text-muted);text-align:right}
+  .receta-doctor b{display:block;color:var(--text);font-weight:600;font-size:13.5px;margin-bottom:2px}
+  .receta-body{margin-top:14px;display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  .receta-sec h4{margin:0 0 8px;font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .med-list{display:flex;flex-direction:column;gap:6px}
+  .med{display:flex;align-items:flex-start;gap:10px;font-size:13px;color:var(--text)}
+  .med .pill{width:22px;height:22px;border-radius:6px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:11px;flex-shrink:0;margin-top:1px}
+  .med b{font-weight:600}
+  .med span{display:block;font-size:11.5px;color:var(--text-subtle);margin-top:1px}
+  .ind{font-size:13px;color:var(--text-muted);line-height:1.55;background:var(--bg);padding:10px 12px;border-radius:7px;border-left:3px solid var(--primary-100)}
+  .receta-foot{margin-top:12px;display:flex;justify-content:space-between;align-items:center;font-size:11.5px;color:var(--text-subtle)}
+  .receta-foot .left{display:flex;gap:14px}
+  .receta-foot .vig{color:var(--primary);font-weight:600}
+  .receta-foot .exp{color:var(--text-subtle)}
+
+  /* Bitácora */
+  .filterbar{display:flex;gap:10px;align-items:center;background:#1a1d27;border:1px solid var(--border);border-radius:10px;padding:12px 16px;margin-bottom:18px;flex-wrap:wrap}
+  .filterbar .lab{font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-right:4px}
+  .ffld{display:flex;align-items:center;gap:8px;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:7px 11px}
+  .ffld input,.ffld select{background:transparent;border:none;outline:none;font-size:13px;color:var(--text);min-width:130px}
+  .ffld .ic{color:var(--text-subtle);font-size:13px}
+  .filterbar .spacer{flex:1}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  th{text-align:left;padding:12px 22px;font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;background:var(--bg);border-bottom:1px solid var(--border)}
+  td{padding:14px 22px;border-bottom:1px solid var(--border);vertical-align:middle}
+  tr:last-child td{border-bottom:none}
+  tr:hover td{background:var(--bg)}
+  .date-cell{display:flex;align-items:center;gap:11px}
+  .date-cell .d{flex-shrink:0;width:42px;text-align:center;background:var(--bg);border-radius:7px;padding:6px 0;color:var(--text-subtle)}
+  .date-cell .d b{display:block;font-size:16px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums}
+  .date-cell .d span{display:block;font-size:9.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;margin-top:2px}
+  .date-cell .dow b{display:block;color:var(--text);font-size:13px;font-weight:500;text-transform:capitalize}
+  .date-cell .dow span{font-size:11.5px;color:var(--text-subtle)}
+  .hr{font-variant-numeric:tabular-nums;font-weight:600}
+  .motivo b{display:block;color:var(--text);font-weight:500;font-size:13.5px;margin-bottom:2px}
+  .motivo span{font-size:12px;color:var(--text-subtle)}
+  .b.attended{background:var(--info-50);color:var(--info)}
+  .b.cancel{background:var(--danger-50);color:var(--danger)}
+  .b.noshow{background:#f1f5f9;color:#64748b}
+
+  /* Switcher */
+  .switcher{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);z-index:200;background:#1a1d27;border:1px solid var(--border);border-radius:8px;padding:3px;display:flex;gap:1px;box-shadow:0 6px 16px rgba(26,92,58,.14)}
+  .switcher button{padding:7px 14px;border-radius:5px;font-size:12.5px;font-weight:500;color:var(--text-muted)}
+  .switcher button.active{background:var(--primary);color:#fff}
+</style>
+</head>
+<body>
+<div id="app"></div>
+<div class="switcher">
+  <button id="s1" class="active">Médica · lectura</button>
+  <button id="s2">Médica · edición</button>
+  <button id="s3">Recetas</button>
+  <button id="s4">Bitácora</button>
+</div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+const {useState}=React;
+
+function Sidebar(){
+  const items=[['inicio','Inicio','▦'],['citas','Mis citas','⊞'],['ia','Pre-evaluación IA','◔'],['rec','Recetas','℞'],['perf','Mi perfil','◉',true]];
+  return (
+    <aside className="sb">
+      <div className="brand"><div className="y">Y</div><div><b>Yoltec</b><span>Servicio médico</span></div></div>
+      <nav>{items.map(([k,l,i,a])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}</a>))}</nav>
+      <div className="user"><div className="av">NM</div><div><b>Nestor Castillo</b><span>22690495</span></div></div>
+    </aside>
+  );
+}
+
+function ProfileHeader({tab,setTab}){
+  return (
+    <div className="phead">
+      <div className="crumb">Mi perfil</div>
+      <div className="pcard">
+        <div className="pavatar">
+          <div className="circle">NM</div>
+          <button className="change">＋ Cambiar foto</button>
+        </div>
+        <div className="pinfo">
+          <h1>Nestor Castillo <span className="b ok"><span className="pulse"></span>Activo</span></h1>
+          <div className="ctrl">No. de control · <b>22690495</b></div>
+          <div className="meta">
+            <div><span>Carrera</span><b>Ing. Sistemas</b></div>
+            <div><span>Semestre</span><b>6°</b></div>
+            <div><span>Correo</span><b>22690495@itsm.edu.mx</b></div>
+            <div><span>Última actualización</span><b>28 abr 2026</b></div>
+          </div>
+        </div>
+      </div>
+      <div className="tabs">
+        <button className={tab==='med'?'active':''} onClick={()=>setTab('med')}>Información médica</button>
+        <button className={tab==='rec'?'active':''} onClick={()=>setTab('rec')}>Mis recetas <span className="ct">3</span></button>
+        <button className={tab==='bit'?'active':''} onClick={()=>setTab('bit')}>Bitácora <span className="ct">7</span></button>
+      </div>
+    </div>
+  );
+}
+
+function MedicaReadonly({onEdit}){
+  return (
+    <div className="card">
+      <div className="section-head">
+        <div className="left">
+          <h2>Información médica</h2>
+          <div className="hint">Tus datos los puede consultar el doctor durante la consulta. Mantenlos actualizados.</div>
+        </div>
+        <button className="btn secondary sm" onClick={onEdit}>✎ Editar</button>
+      </div>
+      <div className="grid2">
+        <div className="field"><label>Tipo de sangre</label><div className="ro">O+</div></div>
+        <div className="field"><label>Peso</label><div className="ro">68 kg</div></div>
+        <div className="field"><label>Estatura</label><div className="ro">175 cm</div></div>
+        <div className="field"><label>Contacto de emergencia</label><div className="ro">Lucía Castillo — (777) 312 4408</div></div>
+        <div className="field full">
+          <label>Alergias conocidas</label>
+          <div className="ro medical">Penicilina (reacción cutánea moderada, reportada en 2023).{'\n'}Polen — rinitis estacional en primavera.</div>
+        </div>
+        <div className="field full">
+          <label>Enfermedades crónicas / antecedentes</label>
+          <div className="ro medical">Asma leve diagnosticada en 2019 — uso ocasional de salbutamol inhalado.{'\n'}Antecedente familiar: diabetes tipo 2 (padre).</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MedicaEdit({onCancel,onSave}){
+  return (
+    <div className="card">
+      <div className="section-head">
+        <div className="left">
+          <h2>Editar información médica</h2>
+          <div className="hint">Los cambios se guardarán en tu expediente y serán visibles para el personal médico autorizado.</div>
+        </div>
+        <span className="b ok"><span className="pulse"></span>Modo edición</span>
+      </div>
+      <div className="grid2">
+        <div className="field">
+          <label>Tipo de sangre <span className="req">*</span></label>
+          <select defaultValue="O+">
+            <option>A+</option><option>A-</option>
+            <option>B+</option><option>B-</option>
+            <option>AB+</option><option>AB-</option>
+            <option>O+</option><option>O-</option>
+            <option>No lo sé</option>
+          </select>
+        </div>
+        <div className="field">
+          <label>Peso (kg)</label>
+          <input defaultValue="68" inputMode="decimal"/>
+        </div>
+        <div className="field">
+          <label>Estatura (cm)</label>
+          <input defaultValue="175" inputMode="numeric"/>
+        </div>
+        <div className="field">
+          <label>Contacto de emergencia <span className="req">*</span></label>
+          <input defaultValue="Lucía Castillo — (777) 312 4408"/>
+          <div className="below">Nombre completo y teléfono a 10 dígitos.</div>
+        </div>
+        <div className="field full">
+          <label>Alergias conocidas</label>
+          <textarea defaultValue={"Penicilina (reacción cutánea moderada, reportada en 2023).\nPolen — rinitis estacional en primavera."}/>
+          <div className="below">Separa cada alergia con un salto de línea. Indica gravedad si aplica.</div>
+        </div>
+        <div className="field full">
+          <label>Enfermedades crónicas / antecedentes</label>
+          <textarea defaultValue={"Asma leve diagnosticada en 2019 — uso ocasional de salbutamol inhalado.\nAntecedente familiar: diabetes tipo 2 (padre)."}/>
+        </div>
+      </div>
+      <div className="editbar">
+        <div className="saved">Última actualización: <b style={{color:'var(--text-muted)',fontWeight:600,marginLeft:4}}>28 abr 2026, 11:42</b></div>
+        <div style={{display:'flex',gap:10}}>
+          <button className="btn gray" onClick={onCancel}>Cancelar</button>
+          <button className="btn primary" onClick={onSave}>Guardar cambios</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const RECETAS=[
+  {
+    d:28,m:'ABR',dow:'martes',doc:'Dr. Omar Salas',esp:'Medicina general',cons:'Faringitis aguda',
+    meds:[{n:'Paracetamol 500 mg',p:'1 tableta cada 8 hrs',dur:'5 días'},{n:'Loratadina 10 mg',p:'1 tableta al día',dur:'7 días'}],
+    ind:'Tomar abundante agua, reposo relativo 48 hrs. Evitar bebidas frías y irritantes. Regresar si la fiebre supera 38.5 °C por más de 24 hrs o si aparece dificultad para tragar saliva.',
+    vig:'Vigente · vence 5 may 2026'
+  },
+  {
+    d:14,m:'ABR',dow:'martes',doc:'Dr. Omar Salas',esp:'Medicina general',cons:'Control general',
+    meds:[{n:'Multivitamínico adulto',p:'1 cápsula al día',dur:'30 días'}],
+    ind:'Mantener actividad física moderada 3 veces por semana. Próximo control en 3 meses para revisión de hemograma.',
+    vig:'Vigente · vence 14 may 2026'
+  },
+  {
+    d:2,m:'ABR',dow:'jueves',doc:'Dra. Daniela Cruz',esp:'Nutrición',cons:'Consulta nutricional',
+    meds:[{n:'Suplemento B12 1000 mcg',p:'1 tableta al día (mañana)',dur:'60 días'},{n:'Hierro 60 mg',p:'1 tableta al día con cítrico',dur:'30 días'}],
+    ind:'Plan alimenticio entregado en consulta. Aumentar ingesta de hierro hemínico (carnes magras) y vegetales de hoja verde. Próxima cita: control de peso y hemoglobina en 30 días.',
+    vig:'Expira el 2 jun 2026'
+  },
+];
+
+function Recetas(){
+  return (
+    <>
+      <div className="section-head card" style={{marginBottom:14}}>
+        <div className="left">
+          <h2>Mis recetas</h2>
+          <div className="hint">Recetas emitidas por el servicio médico universitario. Solo lectura.</div>
+        </div>
+        <div style={{display:'flex',gap:10}}>
+          <button className="btn ghost sm">Imprimir todas</button>
+          <button className="btn secondary sm">Descargar PDF</button>
+        </div>
+      </div>
+      <div className="card">
+        {RECETAS.map((r,i)=>(
+          <div key={i} className="receta">
+            <div className="receta-row receta-head">
+              <div className="date">
+                <div className="d"><b>{String(r.d).padStart(2,'0')}</b><span>{r.m}</span></div>
+                <div className="meta"><b>{r.dow} 2026</b><span>Consulta: {r.cons}</span></div>
+              </div>
+              <div className="receta-doctor"><b>{r.doc}</b>{r.esp}</div>
+            </div>
+            <div className="receta-body">
+              <div className="receta-sec">
+                <h4>Medicamentos</h4>
+                <div className="med-list">
+                  {r.meds.map((m,j)=>(
+                    <div key={j} className="med">
+                      <div className="pill">℞</div>
+                      <div><b>{m.n}</b><span>{m.p} · {m.dur}</span></div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="receta-sec">
+                <h4>Indicaciones</h4>
+                <div className="ind">{r.ind}</div>
+              </div>
+            </div>
+            <div className="receta-foot">
+              <div className="left">
+                <span className={r.vig.startsWith('Vigente')?'vig':'exp'}>{r.vig}</span>
+                <span>Folio: REC-2026-{1240+i}</span>
+              </div>
+              <button className="btn ghost sm">Ver detalle →</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+const BITACORA=[
+  {d:28,m:'ABR',dow:'martes',hr:'09:00',motivo:'Faringitis aguda',meta:'Dr. Omar Salas · Consultorio 2',estado:'attended',label:'Atendida'},
+  {d:14,m:'ABR',dow:'martes',hr:'10:30',motivo:'Control general',meta:'Dr. Omar Salas · Consultorio 2',estado:'attended',label:'Atendida'},
+  {d:2,m:'ABR',dow:'jueves',hr:'13:20',motivo:'Consulta nutricional',meta:'Dra. Daniela Cruz · Consultorio 1',estado:'attended',label:'Atendida'},
+  {d:18,m:'MAR',dow:'miércoles',hr:'11:00',motivo:'Dolor de garganta',meta:'Dra. Daniela Cruz · Consultorio 1',estado:'noshow',label:'No asistió'},
+  {d:5,m:'MAR',dow:'jueves',hr:'08:30',motivo:'Revisión general',meta:'Dr. Omar Salas · Consultorio 2',estado:'attended',label:'Atendida'},
+  {d:22,m:'FEB',dow:'lunes',hr:'12:00',motivo:'Vacunación influenza',meta:'Enf. Marta Robles · Sala 3',estado:'cancel',label:'Cancelada'},
+  {d:8,m:'FEB',dow:'lunes',hr:'09:30',motivo:'Revisión asma',meta:'Dr. Omar Salas · Consultorio 2',estado:'attended',label:'Atendida'},
+];
+
+function Bitacora(){
+  return (
+    <>
+      <div className="filterbar">
+        <span className="lab">Filtrar</span>
+        <div className="ffld"><span className="ic">⌕</span><input placeholder="Buscar por motivo o doctor"/></div>
+        <div className="ffld"><span className="ic">⊞</span><input type="date" defaultValue="2026-02-01"/></div>
+        <div className="ffld"><span className="ic">→</span><input type="date" defaultValue="2026-04-30"/></div>
+        <div className="ffld"><select defaultValue=""><option value="">Todos los estatus</option><option>Atendida</option><option>Cancelada</option><option>No asistió</option></select></div>
+        <div className="spacer"/>
+        <button className="btn ghost sm">Limpiar</button>
+        <button className="btn secondary sm">Exportar</button>
+      </div>
+      <div className="card">
+        <div className="section-head" style={{borderBottom:'1px solid var(--border)'}}>
+          <div className="left"><h2>Bitácora de consultas</h2><div className="hint">Historial completo de citas pasadas. Solo lectura.</div></div>
+          <div style={{fontSize:12.5,color:'var(--text-muted)'}}><b style={{color:'var(--text)'}}>7</b> registros · feb – abr 2026</div>
+        </div>
+        <table>
+          <thead><tr>
+            <th style={{width:'24%'}}>Fecha</th>
+            <th style={{width:'9%'}}>Hora</th>
+            <th>Motivo</th>
+            <th style={{width:'14%'}}>Estatus</th>
+            <th style={{width:'10%',textAlign:'right'}}></th>
+          </tr></thead>
+          <tbody>
+            {BITACORA.map((c,i)=>(
+              <tr key={i}>
+                <td>
+                  <div className="date-cell">
+                    <div className="d"><b>{String(c.d).padStart(2,'0')}</b><span>{c.m}</span></div>
+                    <div className="dow"><b>{c.dow}</b><span>2026</span></div>
+                  </div>
+                </td>
+                <td className="hr">{c.hr}</td>
+                <td className="motivo"><b>{c.motivo}</b><span>{c.meta}</span></td>
+                <td><span className={'b '+c.estado}><span className="pulse"></span>{c.label}</span></td>
+                <td style={{textAlign:'right'}}><button className="btn ghost sm">Ver →</button></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function App({mode}){
+  const tab = mode==='rec'?'rec':mode==='bit'?'bit':'med';
+  const editing = mode==='medEdit';
+  const setTab = (t)=>{
+    // demo: jump to first state of that tab
+    document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));
+    if(t==='med'){document.getElementById('s1').classList.add('active');render('med');}
+    else if(t==='rec'){document.getElementById('s3').classList.add('active');render('rec');}
+    else if(t==='bit'){document.getElementById('s4').classList.add('active');render('bit');}
+  };
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <ProfileHeader tab={tab} setTab={setTab}/>
+        <div className="content">
+          {tab==='med' && !editing && <MedicaReadonly onEdit={()=>{document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));document.getElementById('s2').classList.add('active');render('medEdit');}}/>}
+          {tab==='med' && editing && <MedicaEdit
+            onCancel={()=>{document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));document.getElementById('s1').classList.add('active');render('med');}}
+            onSave={()=>{document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));document.getElementById('s1').classList.add('active');render('med');}}
+          />}
+          {tab==='rec' && <Recetas/>}
+          {tab==='bit' && <Bitacora/>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const root=ReactDOM.createRoot(document.getElementById('app'));
+function render(m){root.render(<App mode={m}/>);}
+document.getElementById('s1').onclick=()=>{setActive('s1');render('med');};
+document.getElementById('s2').onclick=()=>{setActive('s2');render('medEdit');};
+document.getElementById('s3').onclick=()=>{setActive('s3');render('rec');};
+document.getElementById('s4').onclick=()=>{setActive('s4');render('bit');};
+function setActive(id){document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));document.getElementById(id).classList.add('active');}
+render('med');
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Mis Citas.html
+++ b/frontend/design-reference-dark/Mis Citas.html
@@ -1,0 +1,377 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mis citas</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec;
+    --warn:#f59e0b; --warn-50:#fef3e0;
+    --danger:#dc2626; --danger-50:#fde8e8;
+    --info:#0369a1; --info-50:#e0f2fe;
+    --bg:#f7f9f8; --surface:#fff;
+    --border:#2d3144;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body,#app{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+  input,select{font-family:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  .sb{width:232px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;cursor:pointer}
+  .sb a:hover{background:rgba(255,255,255,.05)}
+  .sb a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb a .ic{font-size:14px;width:16px;text-align:center}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px;font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;display:flex;flex-direction:column}
+  .header{padding:32px 36px 0;background:#1a1d27;border-bottom:1px solid var(--border)}
+  .header .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:500;margin-bottom:6px}
+  .header h1{margin:0 0 4px;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .header .sub{font-size:13.5px;color:var(--text-muted);margin-bottom:18px}
+  .head-row{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:18px}
+
+  .tabs{display:flex;gap:0;border-bottom:1px solid transparent;margin-bottom:-1px}
+  .tabs button{padding:13px 4px;margin-right:24px;font-size:14px;font-weight:500;color:var(--text-muted);border-bottom:2px solid transparent;display:flex;align-items:center;gap:8px}
+  .tabs button .ct{background:var(--bg);color:var(--text-muted);padding:1px 8px;border-radius:999px;font-size:11.5px;font-weight:600}
+  .tabs button:hover{color:var(--text)}
+  .tabs button.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+  .tabs button.active .ct{background:var(--primary-50);color:var(--primary)}
+
+  .btn{padding:9px 14px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.secondary{background:#1a1d27;color:var(--primary);border:1px solid var(--primary)}
+  .btn.ghost{color:var(--text-muted)}
+  .btn.ghost:hover{background:var(--bg)}
+  .btn.danger-ghost{color:var(--danger);background:transparent;padding:6px 10px;font-size:12.5px;border-radius:6px}
+  .btn.danger-ghost:hover{background:var(--danger-50)}
+  .btn.sm{padding:6px 11px;font-size:12.5px}
+  .btn .plus{font-size:15px;font-weight:300;line-height:1}
+
+  .content{padding:24px 36px 60px;flex:1}
+
+  /* Filter bar */
+  .filters{display:flex;gap:10px;align-items:center;background:#1a1d27;border:1px solid var(--border);border-radius:10px;padding:12px 16px;margin-bottom:18px;flex-wrap:wrap}
+  .filters .lab{font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-right:4px}
+  .field{display:flex;align-items:center;gap:8px;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:7px 11px}
+  .field input,.field select{background:transparent;border:none;outline:none;font-size:13px;color:var(--text);min-width:120px}
+  .field .ic{color:var(--text-subtle);font-size:13px}
+  .search{flex:1;min-width:220px}
+  .filters .spacer{flex:1}
+  .filters .reset{font-size:12.5px;color:var(--text-muted);font-weight:500}
+  .filters .reset:hover{color:var(--primary)}
+
+  .card{background:#1a1d27;border:1px solid var(--border);border-radius:10px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04)}
+
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  th{text-align:left;padding:12px 22px;font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;background:var(--bg);border-bottom:1px solid var(--border)}
+  td{padding:14px 22px;border-bottom:1px solid var(--border);vertical-align:middle}
+  tr:last-child td{border-bottom:none}
+  tr:hover td{background:var(--bg)}
+  .date-cell{display:flex;align-items:center;gap:11px}
+  .date-cell .d{flex-shrink:0;width:42px;text-align:center;background:var(--primary-50);border-radius:7px;padding:6px 0;color:var(--primary)}
+  .date-cell.past .d{background:var(--bg);color:var(--text-subtle)}
+  .date-cell .d b{display:block;font-size:16px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums}
+  .date-cell .d span{display:block;font-size:9.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;margin-top:2px}
+  .date-cell .dow b{display:block;color:var(--text);font-size:13px;font-weight:500;text-transform:capitalize}
+  .date-cell .dow span{font-size:11.5px;color:var(--text-subtle)}
+  .hr{font-variant-numeric:tabular-nums;font-weight:600;color:var(--text)}
+  .motivo b{display:block;color:var(--text);font-weight:500;font-size:13.5px;margin-bottom:2px}
+  .motivo span{font-size:12px;color:var(--text-subtle)}
+  .b{display:inline-flex;padding:3px 10px;border-radius:999px;font-size:11.5px;font-weight:600;align-items:center;gap:5px}
+  .b.ok{background:var(--primary-50);color:var(--primary)}
+  .b.warn{background:var(--warn-50);color:var(--warn)}
+  .b.cancel{background:var(--danger-50);color:var(--danger)}
+  .b.noshow{background:#f1f5f9;color:#64748b}
+  .b.attended{background:var(--info-50);color:var(--info)}
+  .b .pulse{width:6px;height:6px;border-radius:50%;background:currentColor}
+
+  /* Pagination */
+  .pag{display:flex;justify-content:space-between;align-items:center;padding:14px 22px;border-top:1px solid var(--border);background:#1a1d27}
+  .pag .count{font-size:12.5px;color:var(--text-muted)}
+  .pag .count b{color:var(--text);font-weight:600}
+  .pag .pages{display:flex;gap:4px;align-items:center}
+  .pag button{width:32px;height:32px;border-radius:6px;font-size:13px;color:var(--text-muted);font-weight:500;display:flex;align-items:center;justify-content:center}
+  .pag button:hover{background:var(--bg);color:var(--text)}
+  .pag button.active{background:var(--primary);color:#fff}
+  .pag button:disabled{opacity:.4;cursor:not-allowed}
+
+  /* Empty state */
+  .empty{padding:64px 32px;text-align:center;background:#1a1d27;border:1px solid var(--border);border-radius:10px}
+  .empty .illust{width:120px;height:120px;margin:0 auto 18px;position:relative}
+  .empty h3{margin:0 0 6px;font-size:17px;font-weight:600}
+  .empty p{margin:0 auto 20px;font-size:13.5px;color:var(--text-muted);max-width:380px;line-height:1.55}
+
+  /* Toggle switcher (demo only) */
+  .switcher{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);z-index:200;background:#1a1d27;border:1px solid var(--border);border-radius:8px;padding:3px;display:flex;gap:1px;box-shadow:0 6px 16px rgba(26,92,58,.14)}
+  .switcher button{padding:7px 14px;border-radius:5px;font-size:12.5px;font-weight:500;color:var(--text-muted)}
+  .switcher button.active{background:var(--primary);color:#fff}
+</style>
+</head>
+<body>
+<div id="app"></div>
+<div class="switcher">
+  <button id="m1" class="active">Próximas</button>
+  <button id="m2">Pasadas</button>
+  <button id="m3">Canceladas</button>
+  <button id="m4">Vacío</button>
+</div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+const {useState}=React;
+
+function Sidebar(){
+  const items=[['inicio','Inicio','▦'],['citas','Mis citas','⊞',true],['ia','Pre-evaluación IA','◔'],['rec','Recetas','℞'],['perf','Mi perfil','◉']];
+  return (
+    <aside className="sb">
+      <div className="brand"><div className="y">Y</div><div><b>Yoltec</b><span>Servicio médico</span></div></div>
+      <nav>{items.map(([k,l,i,a])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}</a>))}</nav>
+      <div className="user"><div className="av">AP</div><div><b>Ana Pérez García</b><span>22690495</span></div></div>
+    </aside>
+  );
+}
+
+const PROX=[
+  {d:13,m:'MAY',dow:'miércoles',yr:2026,hr:'10:30',motivo:'Control de presión',meta:'Dr. Omar Salas · Consultorio 2',estado:'ok',label:'Confirmada'},
+  {d:18,m:'MAY',dow:'lunes',yr:2026,hr:'09:15',motivo:'Revisión nutricional',meta:'Dra. Daniela Cruz · Consultorio 1',estado:'warn',label:'Pendiente'},
+  {d:25,m:'MAY',dow:'lunes',yr:2026,hr:'13:00',motivo:'Seguimiento migraña',meta:'Dr. Omar Salas · Consultorio 2',estado:'ok',label:'Confirmada'},
+  {d:2,m:'JUN',dow:'martes',yr:2026,hr:'11:00',motivo:'Vacunación influenza',meta:'Enf. Marta Robles · Sala 3',estado:'warn',label:'Pendiente'},
+];
+const PASADAS=[
+  {d:28,m:'ABR',dow:'martes',yr:2026,hr:'09:00',motivo:'Dolor de garganta',meta:'Dr. Omar Salas',diag:'Faringitis aguda',estado:'attended',label:'Atendida'},
+  {d:14,m:'ABR',dow:'martes',yr:2026,hr:'10:30',motivo:'Control general',meta:'Dr. Omar Salas',diag:'Sin hallazgos significativos',estado:'attended',label:'Atendida'},
+  {d:5,m:'MAR',dow:'jueves',yr:2026,hr:'08:30',motivo:'Revisión general',meta:'Dr. Omar Salas',diag:'',estado:'attended',label:'Atendida'},
+  {d:18,m:'FEB',dow:'miércoles',yr:2026,hr:'11:00',motivo:'Consulta nutricional',meta:'Dra. Daniela Cruz',diag:'Plan alimenticio entregado',estado:'attended',label:'Atendida'},
+];
+const CANCEL=[
+  {d:2,m:'ABR',dow:'jueves',yr:2026,hr:'13:20',motivo:'Consulta nutricional',meta:'Cancelada por el alumno',estado:'cancel',label:'Cancelada'},
+  {d:18,m:'MAR',dow:'miércoles',yr:2026,hr:'11:00',motivo:'Dolor de garganta',meta:'Dra. Daniela Cruz',estado:'noshow',label:'No asistió'},
+  {d:12,m:'MAR',dow:'jueves',yr:2026,hr:'09:15',motivo:'Vacunación',meta:'Cancelada por el doctor',estado:'cancel',label:'Cancelada'},
+];
+
+function Filters({mode}){
+  const isPast = mode==='past' || mode==='cancel';
+  return (
+    <div className="filters">
+      <span className="lab">Filtrar</span>
+      <div className="field"><span className="ic">⌕</span><input placeholder="Buscar por motivo o doctor"/></div>
+      <div className="field"><span className="ic">⊞</span><input type="date" defaultValue={isPast?'2026-02-01':'2026-05-11'}/></div>
+      <div className="field"><span className="ic">→</span><input type="date" defaultValue={isPast?'2026-04-30':'2026-06-30'}/></div>
+      {mode==='cancel' && (
+        <div className="field"><select defaultValue=""><option value="">Todos los estatus</option><option>Cancelada</option><option>No asistió</option></select></div>
+      )}
+      <div className="spacer"/>
+      <button className="btn ghost reset">Limpiar</button>
+    </div>
+  );
+}
+
+function Empty(){
+  return (
+    <div className="empty">
+      <div className="illust">
+        <svg viewBox="0 0 120 120" width="120" height="120">
+          <rect x="14" y="22" width="92" height="84" rx="10" fill="#e8f1ec" stroke="#1a5c3a" strokeWidth="2"/>
+          <rect x="14" y="22" width="92" height="20" rx="10" fill="#1a5c3a"/>
+          <rect x="14" y="34" width="92" height="8" fill="#1a5c3a"/>
+          <circle cx="34" cy="20" r="6" fill="#fff" stroke="#1a5c3a" strokeWidth="2"/>
+          <circle cx="86" cy="20" r="6" fill="#fff" stroke="#1a5c3a" strokeWidth="2"/>
+          <rect x="28" y="14" width="12" height="14" rx="3" fill="#1a5c3a"/>
+          <rect x="80" y="14" width="12" height="14" rx="3" fill="#1a5c3a"/>
+          <line x1="30" y1="58" x2="90" y2="58" stroke="#cdd9d3" strokeWidth="2" strokeLinecap="round"/>
+          <line x1="30" y1="72" x2="74" y2="72" stroke="#cdd9d3" strokeWidth="2" strokeLinecap="round"/>
+          <line x1="30" y1="86" x2="82" y2="86" stroke="#cdd9d3" strokeWidth="2" strokeLinecap="round"/>
+          <circle cx="92" cy="92" r="14" fill="#1a5c3a"/>
+          <path d="M92 86v12M86 92h12" stroke="#fff" strokeWidth="2.5" strokeLinecap="round"/>
+        </svg>
+      </div>
+      <h3>No tienes citas próximas</h3>
+      <p>Cuando agendes una consulta en el servicio médico aparecerá aquí con su fecha, hora y motivo.</p>
+      <button className="btn primary"><span className="plus">＋</span>Agendar cita</button>
+    </div>
+  );
+}
+
+function Row({c,past}){
+  return (
+    <tr>
+      <td>
+        <div className={'date-cell'+(past?' past':'')}>
+          <div className="d"><b>{String(c.d).padStart(2,'0')}</b><span>{c.m}</span></div>
+          <div className="dow"><b>{c.dow}</b><span>{c.yr}</span></div>
+        </div>
+      </td>
+      <td className="hr">{c.hr}</td>
+      <td className="motivo">
+        <b>{c.motivo}</b>
+        <span>{c.meta}</span>
+        {c.diag && <span style={{display:'block',color:'#7b8f86',fontSize:'11.5px',marginTop:'3px'}}>Diagnóstico: {c.diag}</span>}
+      </td>
+      <td><span className={'b '+c.estado}><span className="pulse"></span>{c.label}</span></td>
+      <td style={{textAlign:'right'}}>
+        {past
+          ? <button className="btn ghost sm">Ver detalle</button>
+          : <button className="btn danger-ghost">Cancelar</button>}
+      </td>
+    </tr>
+  );
+}
+
+function Pag({total}){
+  return (
+    <div className="pag">
+      <div className="count">Mostrando <b>1–{total}</b> de <b>{total}</b> citas</div>
+      <div className="pages">
+        <button disabled>‹</button>
+        <button className="active">1</button>
+        <button>2</button>
+        <button>3</button>
+        <button>›</button>
+      </div>
+    </div>
+  );
+}
+
+function App({mode}){
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <div className="header">
+          <div className="head-row">
+            <div>
+              <div className="crumb">Servicio médico · Citas</div>
+              <h1>Mis citas</h1>
+              <div className="sub">Consulta tus citas agendadas y tu historial de consultas pasadas.</div>
+            </div>
+            <div style={{display:'flex',gap:10,marginTop:6}}>
+              <button className="btn secondary">Exportar historial</button>
+              <button className="btn primary"><span className="plus">＋</span>Nueva cita</button>
+            </div>
+          </div>
+          <div className="tabs">
+            <button className={mode==='prox'||mode==='empty'?'active':''}>Próximas <span className="ct">{mode==='empty'?0:PROX.length}</span></button>
+            <button className={mode==='past'?'active':''}>Pasadas <span className="ct">{PASADAS.length}</span></button>
+            <button className={mode==='cancel'?'active':''}>Canceladas <span className="ct">{CANCEL.length}</span></button>
+          </div>
+        </div>
+
+        <div className="content">
+          {mode==='empty' ? (
+            <>
+              <Filters mode="prox"/>
+              <Empty/>
+            </>
+          ) : mode==='past' ? (
+            <>
+              <Filters mode="past"/>
+              <div className="card">
+                <table>
+                  <thead><tr>
+                    <th style={{width:'26%'}}>Fecha</th>
+                    <th style={{width:'10%'}}>Hora</th>
+                    <th>Motivo</th>
+                    <th style={{width:'14%'}}>Estatus</th>
+                    <th style={{width:'14%',textAlign:'right'}}></th>
+                  </tr></thead>
+                  <tbody>{PASADAS.map((c,i)=><Row key={i} c={c} past/>)}</tbody>
+                </table>
+                <Pag total={PASADAS.length}/>
+              </div>
+            </>
+          ) : mode==='cancel' ? (
+            <>
+              <Filters mode="cancel"/>
+              <div className="card">
+                <table>
+                  <thead><tr>
+                    <th style={{width:'26%'}}>Fecha</th>
+                    <th style={{width:'10%'}}>Hora</th>
+                    <th>Motivo</th>
+                    <th style={{width:'14%'}}>Estatus</th>
+                    <th style={{width:'14%',textAlign:'right'}}></th>
+                  </tr></thead>
+                  <tbody>{CANCEL.map((c,i)=><Row key={i} c={c} past/>)}</tbody>
+                </table>
+                <Pag total={CANCEL.length}/>
+              </div>
+            </>
+          ) : (
+            <>
+              <Filters mode="prox"/>
+              <div className="card">
+                <table>
+                  <thead><tr>
+                    <th style={{width:'26%'}}>Fecha</th>
+                    <th style={{width:'10%'}}>Hora</th>
+                    <th>Motivo</th>
+                    <th style={{width:'14%'}}>Estatus</th>
+                    <th style={{width:'14%',textAlign:'right'}}></th>
+                  </tr></thead>
+                  <tbody>{PROX.map((c,i)=><Row key={i} c={c}/>)}</tbody>
+                </table>
+                <Pag total={PROX.length}/>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+let mode='prox';
+const root=ReactDOM.createRoot(document.getElementById('app'));
+const render=()=>root.render(<App mode={mode}/>);
+const setMode=(m,btn)=>{mode=m;document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));btn.classList.add('active');render();};
+document.getElementById('m1').onclick=e=>setMode('prox',e.currentTarget);
+document.getElementById('m2').onclick=e=>setMode('past',e.currentTarget);
+document.getElementById('m3').onclick=e=>setMode('cancel',e.currentTarget);
+document.getElementById('m4').onclick=e=>setMode('empty',e.currentTarget);
+render();
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Nueva Cita Doctor.html
+++ b/frontend/design-reference-dark/Nueva Cita Doctor.html
@@ -1,0 +1,424 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Nueva cita (Doctor)</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec; --primary-100:#d1e3d8;
+    --warn:#f59e0b; --warn-50:#fef3e0;
+    --danger:#dc2626; --danger-50:#fde8e8;
+    --bg:#f7f9f8; --surface:#fff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+    --soft:#f9fafb;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg);display:flex;align-items:center;justify-content:center;gap:32px;padding:40px;flex-wrap:wrap}
+
+  .frame-label{position:absolute;top:-26px;left:0;right:0;text-align:center;color:var(--text-subtle);font:600 11px 'Inter',sans-serif;letter-spacing:.5px;text-transform:uppercase}
+
+  /* Modal */
+  .modal-wrap{position:relative;width:560px;background:#1a1d27;border-radius:14px;box-shadow:0 28px 80px rgba(20,40,30,.18),0 2px 8px rgba(20,40,30,.04);overflow:hidden;display:flex;flex-direction:column;max-height:780px}
+
+  .mh{padding:22px 24px 0;border-bottom:1px solid var(--border)}
+  .mh-top{display:flex;justify-content:space-between;align-items:flex-start}
+  .mh h2{margin:0 0 4px;font-size:18px;font-weight:700;letter-spacing:-.3px}
+  .mh .sub{font-size:12.5px;color:var(--text-muted);margin-bottom:18px}
+  .close{width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;color:var(--text-subtle);background:none;border:0;cursor:pointer;font-size:18px}
+  .close:hover{background:var(--soft);color:var(--text)}
+
+  /* Stepper */
+  .steps{display:flex;gap:6px;padding-bottom:14px;margin-top:4px}
+  .step{flex:1;display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-subtle);font-weight:500}
+  .step .n{width:22px;height:22px;border-radius:50%;background:var(--soft);color:var(--text-subtle);font-size:11.5px;font-weight:700;display:flex;align-items:center;justify-content:center;border:1px solid var(--border)}
+  .step.active{color:var(--primary);font-weight:600}
+  .step.active .n{background:var(--primary);color:#fff;border-color:var(--primary)}
+  .step.done{color:var(--text)}
+  .step.done .n{background:var(--primary-50);color:var(--primary);border-color:var(--primary-100)}
+  .step .arrow{margin:0 4px;color:var(--text-subtle);font-size:13px}
+
+  .mb{padding:20px 24px;flex:1;overflow-y:auto;min-height:0}
+
+  /* Step 1: alumno */
+  .search-field{position:relative;margin-bottom:14px}
+  .search-field svg{position:absolute;left:13px;top:50%;transform:translateY(-50%);color:var(--text-subtle)}
+  .search-field input{width:100%;height:42px;background:var(--soft);border:1px solid var(--border);border-radius:9px;padding:0 14px 0 40px;font:500 13.5px 'Inter',sans-serif;color:var(--text);outline:none}
+  .search-field input:focus{border-color:var(--primary);background:#1a1d27;box-shadow:0 0 0 3px var(--primary-50)}
+  .search-field input::placeholder{color:var(--text-subtle);font-weight:400}
+
+  .list-label{font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin:14px 2px 6px;display:flex;justify-content:space-between;align-items:center}
+  .list-label span:last-child{color:var(--text-subtle);font-weight:500;text-transform:none;letter-spacing:0;font-size:11.5px}
+
+  .student-list{display:flex;flex-direction:column;gap:4px}
+  .student{display:flex;align-items:center;gap:12px;padding:10px 12px;border-radius:9px;cursor:pointer;border:1px solid transparent}
+  .student:hover{background:var(--soft);border-color:var(--border)}
+  .student.sel{background:var(--primary-50);border-color:var(--primary-100)}
+  .av{width:38px;height:38px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px;flex-shrink:0;letter-spacing:.3px}
+  .student .who{flex:1;min-width:0}
+  .student .who b{display:block;font-size:13.5px;font-weight:600;color:var(--text);letter-spacing:-.1px}
+  .student .who span{display:block;font-size:11.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums;margin-top:1px}
+  .student .who span em{font-style:normal;color:var(--text-muted)}
+  .student .meta{font-size:11.5px;color:var(--text-subtle)}
+  .student .ck{width:18px;height:18px;border-radius:50%;border:1.5px solid var(--border-strong);flex-shrink:0;display:flex;align-items:center;justify-content:center;color:#fff}
+  .student.sel .ck{background:var(--primary);border-color:var(--primary)}
+
+  /* Step 2: calendar */
+  .selected-student{display:flex;align-items:center;gap:10px;padding:10px 12px;background:var(--primary-50);border-radius:9px;margin-bottom:16px}
+  .selected-student .who{flex:1;min-width:0}
+  .selected-student .who b{display:block;font-size:13.5px;font-weight:600;color:var(--text)}
+  .selected-student .who span{font-size:11.5px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  .selected-student .av{width:32px;height:32px;font-size:11.5px}
+  .selected-student .change{font-size:12px;color:var(--primary);font-weight:600;background:none;border:0;cursor:pointer}
+
+  .cal-nav{display:flex;align-items:center;justify-content:space-between;padding:0 4px 10px}
+  .cal-nav b{font-size:14px;font-weight:600;text-transform:capitalize}
+  .cal-nav button{width:28px;height:28px;border-radius:6px;border:1px solid var(--border);background:#1a1d27;color:var(--text-muted);font-size:14px}
+  .cal-nav button:hover{border-color:var(--primary);color:var(--primary)}
+
+  .cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:4px}
+  .cal-dow{font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-align:center;text-transform:uppercase;padding:6px 0}
+  .day{aspect-ratio:1;border-radius:7px;display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:12px;font-weight:500;color:var(--text);cursor:pointer;border:1px solid transparent}
+  .day .num{font-size:13.5px;font-weight:600}
+  .day .sub{font-size:9px;font-weight:600;color:var(--primary);margin-top:1px}
+  .day.past{color:var(--text-subtle);cursor:default}
+  .day.past .sub{display:none}
+  .day:hover:not(.past):not(.sel){background:var(--soft)}
+  .day.full{background:var(--danger-50);color:var(--danger);cursor:not-allowed}
+  .day.full .sub{color:var(--danger)}
+  .day.low .sub{color:var(--warn)}
+  .day.sel{background:var(--primary);color:#fff}
+  .day.sel .sub{color:#fff}
+
+  .slot-section{margin-top:18px}
+  .slot-section .lbl{font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin-bottom:10px}
+  .slots{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+  .slot{padding:9px 6px;border:1px solid var(--border);border-radius:7px;background:#1a1d27;font-size:12.5px;font-weight:600;text-align:center;cursor:pointer;color:var(--text);font-variant-numeric:tabular-nums}
+  .slot:hover{border-color:var(--primary);color:var(--primary)}
+  .slot.sel{background:var(--primary);color:#fff;border-color:var(--primary)}
+  .slot.taken{background:var(--soft);color:var(--text-subtle);cursor:not-allowed;text-decoration:line-through}
+  .slot.taken:hover{border-color:var(--border);color:var(--text-subtle)}
+
+  /* Step 3 */
+  .summary{display:flex;flex-direction:column;gap:0;background:var(--soft);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+  .summary .r{display:flex;justify-content:space-between;align-items:center;padding:14px 16px;border-bottom:1px solid var(--border);font-size:13px}
+  .summary .r:last-child{border-bottom:0}
+  .summary .r .k{color:var(--text-subtle);font-weight:500;font-size:12px;text-transform:uppercase;letter-spacing:.4px}
+  .summary .r .v{color:var(--text);font-weight:600;font-variant-numeric:tabular-nums}
+  .summary .r.student-r{padding:14px 16px}
+  .summary .student-r .who{display:flex;align-items:center;gap:10px}
+  .summary .student-r .who b{font-size:13.5px;font-weight:600;display:block}
+  .summary .student-r .who span{font-size:11.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums}
+
+  .form-row{margin-top:16px}
+  .form-row label{display:block;font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin-bottom:6px}
+  .form-row textarea{width:100%;min-height:78px;background:#1a1d27;border:1px solid var(--border);border-radius:9px;padding:11px 13px;font:400 13px 'Inter',sans-serif;color:var(--text);outline:none;resize:vertical}
+  .form-row textarea:focus{border-color:var(--primary);box-shadow:0 0 0 3px var(--primary-50)}
+  .form-row .hint{font-size:11.5px;color:var(--text-subtle);margin-top:5px}
+
+  /* Footer */
+  .mf{padding:14px 24px;border-top:1px solid var(--border);background:var(--soft);display:flex;justify-content:space-between;align-items:center;gap:10px}
+  .mf .left{font-size:11.5px;color:var(--text-subtle)}
+  .mf .actions{display:flex;gap:8px}
+  .btn{padding:9px 16px;border-radius:7px;font:600 13px 'Inter',sans-serif;cursor:pointer;display:inline-flex;align-items:center;gap:6px;border:1px solid transparent;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.primary:disabled{background:var(--border-strong);cursor:not-allowed}
+  .btn.ghost{color:var(--text-muted);background:transparent}
+  .btn.ghost:hover{background:#1a1d27;color:var(--text)}
+  .btn.outline{background:#1a1d27;color:var(--primary);border-color:var(--primary)}
+  .btn.outline:hover{background:var(--primary-50)}
+</style>
+</head>
+<body>
+
+<!-- STEP 1 -->
+<div class="modal-wrap">
+  <div class="frame-label">Paso 1 · Seleccionar alumno</div>
+  <div class="mh">
+    <div class="mh-top">
+      <div>
+        <h2>Nueva cita</h2>
+        <div class="sub">¿Para qué alumno?</div>
+      </div>
+      <button class="close">×</button>
+    </div>
+    <div class="steps">
+      <div class="step active">
+        <div class="n">1</div>Alumno
+      </div>
+      <div class="arrow" style="color:#7b8f86;display:flex;align-items:center">›</div>
+      <div class="step">
+        <div class="n">2</div>Fecha y hora
+      </div>
+      <div class="arrow" style="color:#7b8f86;display:flex;align-items:center">›</div>
+      <div class="step">
+        <div class="n">3</div>Confirmar
+      </div>
+    </div>
+  </div>
+
+  <div class="mb">
+    <div class="search-field">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+      <input placeholder="Nombre o número de control" value="cas">
+    </div>
+
+    <div class="list-label">
+      <span>Resultados</span>
+      <span>3 coincidencias</span>
+    </div>
+    <div class="student-list">
+      <div class="student sel">
+        <div class="av">NC</div>
+        <div class="who">
+          <b>Nestor <em>Cas</em>tillo</b>
+          <span>22690495 · Ing. Sistemas</span>
+        </div>
+        <div class="meta">Última cita: 14 abr</div>
+        <div class="ck">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7"/></svg>
+        </div>
+      </div>
+      <div class="student">
+        <div class="av">DC</div>
+        <div class="who">
+          <b>Daniela <em>Cas</em>tro Ríos</b>
+          <span>23104822 · Ing. Industrial</span>
+        </div>
+        <div class="meta">Última cita: 28 mar</div>
+        <div class="ck"></div>
+      </div>
+      <div class="student">
+        <div class="av">JC</div>
+        <div class="who">
+          <b>Javier <em>Cas</em>anova López</b>
+          <span>21778302 · Lic. Administración</span>
+        </div>
+        <div class="meta">Sin citas previas</div>
+        <div class="ck"></div>
+      </div>
+    </div>
+
+    <div class="list-label" style="margin-top:18px">
+      <span>Recientes</span>
+    </div>
+    <div class="student-list">
+      <div class="student">
+        <div class="av">AP</div>
+        <div class="who">
+          <b>Ana Pérez García</b>
+          <span>22501133 · Ing. Mecatrónica</span>
+        </div>
+        <div class="meta">Hace 2 días</div>
+        <div class="ck"></div>
+      </div>
+      <div class="student">
+        <div class="av">LM</div>
+        <div class="who">
+          <b>Luis Mora Hernández</b>
+          <span>22301844 · Ing. Civil</span>
+        </div>
+        <div class="meta">Hace 5 días</div>
+        <div class="ck"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mf">
+    <div class="left">Selecciona un alumno para continuar</div>
+    <div class="actions">
+      <button class="btn ghost">Cancelar</button>
+      <button class="btn primary">Continuar ›</button>
+    </div>
+  </div>
+</div>
+
+<!-- STEP 2 -->
+<div class="modal-wrap">
+  <div class="frame-label">Paso 2 · Fecha y hora</div>
+  <div class="mh">
+    <div class="mh-top">
+      <div>
+        <h2>Nueva cita</h2>
+        <div class="sub">Selecciona fecha y horario disponible</div>
+      </div>
+      <button class="close">×</button>
+    </div>
+    <div class="steps">
+      <div class="step done"><div class="n">1</div>Alumno</div>
+      <div class="arrow" style="display:flex;align-items:center">›</div>
+      <div class="step active"><div class="n">2</div>Fecha y hora</div>
+      <div class="arrow" style="display:flex;align-items:center">›</div>
+      <div class="step"><div class="n">3</div>Confirmar</div>
+    </div>
+  </div>
+
+  <div class="mb">
+    <div class="selected-student">
+      <div class="av">NC</div>
+      <div class="who">
+        <b>Nestor Castillo</b>
+        <span>22690495 · Ing. Sistemas</span>
+      </div>
+      <button class="change">Cambiar</button>
+    </div>
+
+    <div class="cal-nav">
+      <button>‹</button>
+      <b>Mayo 2026</b>
+      <button>›</button>
+    </div>
+
+    <div class="cal-grid">
+      <div class="cal-dow">L</div><div class="cal-dow">M</div><div class="cal-dow">X</div><div class="cal-dow">J</div><div class="cal-dow">V</div><div class="cal-dow">S</div><div class="cal-dow">D</div>
+
+      <div class="day past"><span class="num">28</span></div>
+      <div class="day past"><span class="num">29</span></div>
+      <div class="day past"><span class="num">30</span></div>
+      <div class="day"><span class="num">1</span><span class="sub">8 disp</span></div>
+      <div class="day"><span class="num">2</span></div>
+      <div class="day"><span class="num">3</span></div>
+      <div class="day low"><span class="num">4</span><span class="sub">3 disp</span></div>
+
+      <div class="day"><span class="num">5</span><span class="sub">7 disp</span></div>
+      <div class="day low"><span class="num">6</span><span class="sub">2 disp</span></div>
+      <div class="day"><span class="num">7</span><span class="sub">5 disp</span></div>
+      <div class="day full"><span class="num">8</span><span class="sub">Lleno</span></div>
+      <div class="day"><span class="num">9</span></div>
+      <div class="day"><span class="num">10</span></div>
+      <div class="day"><span class="num">11</span><span class="sub">6 disp</span></div>
+
+      <div class="day"><span class="num">12</span><span class="sub">8 disp</span></div>
+      <div class="day sel"><span class="num">13</span><span class="sub">5 disp</span></div>
+      <div class="day"><span class="num">14</span><span class="sub">4 disp</span></div>
+      <div class="day low"><span class="num">15</span><span class="sub">1 disp</span></div>
+      <div class="day"><span class="num">16</span></div>
+      <div class="day"><span class="num">17</span></div>
+      <div class="day"><span class="num">18</span><span class="sub">7 disp</span></div>
+    </div>
+
+    <div class="slot-section">
+      <div class="lbl">Horarios — Mié 13 mayo</div>
+      <div class="slots">
+        <div class="slot">08:00</div>
+        <div class="slot taken">08:15</div>
+        <div class="slot">08:30</div>
+        <div class="slot">08:45</div>
+        <div class="slot sel">09:00</div>
+        <div class="slot taken">09:15</div>
+        <div class="slot">09:30</div>
+        <div class="slot taken">09:45</div>
+        <div class="slot">10:00</div>
+        <div class="slot">10:15</div>
+        <div class="slot">10:30</div>
+        <div class="slot">10:45</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mf">
+    <div class="left">Mié 13 mayo · 09:00 – 09:15</div>
+    <div class="actions">
+      <button class="btn ghost">‹ Atrás</button>
+      <button class="btn primary">Continuar ›</button>
+    </div>
+  </div>
+</div>
+
+<!-- STEP 3 -->
+<div class="modal-wrap">
+  <div class="frame-label">Paso 3 · Confirmar</div>
+  <div class="mh">
+    <div class="mh-top">
+      <div>
+        <h2>Nueva cita</h2>
+        <div class="sub">Revisa los datos antes de confirmar</div>
+      </div>
+      <button class="close">×</button>
+    </div>
+    <div class="steps">
+      <div class="step done"><div class="n">1</div>Alumno</div>
+      <div class="arrow" style="display:flex;align-items:center">›</div>
+      <div class="step done"><div class="n">2</div>Fecha y hora</div>
+      <div class="arrow" style="display:flex;align-items:center">›</div>
+      <div class="step active"><div class="n">3</div>Confirmar</div>
+    </div>
+  </div>
+
+  <div class="mb">
+    <div class="summary">
+      <div class="r student-r">
+        <span class="k">Alumno</span>
+        <div class="who" style="display:flex;align-items:center;gap:10px">
+          <div class="av" style="width:32px;height:32px;font-size:11.5px">NC</div>
+          <div>
+            <b>Nestor Castillo</b>
+            <span>22690495 · Ing. Sistemas</span>
+          </div>
+        </div>
+      </div>
+      <div class="r">
+        <span class="k">Fecha</span>
+        <span class="v">Miércoles, 13 de mayo 2026</span>
+      </div>
+      <div class="r">
+        <span class="k">Hora</span>
+        <span class="v">09:00 – 09:15 hrs</span>
+      </div>
+      <div class="r">
+        <span class="k">Consultorio</span>
+        <span class="v">Consultorio 2</span>
+      </div>
+    </div>
+
+    <div class="form-row">
+      <label>Motivo de la cita</label>
+      <textarea placeholder="Ej. Control de presión, seguimiento de tratamiento, revisión general..."></textarea>
+      <div class="hint">El alumno verá este motivo en su agenda.</div>
+    </div>
+
+    <div class="form-row">
+      <label>Notas internas (opcional)</label>
+      <textarea placeholder="Notas visibles solo para personal médico"></textarea>
+    </div>
+  </div>
+
+  <div class="mf">
+    <div class="left">Se enviará notificación al alumno</div>
+    <div class="actions">
+      <button class="btn ghost">‹ Atrás</button>
+      <button class="btn primary">Confirmar cita</button>
+    </div>
+  </div>
+</div>
+
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Panel Admin.html
+++ b/frontend/design-reference-dark/Panel Admin.html
@@ -1,0 +1,312 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec Admin · Panel</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-300:#3a7d5c; --primary-50:#e8f5ee;
+    --bg:#f8fafc; --surface:#fff;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#eef2f0;
+    --blue-bg:#dbeafe; --blue:#1d4ed8;
+    --danger:#dc2626; --danger-bg:#fef2f2;
+    --gray-dark:#374151; --gray-dark-bg:#2d3144;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar */
+  .side{width:220px;background:var(--primary);color:#fff;display:flex;flex-direction:column;flex-shrink:0;padding:22px 0}
+  .side .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;letter-spacing:-.2px}
+  .side .brand .y{width:28px;height:28px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .side nav{display:flex;flex-direction:column;gap:2px;padding:0 12px;flex:1}
+  .side nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;text-decoration:none;cursor:pointer}
+  .side nav a svg{width:18px;height:18px;stroke-width:1.8;flex-shrink:0;opacity:.9}
+  .side nav a:hover{background:rgba(255,255,255,.06);color:#fff}
+  .side nav a.active{background:var(--primary-300);color:#fff;font-weight:600}
+  .side .user{padding:14px 16px;border-top:1px solid rgba(255,255,255,.12);margin:12px 12px 0;display:flex;align-items:center;gap:10px}
+  .side .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .side .user .nm{font-size:13px;font-weight:600;color:#fff;line-height:1.2}
+  .side .user .rl{font-size:11px;color:rgba(255,255,255,.65);margin-top:2px}
+
+  /* Main */
+  .main{flex:1;padding:28px 32px 48px;min-width:0}
+  .hd{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:24px}
+  .hd h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .hd .dt{font-size:13px;color:var(--text-muted);text-transform:capitalize;font-weight:500}
+
+  /* Stat row */
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:28px}
+  .stat{background:#1a1d27;border-radius:12px;padding:18px 20px;box-shadow:0 1px 2px rgba(15,23,42,.04);border:1px solid var(--border-soft)}
+  .stat .l{font-size:12px;font-weight:500;color:var(--text-muted);letter-spacing:.1px}
+  .stat .v{font-size:28px;font-weight:700;margin-top:8px;letter-spacing:-.6px;line-height:1}
+  .stat .sub{font-size:12px;color:var(--text-subtle);margin-top:6px;font-weight:500}
+
+  /* Section card */
+  .sec{background:#1a1d27;border-radius:12px;border:1px solid var(--border-soft);box-shadow:0 1px 2px rgba(15,23,42,.04);margin-bottom:20px}
+  .sec-hd{display:flex;align-items:center;justify-content:space-between;padding:16px 20px;border-bottom:1px solid var(--border-soft)}
+  .sec-hd h2{margin:0;font-size:15px;font-weight:600;letter-spacing:-.2px}
+  .sec-hd .sub{font-size:12px;color:var(--text-muted);margin-top:2px;font-weight:500}
+  .btn-pri{display:inline-flex;align-items:center;gap:6px;background:var(--primary);color:#fff;font:600 12.5px 'Inter',sans-serif;padding:8px 14px;border:0;border-radius:7px;cursor:pointer}
+  .btn-pri:hover{background:var(--primary-600)}
+  .btn-out{display:inline-flex;align-items:center;gap:6px;background:#1a1d27;color:var(--primary);font:600 12.5px 'Inter',sans-serif;padding:7px 14px;border:1px solid var(--primary);border-radius:7px;cursor:pointer}
+  .btn-out:hover{background:var(--primary-50)}
+
+  /* Table */
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  th{text-align:left;padding:11px 20px;font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.4px;text-transform:uppercase;background:#fafbfb;border-bottom:1px solid var(--border-soft)}
+  td{padding:13px 20px;border-bottom:1px solid var(--border-soft);vertical-align:middle}
+  tr:last-child td{border-bottom:0}
+  .uc{display:flex;align-items:center;gap:10px}
+  .uc .av{width:30px;height:30px;border-radius:50%;background:#2d3144;color:#374151;display:flex;align-items:center;justify-content:center;font-weight:600;font-size:11.5px}
+  .uc .nm{font-weight:600;color:var(--text);font-size:13px}
+  .em{color:var(--text-muted);font-size:12.5px}
+  .bd{display:inline-flex;font-size:11px;font-weight:600;padding:3px 8px;border-radius:5px;letter-spacing:.2px}
+  .bd-al{background:var(--blue-bg);color:var(--blue)}
+  .bd-dc{background:var(--primary-50);color:var(--primary)}
+  .bd-ad{background:var(--gray-dark-bg);color:var(--gray-dark)}
+  .bd-ac{background:var(--primary-50);color:var(--primary)}
+  .bd-su{background:var(--danger-bg);color:var(--danger)}
+  .ls{font-size:12.5px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  .acts{display:flex;gap:14px}
+  .acts a{font-size:12.5px;font-weight:500;color:var(--primary);cursor:pointer;text-decoration:none}
+  .acts a.warn{color:var(--danger)}
+  .acts a:hover{text-decoration:underline}
+
+  /* Days list */
+  .days{padding:6px 0}
+  .day{display:grid;grid-template-columns:96px 1fr auto;align-items:center;gap:16px;padding:12px 20px;border-bottom:1px solid var(--border-soft)}
+  .day:last-child{border-bottom:0}
+  .day .dn{font-size:13px;font-weight:700;color:var(--text);letter-spacing:-.2px;font-variant-numeric:tabular-nums}
+  .day .dn .mo{font-size:11px;font-weight:500;color:var(--text-muted);text-transform:uppercase;display:block;letter-spacing:.4px;margin-top:1px}
+  .day .nm{font-size:13.5px;font-weight:500;color:var(--text)}
+  .day .ty{font-size:11.5px;font-weight:600;padding:3px 9px;border-radius:5px}
+  .ty-f{background:#fef3c7;color:#92400e}
+  .ty-r{background:#dbeafe;color:#1d4ed8}
+  .ty-v{background:var(--primary-50);color:var(--primary)}
+  .sec-ft{padding:14px 20px;border-top:1px solid var(--border-soft);display:flex;justify-content:flex-end}
+
+  /* Audit */
+  .audit{padding:4px 0}
+  .ar{display:grid;grid-template-columns:140px 180px 1fr;gap:16px;padding:11px 20px;border-bottom:1px solid var(--border-soft);font-size:13px;align-items:center}
+  .ar:last-child{border-bottom:0}
+  .ts{font-size:12px;color:var(--text-muted);font-variant-numeric:tabular-nums;font-weight:500}
+  .au{font-weight:600;color:var(--text);font-size:12.5px}
+  .au .role{font-size:11px;font-weight:500;color:var(--text-muted);display:block;margin-top:1px}
+  .act{font-size:12.5px;color:var(--text)}
+  .act .em{color:var(--primary);font-weight:600}
+  .lk{display:inline-flex;font-size:12.5px;font-weight:600;color:var(--primary);padding:12px 20px;cursor:pointer;text-decoration:none;align-items:center;gap:5px}
+  .lk:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="side">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a class="active">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
+        Panel
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.5"/><path d="M2.5 20c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6"/><circle cx="17" cy="8" r="3"/><path d="M16 14c2.7.2 5 2.5 5 5.5"/></svg>
+        Usuarios
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/><circle cx="12" cy="15" r="1.5" fill="currentColor"/></svg>
+        Días especiales
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>
+        Auditoría
+      </a>
+    </nav>
+    <div class="user">
+      <div class="av">MA</div>
+      <div>
+        <div class="nm">Marco Admin</div>
+        <div class="rl">Administrador</div>
+      </div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="hd">
+      <h1>Panel de administración</h1>
+      <div class="dt">Lunes, 11 de mayo 2026</div>
+    </div>
+
+    <!-- Stats -->
+    <div class="stats">
+      <div class="stat">
+        <div class="l">Total usuarios</div>
+        <div class="v">1,247</div>
+        <div class="sub">1,198 alumnos · 49 doctores</div>
+      </div>
+      <div class="stat">
+        <div class="l">Citas hoy</div>
+        <div class="v">38</div>
+        <div class="sub">14 completadas · 24 pendientes</div>
+      </div>
+      <div class="stat">
+        <div class="l">Alumnos activos</div>
+        <div class="v">892</div>
+        <div class="sub">Últimos 30 días</div>
+      </div>
+      <div class="stat">
+        <div class="l">Último acceso</div>
+        <div class="v">11:42</div>
+        <div class="sub">dr.ramirez@tecvm.mx</div>
+      </div>
+    </div>
+
+    <!-- Users table -->
+    <section class="sec">
+      <div class="sec-hd">
+        <div>
+          <h2>Gestión de usuarios</h2>
+          <div class="sub">Alumnos, doctores y personal administrativo del sistema</div>
+        </div>
+        <button class="btn-pri">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+          Nuevo usuario
+        </button>
+      </div>
+      <table>
+        <thead>
+          <tr><th>Usuario</th><th>Correo</th><th>Rol</th><th>Estatus</th><th>Última sesión</th><th>Acciones</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><div class="uc"><div class="av">NV</div><div class="nm">Nestor Valles</div></div></td>
+            <td class="em">22690495@tecvm.mx</td>
+            <td><span class="bd bd-al">Alumno</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Hoy, 10:14</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+          <tr>
+            <td><div class="uc"><div class="av" style="background:#e8f5ee;color:#1a5c3a">LR</div><div class="nm">Dra. Laura Ramírez</div></div></td>
+            <td class="em">dr.ramirez@tecvm.mx</td>
+            <td><span class="bd bd-dc">Doctor</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Hoy, 11:42</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+          <tr>
+            <td><div class="uc"><div class="av">SO</div><div class="nm">Sofía Ortega</div></div></td>
+            <td class="em">22810123@tecvm.mx</td>
+            <td><span class="bd bd-al">Alumno</span></td>
+            <td><span class="bd bd-su">Suspendido</span></td>
+            <td class="ls">02 may, 16:08</td>
+            <td><div class="acts"><a>Editar</a><a>Reactivar</a></div></td>
+          </tr>
+          <tr>
+            <td><div class="uc"><div class="av" style="background:#e8f5ee;color:#1a5c3a">JM</div><div class="nm">Dr. Javier Mendoza</div></div></td>
+            <td class="em">dr.mendoza@tecvm.mx</td>
+            <td><span class="bd bd-dc">Doctor</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Ayer, 18:22</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- Two-column row -->
+    <section class="sec">
+      <div class="sec-hd">
+        <div>
+          <h2>Días especiales próximos</h2>
+          <div class="sub">Festivos, horarios reducidos y periodos vacacionales</div>
+        </div>
+      </div>
+      <div class="days">
+        <div class="day">
+          <div class="dn">15<span class="mo">May 2026</span></div>
+          <div class="nm">Día del Maestro</div>
+          <span class="ty ty-f">Festivo</span>
+        </div>
+        <div class="day">
+          <div class="dn">22<span class="mo">May 2026</span></div>
+          <div class="nm">Horario reducido — Junta académica</div>
+          <span class="ty ty-r">Reducido</span>
+        </div>
+        <div class="day">
+          <div class="dn">15<span class="mo">Jun – 28 Jul</span></div>
+          <div class="nm">Periodo vacacional de verano</div>
+          <span class="ty ty-v">Vacaciones</span>
+        </div>
+      </div>
+      <div class="sec-ft">
+        <button class="btn-out">Gestionar calendario</button>
+      </div>
+    </section>
+
+    <!-- Audit -->
+    <section class="sec">
+      <div class="sec-hd">
+        <div>
+          <h2>Bitácora de auditoría reciente</h2>
+          <div class="sub">Acciones registradas en las últimas horas</div>
+        </div>
+      </div>
+      <div class="audit">
+        <div class="ar">
+          <span class="ts">Hoy, 11:42</span>
+          <div class="au">Dra. Laura Ramírez<span class="role">Doctor</span></div>
+          <div class="act">Inició sesión desde <span class="em">192.168.10.34</span></div>
+        </div>
+        <div class="ar">
+          <span class="ts">Hoy, 11:18</span>
+          <div class="au">Marco Admin<span class="role">Administrador</span></div>
+          <div class="act">Suspendió cuenta de alumno <span class="em">Sofía Ortega</span></div>
+        </div>
+        <div class="ar">
+          <span class="ts">Hoy, 10:54</span>
+          <div class="au">Dr. Javier Mendoza<span class="role">Doctor</span></div>
+          <div class="act">Modificó receta del expediente <span class="em">#28104</span></div>
+        </div>
+        <div class="ar">
+          <span class="ts">Hoy, 10:14</span>
+          <div class="au">Nestor Valles<span class="role">Alumno</span></div>
+          <div class="act">Agendó cita para el <span class="em">14 de mayo, 10:30</span></div>
+        </div>
+      </div>
+      <a class="lk">Ver bitácora completa
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+    </section>
+  </main>
+</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Pre-evaluacion IA.html
+++ b/frontend/design-reference-dark/Pre-evaluacion IA.html
@@ -1,0 +1,366 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Pre-evaluación IA</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec;
+    --warn:#f59e0b; --warn-50:#fef3e0;
+    --bg:#f7f9f8; --surface:#ffffff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+    --bubble-ai:#f3f4f6; --bubble-me:#e8f5ee;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;height:100%;font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+
+  .app{display:flex;height:100vh}
+
+  /* Sidebar */
+  .sb{width:232px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px;letter-spacing:-.5px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px;letter-spacing:.3px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;text-decoration:none;cursor:pointer}
+  .sb a:hover{background:rgba(255,255,255,.05)}
+  .sb a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb a .ic{font-size:14px;width:16px;text-align:center;opacity:.95}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px;flex-shrink:0}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px;font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden}
+  .header{padding:24px 36px 18px;background:#1a1d27;border-bottom:1px solid var(--border)}
+  .crumb{font-size:12px;color:var(--text-subtle);margin-bottom:6px;font-weight:500;text-transform:uppercase;letter-spacing:.4px}
+  h1{margin:0 0 4px;font-size:24px;font-weight:700;letter-spacing:-.5px}
+  .header .sub{font-size:13px;color:var(--text-subtle);max-width:640px;line-height:1.5}
+  .header .sub b{color:var(--text-muted);font-weight:600}
+
+  /* Two columns */
+  .grid{display:grid;grid-template-columns:60% 40%;flex:1;min-height:0}
+  .col-chat{display:flex;flex-direction:column;border-right:1px solid var(--border);background:#1a1d27;min-height:0}
+  .col-res{padding:24px 28px;overflow-y:auto;background:var(--bg)}
+
+  /* Chat */
+  .chat-meta{padding:14px 28px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;background:#1a1d27}
+  .chat-meta .session{font-size:12px;color:var(--text-subtle)}
+  .chat-meta .session b{color:var(--text);font-weight:600}
+  .chat-meta .live{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;color:var(--primary);font-weight:600}
+  .chat-meta .live .dot{width:6px;height:6px;border-radius:50%;background:var(--primary);box-shadow:0 0 0 4px rgba(26,92,58,.12)}
+
+  .msgs{flex:1;overflow-y:auto;padding:26px 28px 8px;display:flex;flex-direction:column;gap:18px}
+  .msg{display:flex;gap:10px;max-width:78%}
+  .msg.ai{align-self:flex-start}
+  .msg.me{align-self:flex-end;flex-direction:row-reverse}
+  .msg .av{width:32px;height:32px;border-radius:8px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700}
+  .msg.ai .av{background:var(--primary);color:#fff}
+  .msg.me .av{background:var(--primary-50);color:var(--primary)}
+  .msg .body{display:flex;flex-direction:column;gap:4px}
+  .msg.me .body{align-items:flex-end}
+  .bubble{padding:11px 14px;border-radius:14px;font-size:13.5px;line-height:1.55;color:var(--text)}
+  .msg.ai .bubble{background:var(--bubble-ai);border-top-left-radius:4px}
+  .msg.me .bubble{background:var(--bubble-me);border-top-right-radius:4px;color:#13301f}
+  .msg .ts{font-size:10.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums}
+  .msg.me .ts{text-align:right}
+  .typing{display:flex;gap:4px;padding:4px 0}
+  .typing span{width:6px;height:6px;border-radius:50%;background:var(--text-subtle);opacity:.5;animation:b 1.2s infinite}
+  .typing span:nth-child(2){animation-delay:.15s}
+  .typing span:nth-child(3){animation-delay:.3s}
+  @keyframes b{0%,80%,100%{opacity:.3;transform:translateY(0)}40%{opacity:1;transform:translateY(-3px)}}
+
+  /* Input area */
+  .composer{border-top:1px solid var(--border);padding:14px 28px 18px;background:#1a1d27;flex-shrink:0}
+  .input-row{display:flex;gap:10px;align-items:flex-end;background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:8px 8px 8px 14px;transition:border-color .15s, box-shadow .15s}
+  .input-row:focus-within{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.1);background:#1a1d27}
+  .input-row textarea{flex:1;border:none;outline:none;resize:none;font-family:inherit;font-size:13.5px;line-height:1.5;color:var(--text);background:transparent;padding:6px 0;max-height:96px;min-height:24px}
+  .input-row textarea::placeholder{color:var(--text-subtle)}
+  .input-row .send{background:var(--primary);color:#fff;width:38px;height:38px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:16px;font-weight:700;flex-shrink:0;transition:background .15s}
+  .input-row .send:hover{background:var(--primary-600)}
+  .input-row .send:disabled{background:var(--border-strong);cursor:not-allowed}
+  .input-hint{display:flex;justify-content:space-between;align-items:center;margin-top:10px;font-size:11.5px;color:var(--text-subtle)}
+  .input-hint .left{display:flex;align-items:center;gap:6px}
+  .input-hint kbd{background:var(--bg);border:1px solid var(--border);border-radius:4px;padding:1px 6px;font-family:inherit;font-size:10.5px;color:var(--text-muted);font-weight:600}
+  .finish-btn{width:100%;margin-top:12px;background:var(--primary);color:#fff;padding:12px 16px;border-radius:9px;font-size:13.5px;font-weight:600;display:flex;align-items:center;justify-content:center;gap:8px;transition:background .15s}
+  .finish-btn:hover{background:var(--primary-600)}
+  .finish-btn .ic{font-size:14px}
+
+  /* Right column */
+  .panel{background:#1a1d27;border:1px solid var(--border);border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04);margin-bottom:18px}
+  .panel-head{padding:16px 20px;border-bottom:1px solid var(--border)}
+  .panel-head h2{margin:0;font-size:14px;font-weight:600;letter-spacing:-.1px;display:flex;align-items:center;gap:8px}
+  .panel-head h2 .ic{width:24px;height:24px;border-radius:6px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700}
+  .panel-head .meta{font-size:11.5px;color:var(--text-subtle);margin-top:4px;display:flex;align-items:center;gap:6px}
+  .panel-head .meta .dot{width:5px;height:5px;border-radius:50%;background:var(--primary)}
+
+  /* Diagnoses */
+  .dx{padding:18px 20px;border-bottom:1px solid var(--border)}
+  .dx:last-child{border-bottom:none}
+  .dx-row{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px}
+  .dx-name{font-size:13.5px;font-weight:600;color:var(--text);display:flex;align-items:center;gap:8px}
+  .dx-name .rank{width:18px;height:18px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:inline-flex;align-items:center;justify-content:center;font-size:10.5px;font-weight:700}
+  .dx-name .code{color:var(--text-subtle);font-weight:500;font-size:11.5px;font-variant-numeric:tabular-nums}
+  .dx-pct{font-size:14px;font-weight:700;color:var(--primary);font-variant-numeric:tabular-nums;letter-spacing:-.3px}
+  .bar{height:8px;border-radius:999px;background:var(--bg);overflow:hidden;position:relative}
+  .bar .fill{height:100%;background:var(--primary);border-radius:999px;transition:width .5s ease}
+  .dx-2 .dx-pct{color:#3d8c64}
+  .dx-2 .bar .fill{background:#3d8c64}
+  .dx-3 .dx-pct{color:#6ba88a}
+  .dx-3 .bar .fill{background:#6ba88a}
+  .dx-meta{font-size:11.5px;color:var(--text-subtle);margin-top:8px;line-height:1.4}
+
+  /* Warning callout */
+  .callout{margin:14px 20px 18px;padding:12px 14px;background:var(--warn-50);border:1px solid #fde0a0;border-radius:9px;display:flex;gap:11px;align-items:flex-start}
+  .callout .ic{width:24px;height:24px;border-radius:6px;background:var(--warn);color:#fff;display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;flex-shrink:0}
+  .callout .txt{font-size:12.5px;line-height:1.45;color:#7a4d05}
+  .callout .txt b{display:block;font-weight:700;color:#5e3a02;margin-bottom:1px;font-size:13px}
+
+  /* Symptoms summary */
+  .syms{padding:14px 20px 18px;display:flex;flex-wrap:wrap;gap:6px}
+  .syms .chip{padding:4px 10px;border:1px solid var(--border);background:var(--bg);border-radius:999px;font-size:11.5px;color:var(--text-muted);font-weight:500}
+  .syms .chip.hot{background:var(--primary-50);color:var(--primary);border-color:#c5dccc}
+
+  .panel-cta{padding:14px 20px;background:var(--bg);border-top:1px solid var(--border);display:flex;gap:8px}
+  .btn{padding:10px 14px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap}
+  .btn.secondary{background:#1a1d27;color:var(--primary);border:1px solid var(--primary);flex:1;justify-content:center}
+  .btn.secondary:hover{background:var(--primary-50)}
+  .btn.ghost{color:var(--text-muted);background:#1a1d27;border:1px solid var(--border)}
+  .btn.ghost:hover{background:var(--bg)}
+
+  /* Tips card */
+  .tips ul{list-style:none;margin:0;padding:0}
+  .tips li{display:flex;gap:10px;align-items:flex-start;padding:11px 20px;border-bottom:1px solid var(--border);font-size:12.5px;line-height:1.5;color:var(--text-muted)}
+  .tips li:last-child{border-bottom:none}
+  .tips li .ic{width:20px;height:20px;border-radius:5px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;flex-shrink:0;margin-top:1px}
+  .tips li b{color:var(--text);font-weight:600;display:block;margin-bottom:1px;font-size:13px}
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- Sidebar -->
+  <aside class="sb">
+    <div class="brand">
+      <div class="y">Y</div>
+      <div><b>Yoltec</b><span>Servicio médico</span></div>
+    </div>
+    <nav>
+      <a href="Inicio Alumno.html"><span class="ic">▦</span>Inicio</a>
+      <a href="Mis Citas.html"><span class="ic">⊞</span>Mis citas</a>
+      <a class="active"><span class="ic">◈</span>Pre-evaluación IA</a>
+      <a><span class="ic">℞</span>Recetas</a>
+      <a><span class="ic">◉</span>Mi perfil</a>
+    </nav>
+    <div class="user">
+      <div class="av">AP</div>
+      <div><b>Ana Pérez García</b><span>22690495</span></div>
+    </div>
+  </aside>
+
+  <!-- Main -->
+  <div class="main">
+    <div class="header">
+      <div class="crumb">PRE-EVALUACIÓN IA</div>
+      <h1>Pre-evaluación con IA</h1>
+      <div class="sub">Describe tus síntomas con tus propias palabras. Esto <b>NO reemplaza una consulta médica</b> — solo orienta y prepara tu cita con el doctor.</div>
+    </div>
+
+    <div class="grid">
+      <!-- Chat -->
+      <div class="col-chat">
+        <div class="chat-meta">
+          <div class="session">Sesión <b>#PE-2026-0451</b> · Iniciada 11:14</div>
+          <div class="live"><span class="dot"></span>IA en línea</div>
+        </div>
+
+        <div class="msgs" id="msgs">
+          <div class="msg ai">
+            <div class="av">IA</div>
+            <div class="body">
+              <div class="bubble">Hola, soy tu asistente médico. ¿Qué síntomas estás presentando hoy?</div>
+              <div class="ts">11:14</div>
+            </div>
+          </div>
+
+          <div class="msg me">
+            <div class="av">AP</div>
+            <div class="body">
+              <div class="bubble">Tengo dolor de garganta desde ayer y un poco de fiebre. También me cuesta tragar.</div>
+              <div class="ts">11:14</div>
+            </div>
+          </div>
+
+          <div class="msg ai">
+            <div class="av">IA</div>
+            <div class="body">
+              <div class="bubble">Entiendo. ¿Has notado tos, secreción nasal o ganglios inflamados en el cuello? ¿Sabes qué temperatura has tenido?</div>
+              <div class="ts">11:15</div>
+            </div>
+          </div>
+
+          <div class="msg me">
+            <div class="av">AP</div>
+            <div class="body">
+              <div class="bubble">Sí, tengo los ganglios un poco inflamados del lado derecho. Fiebre de 38.2°C anoche. No tengo tos pero sí algo de congestión.</div>
+              <div class="ts">11:16</div>
+            </div>
+          </div>
+
+          <div class="msg ai">
+            <div class="av">IA</div>
+            <div class="body">
+              <div class="bubble">Gracias, Ana. Con esos datos puedo darte una orientación preliminar. ¿Tienes alguna alergia a medicamentos o has tomado algo en las últimas horas?</div>
+              <div class="ts">11:16</div>
+            </div>
+          </div>
+
+          <div class="msg me">
+            <div class="av">AP</div>
+            <div class="body">
+              <div class="bubble">Soy alérgica a la penicilina. Solo tomé un paracetamol anoche para la fiebre.</div>
+              <div class="ts">11:17</div>
+            </div>
+          </div>
+
+          <div class="msg ai">
+            <div class="av">IA</div>
+            <div class="body">
+              <div class="bubble">Perfecto, lo registré. Ya tengo suficiente información para generar tu pre-evaluación. Revisa la columna derecha → con los posibles diagnósticos y agenda tu cita para confirmación.</div>
+              <div class="ts">11:17</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="composer">
+          <div class="input-row">
+            <textarea placeholder="Escribe otro síntoma o duda..." rows="1"></textarea>
+            <button class="send" title="Enviar">↑</button>
+          </div>
+          <div class="input-hint">
+            <span class="left">Presiona <kbd>Enter</kbd> para enviar · <kbd>Shift</kbd>+<kbd>Enter</kbd> para nueva línea</span>
+            <span>Tus respuestas son confidenciales</span>
+          </div>
+          <button class="finish-btn"><span class="ic">✓</span>Finalizar y guardar pre-evaluación</button>
+        </div>
+      </div>
+
+      <!-- Results -->
+      <div class="col-res">
+        <div class="panel">
+          <div class="panel-head">
+            <h2><span class="ic">◈</span>Posibles diagnósticos</h2>
+            <div class="meta"><span class="dot"></span>Generado a partir de 4 mensajes · Hace 8 s</div>
+          </div>
+          <div class="dx dx-1">
+            <div class="dx-row">
+              <div class="dx-name"><span class="rank">1</span>Faringitis aguda <span class="code">J02.9</span></div>
+              <div class="dx-pct">78%</div>
+            </div>
+            <div class="bar"><div class="fill" style="width:78%"></div></div>
+            <div class="dx-meta">Inflamación de garganta · fiebre · ganglios cervicales</div>
+          </div>
+          <div class="dx dx-2">
+            <div class="dx-row">
+              <div class="dx-name"><span class="rank">2</span>Amigdalitis <span class="code">J03.9</span></div>
+              <div class="dx-pct">45%</div>
+            </div>
+            <div class="bar"><div class="fill" style="width:45%"></div></div>
+            <div class="dx-meta">Requiere examen visual de amígdalas para confirmar</div>
+          </div>
+          <div class="dx dx-3">
+            <div class="dx-row">
+              <div class="dx-name"><span class="rank">3</span>Resfriado común <span class="code">J00</span></div>
+              <div class="dx-pct">30%</div>
+            </div>
+            <div class="bar"><div class="fill" style="width:30%"></div></div>
+            <div class="dx-meta">La congestión nasal apoya esta hipótesis</div>
+          </div>
+
+          <div class="callout">
+            <div class="ic">!</div>
+            <div class="txt">
+              <b>Solo orientativo</b>
+              El doctor confirmará el diagnóstico. No tomes medicamentos sin prescripción — recuerda tu alergia a penicilina.
+            </div>
+          </div>
+
+          <div class="panel-cta">
+            <button class="btn secondary"><span style="font-size:14px">⊞</span>Agendar cita</button>
+            <button class="btn ghost">Imprimir</button>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h2><span class="ic">⚲</span>Síntomas detectados</h2>
+            <div class="meta">6 hallazgos extraídos de la conversación</div>
+          </div>
+          <div class="syms">
+            <span class="chip hot">Dolor de garganta</span>
+            <span class="chip hot">Fiebre 38.2°C</span>
+            <span class="chip hot">Disfagia leve</span>
+            <span class="chip">Ganglios cervicales</span>
+            <span class="chip">Congestión nasal</span>
+            <span class="chip">Sin tos</span>
+          </div>
+        </div>
+
+        <div class="panel tips">
+          <div class="panel-head">
+            <h2><span class="ic">♥</span>Recomendaciones mientras agendas</h2>
+          </div>
+          <ul>
+            <li><span class="ic">1</span><span><b>Hidratación abundante</b>Agua tibia y caldos suaves cada 2 horas.</span></li>
+            <li><span class="ic">2</span><span><b>Reposo relativo</b>Evita esfuerzo físico y exposición al frío.</span></li>
+            <li><span class="ic">3</span><span><b>Monitorea la fiebre</b>Si supera 39°C o persiste 48 h, acude a urgencias.</span></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  // Auto-scroll chat to bottom
+  const m = document.getElementById('msgs');
+  if(m) m.scrollTop = m.scrollHeight;
+
+  // Textarea auto-grow
+  const ta = document.querySelector('.input-row textarea');
+  if(ta){
+    ta.addEventListener('input', () => {
+      ta.style.height = 'auto';
+      ta.style.height = Math.min(ta.scrollHeight, 96) + 'px';
+    });
+  }
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Pre-evaluaciones Doctor.html
+++ b/frontend/design-reference-dark/Pre-evaluaciones Doctor.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Pre-evaluaciones (Doctor)</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec; --primary-100:#d1e3d8;
+    --warn:#f59e0b; --warn-50:#fef3e0;
+    --danger:#dc2626; --danger-50:#fde8e8; --danger-100:#fecaca;
+    --info:#0369a1; --info-50:#e0f2fe;
+    --bg:#f7f9f8; --surface:#fff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+    --soft:#f9fafb;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body,#app{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+  input,select{font-family:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  .sb{width:240px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;cursor:pointer}
+  .sb a:hover{background:rgba(255,255,255,.05)}
+  .sb a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb a .ic{font-size:14px;width:16px;text-align:center}
+  .sb a .ct{margin-left:auto;background:#dc2626;color:#fff;font-size:10.5px;font-weight:700;padding:1px 7px;border-radius:999px;min-width:18px;text-align:center}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px}
+
+  .main{flex:1;min-width:0;display:flex;flex-direction:column}
+  .header{padding:28px 36px 0;background:#1a1d27;border-bottom:1px solid var(--border)}
+  .header .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:500;margin-bottom:6px}
+  .header h1{margin:0 0 4px;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .header .sub{font-size:13.5px;color:var(--text-muted);margin-bottom:18px}
+  .head-row{display:flex;justify-content:space-between;align-items:flex-start}
+
+  .tabs{display:flex;gap:0;margin-bottom:-1px}
+  .tabs button{padding:13px 4px;margin-right:28px;font-size:14px;font-weight:500;color:var(--text-muted);border-bottom:2px solid transparent;display:flex;align-items:center;gap:8px}
+  .tabs button:hover{color:var(--text)}
+  .tabs button.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+  .tabs button .ct{padding:1px 8px;border-radius:999px;font-size:11px;font-weight:700}
+  .tabs button .ct.red{background:var(--danger);color:#fff}
+  .tabs button .ct.gray{background:var(--bg);color:var(--text-muted)}
+  .tabs button.active .ct.gray{background:var(--primary-50);color:var(--primary)}
+
+  .btn{padding:9px 14px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.danger-outline{background:#1a1d27;color:var(--danger);border:1px solid var(--danger-100)}
+  .btn.danger-outline:hover{background:var(--danger-50);border-color:var(--danger)}
+  .btn.secondary{background:#1a1d27;color:var(--primary);border:1px solid var(--primary)}
+  .btn.ghost{color:var(--text-muted)}
+  .btn.ghost:hover{background:var(--bg)}
+  .btn.sm{padding:6px 11px;font-size:12.5px}
+
+  .content{padding:24px 36px 60px;flex:1}
+
+  /* Filter bar (history) */
+  .filters{display:flex;gap:10px;align-items:center;background:#1a1d27;border:1px solid var(--border);border-radius:10px;padding:12px 16px;margin-bottom:18px;flex-wrap:wrap}
+  .filters .lab{font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-right:4px}
+  .ffld{display:flex;align-items:center;gap:8px;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:7px 11px}
+  .ffld input,.ffld select{background:transparent;border:none;outline:none;font-size:13px;color:var(--text);min-width:130px}
+  .ffld .ic{color:var(--text-subtle);font-size:13px}
+  .filters .spacer{flex:1}
+
+  /* Card */
+  .pcard{background:#1a1d27;border:1px solid var(--border);border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04);margin-bottom:18px}
+  .pc-head{padding:18px 22px;display:flex;align-items:center;gap:14px;border-bottom:1px solid var(--border)}
+  .pc-head .av{width:44px;height:44px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:15px;flex-shrink:0}
+  .pc-head .who{flex:1;min-width:0}
+  .pc-head .who b{display:block;font-size:15px;font-weight:600;letter-spacing:-.1px}
+  .pc-head .who span{font-size:12.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums}
+  .pc-head .meta{font-size:12px;color:var(--text-muted);text-align:right}
+  .pc-head .meta b{display:block;color:var(--text);font-weight:600;font-size:13px}
+  .b{display:inline-flex;padding:4px 10px;border-radius:999px;font-size:11px;font-weight:700;align-items:center;gap:5px;text-transform:uppercase;letter-spacing:.3px}
+  .b.warn{background:var(--warn-50);color:#a35200}
+  .b.ok{background:var(--primary-50);color:var(--primary)}
+  .b.danger{background:var(--danger-50);color:var(--danger)}
+  .b .pulse{width:6px;height:6px;border-radius:50%;background:currentColor}
+
+  .pc-body{padding:20px 22px;display:grid;grid-template-columns:1fr 1fr;gap:20px}
+  .pc-section h3{margin:0 0 8px;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .symptoms{background:var(--soft);border:1px solid var(--border);border-radius:8px;padding:12px 14px;font-size:13.5px;line-height:1.55;color:var(--text-muted)}
+  .symptoms b{color:var(--text);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
+  .chip{background:#1a1d27;border:1px solid var(--border-strong);color:var(--text-muted);font-size:11.5px;font-weight:500;padding:3px 9px;border-radius:999px}
+
+  .dx-list{display:flex;flex-direction:column;gap:11px}
+  .dx{position:relative}
+  .dx .row{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:5px}
+  .dx .nm{font-size:13.5px;font-weight:600;color:var(--text)}
+  .dx .nm small{font-size:11px;color:var(--text-subtle);font-weight:500;margin-left:6px;font-variant-numeric:tabular-nums}
+  .dx .pct{font-size:13px;font-weight:700;color:var(--primary);font-variant-numeric:tabular-nums}
+  .dx .bar{height:7px;background:var(--bg);border-radius:999px;overflow:hidden;border:1px solid var(--border)}
+  .dx .fill{height:100%;background:var(--primary);border-radius:999px}
+  .dx.r2 .fill{background:#3f8a64}
+  .dx.r3 .fill{background:#6ba88a}
+
+  .pc-real{padding:16px 22px;background:var(--soft);border-top:1px solid var(--border)}
+  .pc-real h3{margin:0 0 4px;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .pc-real .v{font-size:13.5px;color:var(--text);line-height:1.5}
+  .pc-real .v.muted{color:var(--text-subtle);font-style:italic}
+  .pc-real .v b{color:var(--text);font-weight:600}
+
+  .pc-foot{display:flex;justify-content:space-between;align-items:center;padding:14px 22px;border-top:1px solid var(--border);background:#1a1d27}
+  .pc-foot .hint{font-size:11.5px;color:var(--text-subtle)}
+  .pc-foot .hint b{color:var(--text-muted);font-weight:600}
+  .pc-foot .actions{display:flex;gap:10px}
+
+  .switcher{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);z-index:200;background:#1a1d27;border:1px solid var(--border);border-radius:8px;padding:3px;display:flex;gap:1px;box-shadow:0 6px 16px rgba(26,92,58,.14)}
+  .switcher button{padding:7px 14px;border-radius:5px;font-size:12.5px;font-weight:500;color:var(--text-muted)}
+  .switcher button.active{background:var(--primary);color:#fff}
+</style>
+</head>
+<body>
+<div id="app"></div>
+<div class="switcher">
+  <button id="t1" class="active">Pendientes</button>
+  <button id="t2">Historial</button>
+</div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+function Sidebar(){
+  const items=[
+    ['panel','Panel','▦'],
+    ['citas','Citas','⊞'],
+    ['bit','Bitácoras','≡'],
+    ['rec','Recetas','℞'],
+    ['pe','Pre-evaluaciones','◔',true,3],
+    ['pri','Prioridad IA','◉'],
+    ['est','Estadísticas','◊'],
+  ];
+  return (
+    <aside className="sb">
+      <div className="brand"><div className="y">Y</div><div><b>Yoltec</b><span>Panel médico</span></div></div>
+      <nav>{items.map(([k,l,i,a,n])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}{n?<span className="ct">{n}</span>:null}</a>))}</nav>
+      <div className="user"><div className="av">OG</div><div><b>Dr. Omar González</b><span>Médico general</span></div></div>
+    </aside>
+  );
+}
+
+const PENDIENTES=[
+  {
+    av:'AP', nombre:'Ana Pérez García', ctrl:'22690495', carrera:'Ing. Industrial · 5°',
+    enviado:'hoy, 09:42',
+    sintomas:'Refiere dolor de garganta intenso desde hace 3 días, con dificultad para tragar y sensación de cuerpo extraño. Reporta fiebre de 38.4 °C ayer por la tarde, malestar general y cefalea leve. No hay tos productiva ni dificultad respiratoria. Alergia confirmada a penicilina.',
+    chips:['Odinofagia','Fiebre 38.4 °C','Cefalea','Alergia penicilina'],
+    dx:[['Faringitis aguda','J02.9',78],['Amigdalitis','J03.9',45],['Resfriado común','J00',30]],
+    folio:'PE-2026-0451',
+    citaProgramada:'miércoles 13 may · 10:30',
+  },
+  {
+    av:'RM', nombre:'Raúl Mendoza Vidal', ctrl:'22134781', carrera:'Lic. Administración · 7°',
+    enviado:'ayer, 16:18',
+    sintomas:'Dolor de cabeza pulsátil del lado derecho desde hace 2 días, con sensibilidad a la luz y náusea moderada. El dolor aumenta con actividad física. Reporta episodios similares 2-3 veces al mes desde hace un año. No toma medicación regular.',
+    chips:['Cefalea pulsátil','Fotofobia','Náusea','Recurrente'],
+    dx:[['Migraña sin aura','G43.0',82],['Cefalea tensional','G44.2',38],['Sinusitis','J32.9',22]],
+    folio:'PE-2026-0450',
+    citaProgramada:'jueves 14 may · 12:00',
+  },
+  {
+    av:'LF', nombre:'Lucía Fuentes Ortiz', ctrl:'21450923', carrera:'Ing. Sistemas · 8°',
+    enviado:'hace 2 días',
+    sintomas:'Dolor abdominal en fosa iliaca derecha de inicio gradual desde anoche, intensidad 6/10. Sin fiebre. Náusea sin vómito. Última comida hace 12 horas. Niega cambios en hábito intestinal.',
+    chips:['Dolor FID','Náusea','6/10','Aguda'],
+    dx:[['Apendicitis aguda','K35.80',64],['Gastroenteritis','A09',41],['Cólico menstrual','N94.4',28]],
+    folio:'PE-2026-0449',
+    citaProgramada:'sin agendar — sugerir cita',
+  },
+];
+
+const HISTORIAL=[
+  {
+    av:'JS', nombre:'Jorge Salinas Méndez', ctrl:'22789012', carrera:'Arq. · 4°',
+    enviado:'5 may, 11:20', validadoEn:'5 may, 14:35',
+    sintomas:'Tos seca persistente por 5 días, irritación faríngea leve. Sin fiebre. Trabajo cerca de zona en obra con polvo.',
+    chips:['Tos seca','Irritación','Polvo ambiental'],
+    dx:[['Bronquitis aguda','J20.9',71],['Faringitis','J02.9',52],['Rinitis alérgica','J30.9',34]],
+    real:'Bronquitis aguda — coincide con la sugerencia de mayor probabilidad.',
+    status:'ok', label:'Validada',
+  },
+  {
+    av:'MC', nombre:'María Carrillo López', ctrl:'21567890', carrera:'Lic. Psicología · 6°',
+    enviado:'3 may, 08:50', validadoEn:'3 may, 13:10',
+    sintomas:'Mareo al levantarse desde hace una semana, sensación de vértigo de pocos segundos, sin pérdida auditiva. Refiere estrés académico.',
+    chips:['Vértigo posicional','Estrés','Breve'],
+    dx:[['VPPB','H81.10',69],['Migraña vestibular','G43.A',44],['Hipotensión ortostática','I95.1',25]],
+    real:'Hipotensión ortostática secundaria a bajo consumo de líquidos — la IA priorizó VPPB.',
+    status:'danger', label:'Descartada',
+  },
+];
+
+function Card({c,mode}){
+  return (
+    <div className="pcard">
+      <div className="pc-head">
+        <div className="av">{c.av}</div>
+        <div className="who">
+          <b>{c.nombre}</b>
+          <span>No. {c.ctrl} · {c.carrera}</span>
+        </div>
+        <div className="meta">
+          <b>Folio {c.folio || '—'}</b>
+          Enviada: {c.enviado}
+          {c.validadoEn && <><br/>Validada: {c.validadoEn}</>}
+        </div>
+        {mode==='pend' && <span className="b warn"><span className="pulse"></span>Pendiente</span>}
+        {mode==='hist' && c.status==='ok' && <span className="b ok"><span className="pulse"></span>Validada</span>}
+        {mode==='hist' && c.status==='danger' && <span className="b danger"><span className="pulse"></span>Descartada</span>}
+      </div>
+
+      <div className="pc-body">
+        <div className="pc-section">
+          <h3>Síntomas reportados por el alumno</h3>
+          <div className="symptoms">{c.sintomas}</div>
+          <div className="chips">{c.chips.map(ch=><span key={ch} className="chip">{ch}</span>)}</div>
+        </div>
+        <div className="pc-section">
+          <h3>Diagnósticos sugeridos por IA</h3>
+          <div className="dx-list">
+            {c.dx.map(([n,code,p],i)=>(
+              <div key={i} className={'dx r'+(i+1)}>
+                <div className="row">
+                  <div className="nm">{n}<small>{code}</small></div>
+                  <div className="pct">{p}%</div>
+                </div>
+                <div className="bar"><div className="fill" style={{width:p+'%'}}/></div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="pc-real">
+        <h3>Diagnóstico real de la consulta</h3>
+        {mode==='pend' ? (
+          <div className="v muted">Pendiente de consulta. {c.citaProgramada && <>Cita: <b style={{fontStyle:'normal',color:'var(--text-muted)'}}>{c.citaProgramada}</b>.</>}</div>
+        ) : (
+          <div className="v">{c.real}</div>
+        )}
+      </div>
+
+      {mode==='pend' && (
+        <div className="pc-foot">
+          <div className="hint">Una vez atendida la consulta, valida o descarta para entrenar la <b>IA</b>.</div>
+          <div className="actions">
+            <button className="btn ghost sm">Ver expediente</button>
+            <button className="btn danger-outline">✕ Descartar</button>
+            <button className="btn primary">✓ Validar</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function App({mode}){
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <div className="header">
+          <div className="head-row">
+            <div>
+              <div className="crumb">Servicio médico · Pre-evaluaciones</div>
+              <h1>Pre-evaluaciones IA</h1>
+              <div className="sub">Valida si el diagnóstico sugerido por la IA coincidió con el diagnóstico real de la consulta. Esto entrena al modelo.</div>
+            </div>
+            <div style={{display:'flex',gap:10,marginTop:6}}>
+              <button className="btn secondary">Exportar reporte</button>
+              <button className="btn ghost">Configurar umbrales</button>
+            </div>
+          </div>
+          <div className="tabs">
+            <button className={mode==='pend'?'active':''}>Pendientes de validar <span className="ct red">3</span></button>
+            <button className={mode==='hist'?'active':''}>Historial <span className="ct gray">142</span></button>
+          </div>
+        </div>
+
+        <div className="content">
+          {mode==='hist' && (
+            <div className="filters">
+              <span className="lab">Filtrar</span>
+              <div className="ffld"><span className="ic">⌕</span><input placeholder="Buscar por alumno o folio"/></div>
+              <div className="ffld"><span className="ic">⊞</span><input type="date" defaultValue="2026-04-01"/></div>
+              <div className="ffld"><span className="ic">→</span><input type="date" defaultValue="2026-05-11"/></div>
+              <div className="ffld"><select defaultValue=""><option value="">Todos los estatus</option><option>Validadas</option><option>Descartadas</option></select></div>
+              <div className="ffld"><select defaultValue=""><option value="">Todos los diagnósticos</option><option>Faringitis</option><option>Migraña</option><option>Bronquitis</option></select></div>
+              <div className="spacer"/>
+              <button className="btn ghost sm">Limpiar</button>
+            </div>
+          )}
+          {(mode==='pend'?PENDIENTES:HISTORIAL).map((c,i)=><Card key={i} c={c} mode={mode}/>)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const root=ReactDOM.createRoot(document.getElementById('app'));
+function setActive(id){document.querySelectorAll('.switcher button').forEach(b=>b.classList.remove('active'));document.getElementById(id).classList.add('active');}
+function render(m){root.render(<App mode={m}/>);}
+document.getElementById('t1').onclick=()=>{setActive('t1');render('pend');};
+document.getElementById('t2').onclick=()=>{setActive('t2');render('hist');};
+render('pend');
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Prioridad IA Doctor.html
+++ b/frontend/design-reference-dark/Prioridad IA Doctor.html
@@ -1,0 +1,357 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Prioridad IA (Doctor)</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec; --primary-100:#d1e3d8;
+    --danger:#dc2626; --danger-50:#fef2f2; --danger-100:#fecaca; --danger-700:#991b1b;
+    --warn:#ea580c; --warn-50:#fff7ed; --warn-100:#fed7aa; --warn-700:#9a3412;
+    --info:#3b82f6; --info-50:#eff6ff; --info-700:#1e40af;
+    --bg:#f7f9f8; --surface:#fff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+    --soft:#f9fafb;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body,#app{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+  input,select{font-family:inherit}
+  a{color:var(--primary);text-decoration:none;font-weight:600;cursor:pointer}
+  a:hover{text-decoration:underline}
+
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar (same as Pre-evaluaciones) */
+  .sb{width:240px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb nav a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;text-decoration:none}
+  .sb nav a:hover{background:rgba(255,255,255,.05);text-decoration:none}
+  .sb nav a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb nav a .ic{font-size:14px;width:16px;text-align:center}
+  .sb nav a .ct{margin-left:auto;background:var(--danger);color:#fff;font-size:10.5px;font-weight:700;padding:1px 7px;border-radius:999px;min-width:18px;text-align:center}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px}
+
+  /* Main */
+  .main{flex:1;min-width:0;display:flex;flex-direction:column}
+  .header{padding:28px 36px 24px;background:#1a1d27;border-bottom:1px solid var(--border)}
+  .head-top{display:flex;justify-content:space-between;align-items:flex-start;gap:20px}
+  .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:500;margin-bottom:6px}
+  h1{margin:0 0 4px;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .sub{font-size:13.5px;color:var(--text-muted)}
+
+  .banner{display:flex;align-items:flex-start;gap:11px;background:var(--info-50);border-left:3px solid var(--info);border-radius:0 8px 8px 0;padding:12px 16px;margin-top:18px;color:#1e3a8a;font-size:13px;line-height:1.55}
+  .banner .ic{width:18px;height:18px;border-radius:50%;background:var(--info);color:#fff;display:inline-flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;flex-shrink:0;margin-top:1px}
+  .banner b{font-weight:600;color:#1e3a8a}
+
+  .btn{padding:9px 14px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap;border:1px solid transparent}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.outline{background:#1a1d27;color:var(--primary);border-color:var(--primary)}
+  .btn.outline:hover{background:var(--primary-50)}
+  .btn.ghost{color:var(--text-muted)}
+  .btn.ghost:hover{background:var(--bg)}
+  .btn.sm{padding:6px 12px;font-size:12.5px}
+
+  .content{padding:24px 36px 60px;flex:1}
+
+  /* KPI mini cards */
+  .kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-bottom:24px}
+  .kpi{border-radius:12px;padding:18px 20px;border:1px solid var(--border);position:relative;overflow:hidden}
+  .kpi .lbl{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;display:flex;align-items:center;gap:7px}
+  .kpi .lbl .dot{width:8px;height:8px;border-radius:50%}
+  .kpi .n{font-size:42px;font-weight:700;letter-spacing:-1px;line-height:1;margin-top:14px;font-variant-numeric:tabular-nums}
+  .kpi .foot{font-size:12px;margin-top:8px;display:flex;justify-content:space-between;align-items:baseline}
+  .kpi .foot b{font-weight:600}
+  .kpi.red{background:var(--danger-50);border-color:#fecaca}
+  .kpi.red .lbl,.kpi.red .n,.kpi.red .foot b{color:var(--danger-700)}
+  .kpi.red .dot{background:var(--danger)}
+  .kpi.red .foot{color:#b91c1c}
+  .kpi.orange{background:var(--warn-50);border-color:#fed7aa}
+  .kpi.orange .lbl,.kpi.orange .n,.kpi.orange .foot b{color:var(--warn-700)}
+  .kpi.orange .dot{background:var(--warn)}
+  .kpi.orange .foot{color:#c2410c}
+  .kpi.gray{background:var(--soft);border-color:var(--border)}
+  .kpi.gray .lbl,.kpi.gray .n,.kpi.gray .foot b{color:var(--text-muted)}
+  .kpi.gray .dot{background:var(--text-subtle)}
+  .kpi.gray .foot{color:var(--text-subtle)}
+
+  /* Table */
+  .table-wrap{background:#1a1d27;border:1px solid var(--border);border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04)}
+  .table-head{padding:16px 22px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border);gap:12px;flex-wrap:wrap}
+  .table-head h2{margin:0;font-size:15px;font-weight:600}
+  .table-head .meta{font-size:12px;color:var(--text-subtle)}
+  .table-head .meta b{color:var(--text-muted);font-weight:600}
+  .th-actions{display:flex;gap:8px;align-items:center}
+  .pill-tabs{display:flex;background:var(--bg);border-radius:7px;padding:3px;gap:1px}
+  .pill-tabs button{padding:6px 12px;border-radius:5px;font-size:12px;font-weight:500;color:var(--text-muted)}
+  .pill-tabs button.active{background:#1a1d27;color:var(--text);box-shadow:0 1px 2px rgba(0,0,0,.06)}
+
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{text-align:left;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;background:var(--soft);padding:11px 22px;border-bottom:1px solid var(--border);white-space:nowrap}
+  thead th.num{text-align:right}
+  thead th .so{margin-left:4px;color:var(--text-subtle);font-size:9px}
+  tbody td{padding:14px 22px;border-bottom:1px solid var(--border);vertical-align:middle}
+  tbody tr:last-child td{border-bottom:none}
+  tbody tr:hover{background:var(--soft)}
+
+  .who{display:flex;align-items:center;gap:11px;min-width:200px}
+  .who .av{width:36px;height:36px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12.5px;flex-shrink:0}
+  .who b{display:block;font-size:13.5px;font-weight:600}
+  .who span{font-size:11.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums}
+
+  .symp{color:var(--text-muted);max-width:340px;display:flex;align-items:center;gap:6px;font-size:13px}
+  .symp .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:280px}
+
+  .score{font-weight:700;font-size:14.5px;font-variant-numeric:tabular-nums;text-align:right;white-space:nowrap}
+  .score small{font-weight:500;color:var(--text-subtle);font-size:11.5px;margin-left:3px}
+  .score .bar{display:inline-block;vertical-align:middle;width:60px;height:5px;background:var(--bg);border-radius:999px;margin-right:9px;overflow:hidden;border:1px solid var(--border)}
+  .score .bar i{display:block;height:100%}
+
+  .b{display:inline-flex;padding:4px 10px;border-radius:999px;font-size:11px;font-weight:700;align-items:center;gap:5px;text-transform:uppercase;letter-spacing:.3px;border:1px solid transparent}
+  .b .dot{width:6px;height:6px;border-radius:50%;background:currentColor}
+  .b.red{background:var(--danger-50);color:var(--danger-700);border-color:#fecaca}
+  .b.orange{background:var(--warn-50);color:var(--warn-700);border-color:#fed7aa}
+  .b.gray{background:var(--soft);color:var(--text-muted);border-color:var(--border)}
+
+  .date{color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap}
+  .date.muted{color:var(--text-subtle);font-style:italic}
+
+  .footnote{margin-top:14px;padding:10px 14px;font-size:11.5px;color:var(--text-subtle);display:flex;align-items:center;gap:8px}
+  .footnote .ic{width:14px;height:14px;border-radius:50%;border:1.5px solid var(--text-subtle);display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:700;flex-shrink:0}
+
+  .updated{font-size:11.5px;color:var(--text-subtle);margin-top:8px;text-align:right}
+</style>
+</head>
+<body>
+<div id="app"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+function Sidebar(){
+  const items=[
+    ['panel','Panel','▦'],
+    ['citas','Citas','⊞'],
+    ['bit','Bitácoras','≡'],
+    ['rec','Recetas','℞'],
+    ['pe','Pre-evaluaciones','◔',false,3],
+    ['pri','Prioridad IA','◉',true],
+    ['est','Estadísticas','◊'],
+  ];
+  return (
+    <aside className="sb">
+      <div className="brand"><div className="y">Y</div><div><b>Yoltec</b><span>Panel médico</span></div></div>
+      <nav>{items.map(([k,l,i,a,n])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}{n?<span className="ct">{n}</span>:null}</a>))}</nav>
+      <div className="user"><div className="av">OG</div><div><b>Dr. Omar González</b><span>Médico general</span></div></div>
+    </aside>
+  );
+}
+
+const ROWS=[
+  {
+    av:'LF', nombre:'Lucía Fuentes Ortiz', ctrl:'21450923',
+    sintomas:'Dolor abdominal en fosa iliaca derecha 6/10, náusea sin vómito, sin fiebre desde anoche.',
+    score:21, pri:'ALTA', cita:'2 may 2026',
+    factores:'Síntomas agudos + inasistencias previas (3)'
+  },
+  {
+    av:'AP', nombre:'Ana Pérez García', ctrl:'22690495',
+    sintomas:'Odinofagia intensa 3 días, fiebre 38.4 °C, alergia confirmada a penicilina.',
+    score:18, pri:'ALTA', cita:'10 abr 2026',
+    factores:'Alergia medicamentosa + fiebre alta'
+  },
+  {
+    av:'DK', nombre:'Diego Kuri Salazar', ctrl:'22034512',
+    sintomas:'Crisis asmática leve esta mañana, sibilancias audibles, usa inhalador.',
+    score:16, pri:'ALTA', cita:'15 mar 2026',
+    factores:'Asma crónica + síntomas activos'
+  },
+  {
+    av:'RM', nombre:'Raúl Mendoza Vidal', ctrl:'22134781',
+    sintomas:'Cefalea pulsátil derecha con fotofobia y náusea, 2 días de evolución, recurrente.',
+    score:13, pri:'MEDIA', cita:'28 abr 2026',
+    factores:'Recurrencia mensual'
+  },
+  {
+    av:'KB', nombre:'Karla Bárcenas Ríos', ctrl:'21897603',
+    sintomas:'Dolor lumbar mecánico 4 días, irradia a glúteo derecho, sin parestesias.',
+    score:11, pri:'MEDIA', cita:'sin citas',
+    factores:'Primera consulta, sin antecedentes'
+  },
+  {
+    av:'JS', nombre:'Jorge Salinas Méndez', ctrl:'22789012',
+    sintomas:'Tos seca persistente 5 días, irritación faríngea leve, sin fiebre.',
+    score:9, pri:'MEDIA', cita:'5 may 2026',
+    factores:'Síntomas leves controlados'
+  },
+  {
+    av:'MC', nombre:'María Carrillo López', ctrl:'21567890',
+    sintomas:'Revisión de control hipertensión arterial — sin síntomas nuevos.',
+    score:6, pri:'BAJA', cita:'3 may 2026',
+    factores:'Control rutinario'
+  },
+  {
+    av:'IT', nombre:'Iván Torres Ramírez', ctrl:'23012398',
+    sintomas:'Solicita constancia médica para clase de educación física.',
+    score:3, pri:'BAJA', cita:'1 may 2026',
+    factores:'Trámite administrativo'
+  },
+];
+
+function priClass(p){return p==='ALTA'?'red':p==='MEDIA'?'orange':'gray'}
+function priFill(p){return p==='ALTA'?'#dc2626':p==='MEDIA'?'#ea580c':'#94a3b8'}
+
+function Row({r}){
+  const pct=Math.min(100,(r.score/22)*100);
+  return (
+    <tr>
+      <td>
+        <div className="who">
+          <div className="av">{r.av}</div>
+          <div><b>{r.nombre}</b><span>No. {r.ctrl}</span></div>
+        </div>
+      </td>
+      <td>
+        <div className="symp" title={r.sintomas}>
+          <span className="tx">{r.sintomas}</span>
+          <a>ver más</a>
+        </div>
+      </td>
+      <td className="score">
+        <span className="bar"><i style={{width:pct+'%',background:priFill(r.pri)}}/></span>
+        {r.score}<small>pts</small>
+      </td>
+      <td><span className={'b '+priClass(r.pri)}><span className="dot"></span>{r.pri}</span></td>
+      <td className={r.cita==='sin citas'?'date muted':'date'}>{r.cita==='sin citas'?'Sin citas':r.cita}</td>
+      <td><button className="btn outline sm">Ver ficha</button></td>
+    </tr>
+  );
+}
+
+function App(){
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <div className="header">
+          <div className="head-top">
+            <div>
+              <div className="crumb">Servicio médico · Triage</div>
+              <h1>Clasificación de Prioridad IA</h1>
+              <div className="sub">Herramienta de apoyo. La decisión final es del doctor.</div>
+            </div>
+            <div style={{display:'flex',flexDirection:'column',alignItems:'flex-end',gap:6}}>
+              <button className="btn primary">↻ Actualizar clasificación</button>
+              <div className="updated">Última actualización: hoy, 09:14</div>
+            </div>
+          </div>
+          <div className="banner">
+            <span className="ic">i</span>
+            <span>La puntuación se calcula con base en <b>síntomas reportados</b>, <b>historial de inasistencias</b> y <b>condiciones crónicas registradas</b>. Pondera severidad, frecuencia y cronicidad para sugerir un orden de atención.</span>
+          </div>
+        </div>
+
+        <div className="content">
+          <div className="kpis">
+            <div className="kpi red">
+              <div className="lbl"><span className="dot"></span>Alta prioridad</div>
+              <div className="n">3</div>
+              <div className="foot"><span><b>≥15 pts</b></span><span>+1 vs ayer</span></div>
+            </div>
+            <div className="kpi orange">
+              <div className="lbl"><span className="dot"></span>Media prioridad</div>
+              <div className="n">7</div>
+              <div className="foot"><span><b>8 – 14 pts</b></span><span>−2 vs ayer</span></div>
+            </div>
+            <div className="kpi gray">
+              <div className="lbl"><span className="dot"></span>Baja prioridad</div>
+              <div className="n">12</div>
+              <div className="foot"><span><b>&lt;8 pts</b></span><span>=  vs ayer</span></div>
+            </div>
+          </div>
+
+          <div className="table-wrap">
+            <div className="table-head">
+              <div>
+                <h2>Alumnos clasificados</h2>
+                <div className="meta"><b>22</b> alumnos analizados · ordenado por score descendente</div>
+              </div>
+              <div className="th-actions">
+                <div className="pill-tabs">
+                  <button className="active">Todos</button>
+                  <button>Alta</button>
+                  <button>Media</button>
+                  <button>Baja</button>
+                </div>
+                <button className="btn ghost sm">Exportar</button>
+              </div>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>Alumno</th>
+                  <th>Síntomas</th>
+                  <th className="num">Score <span className="so">▼</span></th>
+                  <th>Prioridad</th>
+                  <th>Última cita</th>
+                  <th>Acción</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ROWS.map((r,i)=><Row key={i} r={r}/>)}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="footnote">
+            <span className="ic">i</span>
+            Los resultados son orientativos y de apoyo al criterio médico. La clasificación no sustituye la evaluación clínica ni constituye un diagnóstico.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(<App/>);
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Recetas Doctor.html
+++ b/frontend/design-reference-dark/Recetas Doctor.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Recetas (Doctor)</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec; --primary-100:#d1e3d8;
+    --danger:#dc2626;
+    --bg:#f7f9f8; --surface:#fff;
+    --border:#2d3144; --border-strong:#cdd9d3;
+    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
+    --soft:#f9fafb;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body,#app{margin:0;padding:0;min-height:100vh}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+  input,select,textarea{font-family:inherit}
+
+  .app{display:flex;min-height:100vh;position:relative}
+
+  /* Sidebar */
+  .sb{width:240px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
+  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:32px;height:32px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
+  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
+  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
+  .sb nav a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;cursor:pointer}
+  .sb nav a:hover{background:rgba(255,255,255,.05)}
+  .sb nav a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
+  .sb nav a .ic{font-size:14px;width:16px;text-align:center}
+  .sb nav a .ct{margin-left:auto;background:var(--danger);color:#fff;font-size:10.5px;font-weight:700;padding:1px 7px;border-radius:999px;min-width:18px;text-align:center}
+  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
+  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
+  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px}
+
+  /* Main */
+  .main{flex:1;min-width:0;display:flex;flex-direction:column;padding-right:420px}
+  .header{padding:28px 36px 22px;background:#1a1d27;border-bottom:1px solid var(--border)}
+  .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:500;margin-bottom:6px}
+  h1{margin:0 0 18px;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .head-tools{display:flex;gap:12px;align-items:center}
+  .search{flex:1;background:var(--soft);border:1px solid var(--border);border-radius:8px;padding:10px 14px;display:flex;align-items:center;gap:10px;max-width:560px}
+  .search .ic{color:var(--text-subtle);font-size:14px}
+  .search input{flex:1;border:none;outline:none;background:transparent;font-size:13.5px;color:var(--text)}
+  .search input::placeholder{color:var(--text-subtle)}
+  .head-tools .filters-btn{padding:10px 14px;background:#1a1d27;border:1px solid var(--border);border-radius:8px;font-size:13px;color:var(--text-muted);font-weight:500;display:inline-flex;align-items:center;gap:7px}
+  .head-tools .filters-btn:hover{border-color:var(--primary);color:var(--primary)}
+  .head-tools .filters-btn .ct{background:var(--primary-50);color:var(--primary);font-size:11px;font-weight:700;padding:1px 6px;border-radius:999px}
+
+  .btn{padding:10px 16px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px;border:1px solid transparent;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.outline{background:#1a1d27;color:var(--primary);border-color:var(--primary)}
+  .btn.outline:hover{background:var(--primary-50)}
+  .btn.gray{background:#1a1d27;color:var(--text-muted);border-color:var(--border-strong)}
+  .btn.gray:hover{border-color:var(--text-muted);color:var(--text)}
+  .btn.sm{padding:7px 13px;font-size:12.5px}
+
+  .content{padding:24px 36px 40px;flex:1}
+
+  .table-wrap{background:#1a1d27;border:1px solid var(--border);border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04)}
+  .table-head{padding:14px 22px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border);font-size:12px;color:var(--text-subtle)}
+  .table-head b{color:var(--text-muted);font-weight:600}
+  .table-head .sort{display:flex;align-items:center;gap:8px}
+  .table-head select{background:#1a1d27;border:1px solid var(--border);border-radius:6px;padding:5px 9px;font-size:12.5px;color:var(--text-muted)}
+
+  .row{display:grid;grid-template-columns:auto 1fr auto 1.5fr auto;gap:18px;align-items:center;padding:16px 22px;border-bottom:1px solid var(--border)}
+  .row:last-child{border-bottom:none}
+  .row:hover{background:var(--soft)}
+  .row.sel{background:var(--primary-50);box-shadow:inset 3px 0 0 var(--primary)}
+  .row.sel:hover{background:#dceadf}
+
+  .av{width:42px;height:42px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14.5px;flex-shrink:0}
+
+  .who{min-width:0}
+  .who b{display:block;font-size:14px;font-weight:600;letter-spacing:-.1px}
+  .who span{font-size:12.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums;margin-top:1px;display:block}
+
+  .b-date{display:inline-flex;padding:5px 11px;border-radius:6px;font-size:10.5px;font-weight:700;letter-spacing:.5px;background:var(--primary-50);color:var(--primary);white-space:nowrap;align-items:center;gap:6px}
+  .b-date .dot{width:6px;height:6px;border-radius:50%;background:currentColor}
+
+  .meds{font-size:13px;color:var(--text-muted);line-height:1.45;min-width:0}
+  .meds .l{display:block;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin-bottom:3px}
+  .meds .mlist{color:var(--text)}
+  .meds .more{color:var(--text-subtle);font-weight:600;cursor:pointer}
+  .meds .more:hover{color:var(--primary)}
+
+  .actions{display:flex;gap:8px;justify-content:flex-end}
+
+  .pagination{display:flex;justify-content:space-between;align-items:center;padding:14px 22px;border-top:1px solid var(--border);font-size:12.5px;color:var(--text-subtle)}
+  .pagination .pages{display:flex;gap:4px;align-items:center}
+  .pagination .pages button{width:30px;height:30px;border-radius:6px;font-size:12.5px;color:var(--text-muted);font-weight:500;border:1px solid var(--border);background:#1a1d27}
+  .pagination .pages button:hover{border-color:var(--primary);color:var(--primary)}
+  .pagination .pages button.active{background:var(--primary);color:#fff;border-color:var(--primary)}
+  .pagination .pages .nav{padding:0 10px;width:auto}
+
+  /* Drawer */
+  .drawer{position:fixed;top:0;right:0;width:420px;height:100vh;background:#1a1d27;border-left:1px solid var(--border);box-shadow:-12px 0 32px rgba(26,46,37,.08);display:flex;flex-direction:column;z-index:50}
+  .drawer-head{padding:20px 22px 16px;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between}
+  .drawer-head h2{margin:0;font-size:17px;font-weight:700;letter-spacing:-.2px;display:flex;align-items:center;gap:8px}
+  .drawer-head h2 .ic{width:26px;height:26px;border-radius:6px;background:var(--primary-50);color:var(--primary);display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700}
+  .drawer-head .x{width:30px;height:30px;border-radius:6px;color:var(--text-subtle);font-size:18px;display:inline-flex;align-items:center;justify-content:center}
+  .drawer-head .x:hover{background:var(--bg);color:var(--text)}
+  .drawer-head .folio{font-size:11.5px;color:var(--text-subtle);margin-top:3px;font-variant-numeric:tabular-nums}
+
+  .drawer-body{flex:1;overflow-y:auto;padding:18px 22px 22px}
+
+  .d-patient{background:var(--soft);border:1px solid var(--border);border-radius:10px;padding:14px 16px;display:flex;gap:12px;align-items:center;margin-bottom:18px}
+  .d-patient .av{width:44px;height:44px;font-size:15px}
+  .d-patient .info b{display:block;font-size:14px;font-weight:600}
+  .d-patient .info .l{font-size:11.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums}
+  .d-patient .info .l b{display:inline;font-weight:600;color:var(--text-muted)}
+  .d-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:18px;font-size:12px}
+  .d-grid .cell{background:#1a1d27;border:1px solid var(--border);border-radius:8px;padding:9px 12px}
+  .d-grid .cell .l{font-size:10.5px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:600;margin-bottom:3px}
+  .d-grid .cell b{font-size:12.5px;color:var(--text);font-weight:600}
+
+  .d-section{margin-bottom:20px}
+  .d-section .head{font-size:10.5px;color:var(--text-subtle);font-weight:700;letter-spacing:.5px;text-transform:uppercase;margin-bottom:10px;display:flex;justify-content:space-between;align-items:baseline}
+  .d-section .head span{font-weight:600;color:var(--text-muted);text-transform:none;letter-spacing:0;font-size:11.5px}
+
+  .med{border:1px solid var(--border);border-radius:10px;padding:13px 14px;margin-bottom:9px;background:#1a1d27}
+  .med .top{display:flex;justify-content:space-between;align-items:flex-start;gap:10px;margin-bottom:4px}
+  .med .name{font-size:13.5px;font-weight:600;letter-spacing:-.1px}
+  .med .form{font-size:11px;font-weight:600;color:var(--primary);background:var(--primary-50);padding:2px 8px;border-radius:999px;text-transform:uppercase;letter-spacing:.4px;flex-shrink:0}
+  .med .dose{font-size:12.5px;color:var(--text-muted);margin-bottom:6px}
+  .med .ind{font-size:12.5px;color:var(--text);background:var(--soft);border-radius:6px;padding:8px 11px;line-height:1.45;border-left:2px solid var(--primary-100)}
+  .med .ind b{font-weight:600}
+
+  textarea.obs{width:100%;border:1px solid var(--border);border-radius:8px;padding:11px 13px;font-size:12.5px;color:var(--text);line-height:1.5;background:var(--soft);resize:none;outline:none;min-height:80px}
+  textarea.obs:focus{border-color:var(--primary);background:#1a1d27}
+
+  .drawer-foot{padding:14px 22px;border-top:1px solid var(--border);display:flex;gap:10px;background:#1a1d27}
+  .drawer-foot .btn{flex:1;justify-content:center}
+</style>
+</head>
+<body>
+<div id="app"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel">
+function Sidebar(){
+  const items=[
+    ['panel','Panel','▦'],
+    ['citas','Citas','⊞'],
+    ['bit','Bitácoras','≡'],
+    ['rec','Recetas','℞',true],
+    ['pe','Pre-evaluaciones','◔',false,3],
+    ['pri','Prioridad IA','◉'],
+    ['est','Estadísticas','◊'],
+  ];
+  return (
+    <aside className="sb">
+      <div className="brand"><div className="y">Y</div><div><b>Yoltec</b><span>Panel médico</span></div></div>
+      <nav>{items.map(([k,l,i,a,n])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}{n?<span className="ct">{n}</span>:null}</a>))}</nav>
+      <div className="user"><div className="av">OG</div><div><b>Dr. Omar González</b><span>Médico general</span></div></div>
+    </aside>
+  );
+}
+
+const RX=[
+  {
+    id:0, av:'AP', n:'Ana Pérez García', ctrl:'22690495', fecha:'7 ABR 2026',
+    meds:['Amoxicilina 500 mg cápsulas','Paracetamol 500 mg tabletas','Ibuprofeno 400 mg tabletas','Loratadina 10 mg tabletas'],
+    selected:true,
+  },
+  {
+    id:1, av:'RM', n:'Raúl Mendoza Vidal', ctrl:'22134781', fecha:'5 ABR 2026',
+    meds:['Sumatriptán 50 mg tabletas','Metoclopramida 10 mg tabletas','Naproxeno 250 mg tabletas'],
+  },
+  {
+    id:2, av:'JS', n:'Jorge Salinas Méndez', ctrl:'22789012', fecha:'2 ABR 2026',
+    meds:['Ambroxol 30 mg jarabe','Loratadina 10 mg tabletas'],
+  },
+  {
+    id:3, av:'KB', n:'Karla Bárcenas Ríos', ctrl:'21897603', fecha:'29 MAR 2026',
+    meds:['Diclofenaco 100 mg tabletas','Metocarbamol 750 mg tabletas','Omeprazol 20 mg cápsulas'],
+  },
+  {
+    id:4, av:'DK', n:'Diego Kuri Salazar', ctrl:'22034512', fecha:'24 MAR 2026',
+    meds:['Salbutamol inhalador 100 mcg','Beclometasona inhalador 250 mcg','Prednisona 5 mg tabletas','Loratadina 10 mg tabletas','Bromuro de ipratropio inhalador'],
+  },
+];
+
+function Row({r,onSel}){
+  const visibles=r.meds.slice(0,2);
+  const extra=r.meds.length-2;
+  return (
+    <div className={'row'+(r.selected?' sel':'')} onClick={()=>onSel(r.id)}>
+      <div className="av">{r.av}</div>
+      <div className="who"><b>{r.n}</b><span>No. {r.ctrl}</span></div>
+      <span className="b-date"><span className="dot"></span>Emitida {r.fecha}</span>
+      <div className="meds">
+        <span className="l">Medicamentos</span>
+        <span className="mlist">{visibles.join(' · ')}</span>
+        {extra>0 && <> · <span className="more">+ {extra} más</span></>}
+      </div>
+      <div className="actions">
+        <button className="btn outline sm">Ver detalle</button>
+        <button className="btn gray sm">Editar</button>
+      </div>
+    </div>
+  );
+}
+
+function Drawer(){
+  return (
+    <aside className="drawer">
+      <div className="drawer-head">
+        <div>
+          <h2><span className="ic">℞</span>Receta médica</h2>
+          <div className="folio">Folio RX-2026-0319 · Emitida 7 abr 2026</div>
+        </div>
+        <button className="x" title="Cerrar">×</button>
+      </div>
+
+      <div className="drawer-body">
+        <div className="d-patient">
+          <div className="av">AP</div>
+          <div className="info">
+            <b>Ana Pérez García</b>
+            <span className="l">Matrícula <b>22690495</b> · Ing. Industrial · 5°</span>
+          </div>
+        </div>
+
+        <div className="d-grid">
+          <div className="cell"><div className="l">Diagnóstico</div><b>Faringitis aguda (J02.9)</b></div>
+          <div className="cell"><div className="l">Cita asociada</div><b>7 abr · 10:30</b></div>
+          <div className="cell"><div className="l">Vigencia</div><b>14 días · hasta 21 abr</b></div>
+          <div className="cell"><div className="l">Alergias</div><b style={{color:'var(--danger)'}}>Penicilina</b></div>
+        </div>
+
+        <div className="d-section">
+          <div className="head"><span>Medicamentos prescritos</span><span>4 medicamentos</span></div>
+
+          <div className="med">
+            <div className="top">
+              <div className="name">Amoxicilina 500 mg</div>
+              <div className="form">Cápsulas</div>
+            </div>
+            <div className="dose">1 cápsula cada 8 h · 7 días · vía oral</div>
+            <div className="ind"><b>Indicaciones:</b> Tomar con alimentos. No interrumpir el tratamiento aunque mejoren los síntomas.</div>
+          </div>
+
+          <div className="med">
+            <div className="top">
+              <div className="name">Paracetamol 500 mg</div>
+              <div className="form">Tabletas</div>
+            </div>
+            <div className="dose">1 tableta cada 6 h · por razón necesaria · máximo 4 al día</div>
+            <div className="ind"><b>Indicaciones:</b> Para fiebre o dolor. Suspender si síntomas ceden por 48 h.</div>
+          </div>
+
+          <div className="med">
+            <div className="top">
+              <div className="name">Ibuprofeno 400 mg</div>
+              <div className="form">Tabletas</div>
+            </div>
+            <div className="dose">1 tableta cada 8 h · 5 días · con alimentos</div>
+            <div className="ind"><b>Indicaciones:</b> Antiinflamatorio. Suspender si hay molestias gástricas.</div>
+          </div>
+
+          <div className="med">
+            <div className="top">
+              <div className="name">Loratadina 10 mg</div>
+              <div className="form">Tabletas</div>
+            </div>
+            <div className="dose">1 tableta cada 24 h · 7 días · vía oral</div>
+            <div className="ind"><b>Indicaciones:</b> Tomar por la mañana. No mezclar con bebidas alcohólicas.</div>
+          </div>
+        </div>
+
+        <div className="d-section">
+          <div className="head"><span>Observaciones del doctor</span></div>
+          <textarea className="obs" defaultValue="Reposo relativo por 48 h. Hidratación abundante (≥ 2 L/día). Gárgaras con agua tibia y sal cada 6 h. Si persiste fiebre &gt; 38.5 °C tras 72 h de antibiótico o aparece dificultad respiratoria, acudir a urgencias."/>
+        </div>
+      </div>
+
+      <div className="drawer-foot">
+        <button className="btn gray">Cerrar</button>
+        <button className="btn primary">Editar receta</button>
+      </div>
+    </aside>
+  );
+}
+
+function App(){
+  const [sel,setSel]=React.useState(0);
+  return (
+    <div className="app">
+      <Sidebar/>
+      <div className="main">
+        <div className="header">
+          <div className="crumb">Servicio médico · Recetas</div>
+          <h1>Gestión de Recetas</h1>
+          <div className="head-tools">
+            <div className="search">
+              <span className="ic">⌕</span>
+              <input placeholder="Buscar por alumno, número de control o medicamento…"/>
+            </div>
+            <button className="filters-btn">⊟ Filtros <span className="ct">2</span></button>
+            <button className="btn primary">+ Nueva receta</button>
+          </div>
+        </div>
+
+        <div className="content">
+          <div className="table-wrap">
+            <div className="table-head">
+              <span><b>5</b> de <b>23</b> recetas · mes en curso</span>
+              <div className="sort">
+                <span>Ordenar por</span>
+                <select defaultValue="reciente"><option value="reciente">Más recientes</option><option>Alumno</option><option>Vigencia</option></select>
+              </div>
+            </div>
+            {RX.map(r=><Row key={r.id} r={{...r,selected:r.id===sel}} onSel={setSel}/>)}
+            <div className="pagination">
+              <span>Mostrando 1–5 de 23</span>
+              <div className="pages">
+                <button className="nav">‹ Anterior</button>
+                <button className="active">1</button>
+                <button>2</button>
+                <span style={{padding:'0 4px',color:'var(--text-subtle)'}}>1 / 2</span>
+                <button className="nav">Siguiente ›</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Drawer/>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(<App/>);
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference-dark/Usuarios Admin.html
+++ b/frontend/design-reference-dark/Usuarios Admin.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec Admin · Usuarios</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-300:#3a7d5c; --primary-50:#e8f5ee;
+    --bg:#f8fafc; --surface:#fff;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#eef2f0;
+    --blue-bg:#dbeafe; --blue:#1d4ed8;
+    --danger:#dc2626; --danger-bg:#fef2f2;
+    --gray-dark:#374151; --gray-dark-bg:#2d3144;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar */
+  .side{width:220px;background:var(--primary);color:#fff;display:flex;flex-direction:column;flex-shrink:0;padding:22px 0}
+  .side .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;letter-spacing:-.2px}
+  .side .brand .y{width:28px;height:28px;border-radius:7px;background:#1a1d27;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .side nav{display:flex;flex-direction:column;gap:2px;padding:0 12px;flex:1}
+  .side nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;text-decoration:none;cursor:pointer}
+  .side nav a svg{width:18px;height:18px;stroke-width:1.8;flex-shrink:0;opacity:.9}
+  .side nav a:hover{background:rgba(255,255,255,.06);color:#fff}
+  .side nav a.active{background:var(--primary-300);color:#fff;font-weight:600}
+  .side nav a.disabled{color:rgba(255,255,255,.55);cursor:default}
+  .side nav a.disabled:hover{background:transparent;color:rgba(255,255,255,.55)}
+  .side nav a .soon{margin-left:auto;font-size:9.5px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;background:rgba(255,255,255,.14);color:rgba(255,255,255,.75);padding:2px 6px;border-radius:99px;white-space:nowrap}
+  .side .user{padding:14px 16px;border-top:1px solid rgba(255,255,255,.12);margin:12px 12px 0;display:flex;align-items:center;gap:10px}
+  .side .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .side .user .nm{font-size:13px;font-weight:600;color:#fff;line-height:1.2}
+  .side .user .rl{font-size:11px;color:rgba(255,255,255,.65);margin-top:2px}
+
+  /* Main */
+  .main{flex:1;padding:28px 32px 48px;min-width:0}
+  .hd{margin-bottom:20px}
+  .hd h1{margin:0 0 16px;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .toolbar{display:flex;align-items:center;gap:12px}
+  .search{position:relative;flex:1;max-width:520px}
+  .search svg{position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-subtle)}
+  .search input{width:100%;height:38px;border:1px solid var(--border);border-radius:8px;background:#1a1d27;padding:0 12px 0 38px;font:500 13px 'Inter',sans-serif;color:var(--text);outline:none}
+  .search input:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.12)}
+  .btn-pri{display:inline-flex;align-items:center;gap:6px;background:var(--primary);color:#fff;font:600 13px 'Inter',sans-serif;padding:9px 14px;border:0;border-radius:7px;cursor:pointer}
+  .btn-pri:hover{background:var(--primary-600)}
+  .btn-gh{display:inline-flex;align-items:center;gap:6px;background:#1a1d27;color:var(--text);font:500 13px 'Inter',sans-serif;padding:8px 14px;border:1px solid var(--border);border-radius:7px;cursor:pointer}
+  .btn-gh:hover{background:#fafbfb}
+  .btn-gh svg{stroke-width:2}
+
+  /* Tabs */
+  .tabs{display:flex;gap:2px;border-bottom:1px solid var(--border);margin:20px 0 0}
+  .tab{padding:11px 16px;font-size:13px;font-weight:500;color:var(--text-muted);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
+  .tab.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+  .tab .ct{display:inline-flex;background:#f1f5f9;color:var(--text-muted);font-size:11px;padding:1px 7px;border-radius:99px;margin-left:6px;font-weight:600}
+  .tab.active .ct{background:var(--primary-50);color:var(--primary)}
+
+  /* Section */
+  .sec{background:#1a1d27;border-radius:0 0 12px 12px;border:1px solid var(--border-soft);border-top:0;box-shadow:0 1px 2px rgba(15,23,42,.04)}
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  th{text-align:left;padding:11px 16px;font-size:11px;font-weight:600;color:var(--text-muted);letter-spacing:.4px;text-transform:uppercase;background:#fafbfb;border-bottom:1px solid var(--border-soft)}
+  th:first-child,td:first-child{padding-left:20px;width:36px}
+  td{padding:13px 16px;border-bottom:1px solid var(--border-soft);vertical-align:middle}
+  tr:last-child td{border-bottom:0}
+  tr:hover td{background:#fbfcfc}
+
+  input[type=checkbox]{appearance:none;width:16px;height:16px;border:1.5px solid var(--border);border-radius:4px;background:#1a1d27;cursor:pointer;position:relative;vertical-align:middle}
+  input[type=checkbox]:checked{background:var(--primary);border-color:var(--primary)}
+  input[type=checkbox]:checked::after{content:'';position:absolute;top:1px;left:4px;width:5px;height:9px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}
+
+  .uc{display:flex;align-items:center;gap:10px}
+  .uc .av{width:32px;height:32px;border-radius:50%;background:#2d3144;color:#374151;display:flex;align-items:center;justify-content:center;font-weight:600;font-size:11.5px;flex-shrink:0}
+  .uc .av.dc{background:#e8f5ee;color:#1a5c3a}
+  .uc .nm{font-weight:600;color:var(--text);font-size:13px;line-height:1.2}
+  .uc .id{font-size:11.5px;color:var(--text-subtle);font-weight:500;margin-top:2px;font-variant-numeric:tabular-nums}
+  .em{color:var(--text-muted);font-size:12.5px}
+  .bd{display:inline-flex;font-size:11px;font-weight:600;padding:3px 8px;border-radius:5px;letter-spacing:.2px}
+  .bd-al{background:var(--blue-bg);color:var(--blue)}
+  .bd-dc{background:var(--primary-50);color:var(--primary)}
+  .bd-ac{background:var(--primary-50);color:var(--primary)}
+  .bd-su{background:var(--danger-bg);color:var(--danger)}
+  .ls{font-size:12.5px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  .acts{display:flex;gap:14px}
+  .acts a{font-size:12.5px;font-weight:500;cursor:pointer;text-decoration:none;color:var(--primary)}
+  .acts a.warn{color:var(--danger)}
+  .acts a.gh{color:var(--text-muted)}
+  .acts a:hover{text-decoration:underline}
+
+  /* Footer / pagination */
+  .pag{display:flex;align-items:center;justify-content:space-between;padding:14px 20px;border-top:1px solid var(--border-soft);font-size:12.5px;color:var(--text-muted);font-weight:500}
+  .pag .pgr{display:flex;gap:4px}
+  .pag .pgr button{width:30px;height:30px;border:1px solid var(--border);background:#1a1d27;color:var(--text);border-radius:6px;font:500 12.5px 'Inter',sans-serif;cursor:pointer;font-variant-numeric:tabular-nums}
+  .pag .pgr button.active{background:var(--primary);color:#fff;border-color:var(--primary);font-weight:600}
+  .pag .pgr button:hover:not(.active){background:#fafbfb}
+  .pag .pgr button.nav{padding:0 8px;width:auto}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="side">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
+        Panel
+      </a>
+      <a class="active">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.5"/><path d="M2.5 20c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6"/><circle cx="17" cy="8" r="3"/><path d="M16 14c2.7.2 5 2.5 5 5.5"/></svg>
+        Usuarios
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/><circle cx="12" cy="15" r="1.5" fill="currentColor"/></svg>
+        Días especiales
+      </a>
+      <a class="disabled">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>
+        Auditoría
+        <span class="soon">Próximamente</span>
+      </a>
+    </nav>
+    <div class="user">
+      <div class="av">MA</div>
+      <div>
+        <div class="nm">Marco Admin</div>
+        <div class="rl">Administrador</div>
+      </div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="hd">
+      <h1>Gestión de usuarios</h1>
+      <div class="toolbar">
+        <div class="search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+          <input placeholder="Buscar por nombre, número de control o correo...">
+        </div>
+        <button class="btn-pri">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+          Nuevo usuario
+        </button>
+      </div>
+      <div class="tabs">
+        <div class="tab active">Todos<span class="ct">48</span></div>
+        <div class="tab">Alumnos<span class="ct">42</span></div>
+        <div class="tab">Doctores<span class="ct">5</span></div>
+        <div class="tab">Suspendidos<span class="ct">3</span></div>
+      </div>
+    </div>
+
+    <section class="sec">
+      <table>
+        <thead>
+          <tr>
+            <th><input type="checkbox"></th>
+            <th>Usuario</th>
+            <th>Correo institucional</th>
+            <th>Rol</th>
+            <th>Estatus</th>
+            <th>Última sesión</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><input type="checkbox"></td>
+            <td><div class="uc"><div class="av">NV</div><div><div class="nm">Nestor Valles</div><div class="id">22690495</div></div></div></td>
+            <td class="em">22690495@tecvm.mx</td>
+            <td><span class="bd bd-al">Alumno</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Hoy, 10:14</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox" checked></td>
+            <td><div class="uc"><div class="av dc">LR</div><div><div class="nm">Dra. Laura Ramírez</div><div class="id">DOC-0014</div></div></div></td>
+            <td class="em">dr.ramirez@tecvm.mx</td>
+            <td><span class="bd bd-dc">Doctor</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Hoy, 11:42</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox"></td>
+            <td><div class="uc"><div class="av">SO</div><div><div class="nm">Sofía Ortega</div><div class="id">22810123</div></div></div></td>
+            <td class="em">22810123@tecvm.mx</td>
+            <td><span class="bd bd-al">Alumno</span></td>
+            <td><span class="bd bd-su">Suspendido</span></td>
+            <td class="ls">02 may, 16:08</td>
+            <td><div class="acts"><a>Editar</a><a class="gh">Reactivar</a></div></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox"></td>
+            <td><div class="uc"><div class="av dc">JM</div><div><div class="nm">Dr. Javier Mendoza</div><div class="id">DOC-0021</div></div></div></td>
+            <td class="em">dr.mendoza@tecvm.mx</td>
+            <td><span class="bd bd-dc">Doctor</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Ayer, 18:22</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox"></td>
+            <td><div class="uc"><div class="av">AC</div><div><div class="nm">Andrea Castillo</div><div class="id">22745880</div></div></div></td>
+            <td class="em">22745880@tecvm.mx</td>
+            <td><span class="bd bd-al">Alumno</span></td>
+            <td><span class="bd bd-ac">Activo</span></td>
+            <td class="ls">Ayer, 09:47</td>
+            <td><div class="acts"><a>Editar</a><a class="warn">Suspender</a></div></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox"></td>
+            <td><div class="uc"><div class="av">RG</div><div><div class="nm">Ricardo Galván</div><div class="id">22912034</div></div></div></td>
+            <td class="em">22912034@tecvm.mx</td>
+            <td><span class="bd bd-al">Alumno</span></td>
+            <td><span class="bd bd-su">Suspendido</span></td>
+            <td class="ls">28 abr, 13:55</td>
+            <td><div class="acts"><a>Editar</a><a class="gh">Reactivar</a></div></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="pag">
+        <span>Mostrando 1–6 de 48 usuarios</span>
+        <div class="pgr">
+          <button class="nav">‹ Anterior</button>
+          <button class="active">1</button>
+          <button>2</button>
+          <button>3</button>
+          <button>…</button>
+          <button>8</button>
+          <button class="nav">Siguiente ›</button>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/frontend/design-reference/Citas Doctor.html
+++ b/frontend/design-reference/Citas Doctor.html
@@ -1,0 +1,732 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Citas (Doctor)</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee; --primary-100:#d1e3d8;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#f3f4f6;
+    --bg:#f8fafc; --chip-bg:#f3f4f6; --soft:#f9fafb;
+    --danger:#dc2626; --danger-50:#fef2f2;
+    --warn:#b45309; --warn-50:#fef3c7;
+    --info:#1d4ed8; --info-50:#dbeafe;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit;font-size:inherit}
+  input,select{font-family:inherit;color:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar Doctor */
+  .sb{width:240px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column;padding:22px 0}
+  .sb .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:28px;height:28px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb nav{display:flex;flex-direction:column;gap:2px;padding:14px 12px 0;flex:1}
+  .sb nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;cursor:pointer;text-decoration:none}
+  .sb nav a:hover{background:rgba(255,255,255,.05);color:#fff}
+  .sb nav a.active{background:rgba(255,255,255,.1);color:#fff;font-weight:600}
+  .sb nav a svg{width:16px;height:16px;stroke-width:1.8;flex-shrink:0}
+  .sb nav a .ct{margin-left:auto;background:var(--danger);color:#fff;font-size:10.5px;font-weight:700;padding:1px 6px;border-radius:99px}
+  .sb .user{margin-top:auto;padding:14px 18px 4px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .sb .user b{display:block;font-size:13px;font-weight:600}
+  .sb .user span{font-size:11px;color:rgba(255,255,255,.65)}
+
+  .main{flex:1;min-width:0;padding:28px 32px 32px}
+  .head{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:18px;flex-wrap:wrap;gap:14px}
+  .crumb{font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.5px;font-weight:600;margin-bottom:6px}
+  h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .sub{font-size:13.5px;color:var(--text-muted);margin-top:4px}
+
+  .btn{padding:9px 14px;border-radius:7px;font:600 13px 'Inter',sans-serif;cursor:pointer;display:inline-flex;align-items:center;gap:7px;border:1px solid transparent;white-space:nowrap}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.outline{background:#fff;color:var(--primary);border-color:var(--primary)}
+  .btn.outline:hover{background:var(--primary-50)}
+  .btn.ghost{color:var(--text-muted);background:transparent}
+  .btn.ghost:hover{background:var(--chip-bg);color:var(--text)}
+  .btn.sm{padding:6px 11px;font-size:12.5px}
+
+  /* KPIs */
+  .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
+  .kpi{background:#fff;border-radius:10px;border:1px solid var(--border-soft);padding:14px 16px;display:flex;align-items:center;gap:12px}
+  .kpi .ic{width:36px;height:36px;border-radius:9px;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;flex-shrink:0}
+  .kpi .ic svg{width:16px;height:16px;stroke-width:1.8}
+  .kpi .lbl{font-size:11px;color:var(--text-muted);font-weight:600;letter-spacing:.3px;text-transform:uppercase}
+  .kpi .v{font-size:20px;font-weight:700;letter-spacing:-.4px}
+  .kpi.warn .ic{background:var(--warn-50);color:var(--warn)}
+  .kpi.danger .ic{background:var(--danger-50);color:var(--danger)}
+  .kpi.info .ic{background:var(--info-50);color:var(--info)}
+
+  /* Toolbar */
+  .toolbar{background:#fff;border-radius:10px;padding:12px 14px;display:flex;gap:10px;align-items:center;margin-bottom:14px;flex-wrap:wrap;border:1px solid var(--border-soft)}
+  .view-pill{display:inline-flex;background:var(--chip-bg);border-radius:8px;padding:3px;gap:2px}
+  .view-pill button{padding:6px 12px;font:600 12.5px 'Inter',sans-serif;color:var(--text-muted);border-radius:6px}
+  .view-pill button.active{background:#fff;color:var(--text);box-shadow:0 1px 2px rgba(0,0,0,.06)}
+  .toolbar .nav-day{display:inline-flex;align-items:center;gap:6px;margin-left:6px}
+  .toolbar .nav-day b{font-size:13.5px;font-weight:600;letter-spacing:-.1px;text-transform:capitalize;padding:0 6px;font-variant-numeric:tabular-nums}
+  .nav-btn{width:28px;height:28px;border:1px solid var(--border);background:#fff;border-radius:6px;color:var(--text-muted);display:inline-flex;align-items:center;justify-content:center}
+  .nav-btn:hover{border-color:var(--primary);color:var(--primary)}
+  .spacer{flex:1}
+  .search{position:relative;width:220px}
+  .search svg{position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-subtle)}
+  .search input{width:100%;height:34px;background:var(--soft);border:1px solid var(--border);border-radius:7px;padding:0 12px 0 36px;font:500 12.5px 'Inter',sans-serif;outline:none}
+  .search input:focus{border-color:var(--primary);box-shadow:0 0 0 3px var(--primary-50)}
+  .filter-sel{height:34px;padding:0 30px 0 12px;background:#fff;border:1px solid var(--border);border-radius:7px;font:500 12.5px 'Inter',sans-serif;color:var(--text);appearance:none;background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");background-repeat:no-repeat;background-position:right 10px center}
+
+  /* Body grid: day schedule + sidebar (next cita + mini cal) */
+  .grid{display:grid;grid-template-columns:1fr 320px;gap:16px;align-items:start}
+
+  .card{background:#fff;border-radius:12px;border:1px solid var(--border-soft);box-shadow:0 1px 3px rgba(0,0,0,.04);overflow:hidden}
+  .card-h{padding:14px 18px;border-bottom:1px solid var(--border-soft);display:flex;justify-content:space-between;align-items:center}
+  .card-h h2{margin:0;font-size:14px;font-weight:600;letter-spacing:-.1px}
+  .card-h .meta{font-size:11.5px;color:var(--text-subtle);font-weight:500}
+
+  /* Schedule */
+  .sched{display:flex;flex-direction:column}
+  .slot{display:grid;grid-template-columns:64px 1fr;gap:14px;padding:0 18px;border-bottom:1px solid var(--border-soft);min-height:62px;position:relative}
+  .slot:last-child{border-bottom:none}
+  .slot .h{padding-top:14px;font-size:12px;color:var(--text-muted);font-weight:600;font-variant-numeric:tabular-nums}
+  .slot .h small{display:block;font-size:10.5px;color:var(--text-subtle);font-weight:500;margin-top:2px}
+  .slot-card{margin:10px 0;padding:10px 12px;border-radius:8px;border-left:3px solid var(--primary);background:var(--primary-50);display:flex;align-items:center;gap:10px;cursor:pointer;transition:background .15s}
+  .slot-card:hover{background:#d8e8e0}
+  .slot-card.warn{border-left-color:var(--warn);background:var(--warn-50)}
+  .slot-card.warn:hover{background:#fbe7b8}
+  .slot-card.info{border-left-color:var(--info);background:var(--info-50)}
+  .slot-card.info:hover{background:#c2d6f9}
+  .slot-card.busy{border-left-color:var(--text-subtle);background:var(--chip-bg);color:var(--text-muted)}
+  .slot-card .av{width:30px;height:30px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:11px;flex-shrink:0}
+  .slot-card.warn .av{background:var(--warn)}
+  .slot-card.info .av{background:var(--info)}
+  .slot-card.busy .av{background:var(--text-subtle)}
+  .slot-card .who{flex:1;min-width:0}
+  .slot-card .who b{display:block;font-size:13px;font-weight:600;color:var(--text);letter-spacing:-.1px}
+  .slot-card .who span{display:block;font-size:11.5px;color:var(--text-muted);margin-top:1px}
+  .slot-card.busy .who b{color:var(--text-muted);font-weight:500}
+  .slot-card .badge{font-size:10px;font-weight:700;padding:2px 7px;border-radius:99px;text-transform:uppercase;letter-spacing:.3px;background:rgba(26,92,58,.18);color:var(--primary)}
+  .slot-card.warn .badge{background:rgba(180,83,9,.18);color:var(--warn)}
+  .slot-card.info .badge{background:rgba(29,78,216,.18);color:var(--info)}
+  .slot.empty .slot-card{background:repeating-linear-gradient(45deg,transparent,transparent 8px,var(--soft) 8px,var(--soft) 14px);border-left-color:transparent;color:var(--text-subtle);cursor:default}
+  .slot.empty .slot-card:hover{background:repeating-linear-gradient(45deg,transparent,transparent 8px,var(--soft) 8px,var(--soft) 14px)}
+  .add-slot{display:inline-flex;align-items:center;gap:5px;color:var(--text-subtle);font-size:11.5px;font-weight:500;cursor:pointer}
+  .add-slot:hover{color:var(--primary)}
+  .add-slot svg{width:12px;height:12px;stroke-width:2}
+
+  .now-line{position:absolute;left:0;right:0;height:2px;background:var(--danger);z-index:2}
+  .now-line::before{content:'';position:absolute;left:14px;top:-4px;width:10px;height:10px;border-radius:50%;background:var(--danger);box-shadow:0 0 0 4px rgba(220,38,38,.15)}
+  .now-label{position:absolute;left:14px;top:-22px;font-size:10px;font-weight:700;color:var(--danger);background:#fff;padding:2px 6px;border-radius:99px;letter-spacing:.3px}
+
+  /* Right column */
+  .next-cita{padding:14px 18px}
+  .next-cita .av-row{display:flex;align-items:center;gap:11px;margin-bottom:12px}
+  .next-cita .av{width:42px;height:42px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px}
+  .next-cita .who b{display:block;font-size:14px;font-weight:600}
+  .next-cita .who span{font-size:11.5px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  .next-cita .row{display:flex;justify-content:space-between;padding:7px 0;border-bottom:1px dashed var(--border-soft);font-size:12.5px}
+  .next-cita .row:last-of-type{border-bottom:0}
+  .next-cita .row .k{color:var(--text-muted);font-weight:500}
+  .next-cita .row .v{color:var(--text);font-weight:600}
+  .next-cita .countdown{margin-top:10px;background:var(--primary-50);color:var(--primary);font-size:11.5px;font-weight:600;padding:6px 10px;border-radius:7px;text-align:center}
+  .next-cita .actions-row{display:flex;gap:6px;margin-top:12px}
+  .next-cita .actions-row .btn{flex:1;justify-content:center;padding:8px 6px}
+
+  /* Mini cal */
+  .mini-cal{padding:14px 18px 18px}
+  .mini-cal .nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+  .mini-cal .nav b{font-size:13px;font-weight:600;text-transform:capitalize}
+  .mini-cal .grid{display:grid;grid-template-columns:repeat(7,1fr);gap:4px}
+  .mini-cal .dh{font-size:10.5px;font-weight:600;color:var(--text-subtle);text-align:center;padding:4px 0;letter-spacing:.3px;text-transform:uppercase}
+  .mini-cal .d{aspect-ratio:1;font-size:11.5px;font-weight:500;color:var(--text);display:flex;flex-direction:column;align-items:center;justify-content:center;border-radius:6px;cursor:pointer;gap:2px}
+  .mini-cal .d:hover{background:var(--chip-bg)}
+  .mini-cal .d.past{color:var(--text-subtle)}
+  .mini-cal .d.sel{background:var(--primary);color:#fff;font-weight:700}
+  .mini-cal .d.sel .dot{background:#fff}
+  .mini-cal .d .dot{width:4px;height:4px;border-radius:50%;background:var(--primary);visibility:hidden}
+  .mini-cal .d.has .dot{visibility:visible}
+
+  /* MODAL OVERLAY */
+  .overlay-wrap{position:relative;margin-top:24px}
+  .overlay{position:relative;background:rgba(15,30,22,.45);border-radius:14px;padding:24px}
+  .modal{max-width:560px;margin:0 auto;background:#fff;border-radius:14px;box-shadow:0 28px 80px rgba(20,40,30,.18);overflow:hidden;display:flex;flex-direction:column}
+  .mh{padding:18px 22px;border-bottom:1px solid var(--border)}
+  .mh-top{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:14px}
+  .mh h2{margin:0 0 2px;font-size:17px;font-weight:700;letter-spacing:-.2px}
+  .mh .ssub{font-size:12.5px;color:var(--text-muted)}
+  .steps{display:flex;align-items:center;gap:6px}
+  .step{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-subtle);font-weight:500;flex:1}
+  .step .n{width:22px;height:22px;border-radius:50%;background:var(--chip-bg);color:var(--text-subtle);font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;border:1px solid var(--border)}
+  .step.active{color:var(--primary);font-weight:600}
+  .step.active .n{background:var(--primary);color:#fff;border-color:var(--primary)}
+  .step.done{color:var(--text)}
+  .step.done .n{background:var(--primary-50);color:var(--primary);border-color:var(--primary-100)}
+  .arr{color:var(--text-subtle);font-size:13px}
+
+  .mb{padding:18px 22px;flex:1;overflow-y:auto}
+  .selected-st{display:flex;align-items:center;gap:10px;padding:10px 12px;background:var(--primary-50);border-radius:8px;margin-bottom:16px}
+  .selected-st .av{width:30px;height:30px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:11px;flex-shrink:0}
+  .selected-st .who{flex:1;min-width:0}
+  .selected-st .who b{display:block;font-size:13px;font-weight:600}
+  .selected-st .who span{font-size:11px;color:var(--text-muted)}
+  .selected-st .change{font-size:12px;color:var(--primary);font-weight:600;background:none;border:0;cursor:pointer}
+
+  .cal-nav{display:flex;align-items:center;justify-content:space-between;padding-bottom:10px}
+  .cal-nav b{font-size:13.5px;font-weight:600;text-transform:capitalize}
+  .cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:4px}
+  .cal-dow{font-size:10px;font-weight:600;color:var(--text-subtle);letter-spacing:.4px;text-align:center;text-transform:uppercase;padding:4px 0}
+  .day{aspect-ratio:1;border-radius:7px;display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:12px;font-weight:500;color:var(--text);cursor:pointer}
+  .day .num{font-size:13px;font-weight:600}
+  .day .sub{font-size:9px;font-weight:600;color:var(--primary);margin-top:1px}
+  .day.past{color:var(--text-subtle);cursor:default}
+  .day.past .sub{display:none}
+  .day:hover:not(.past):not(.sel){background:var(--chip-bg)}
+  .day.full{background:var(--danger-50);color:var(--danger);cursor:not-allowed}
+  .day.full .sub{color:var(--danger)}
+  .day.low .sub{color:var(--warn)}
+  .day.sel{background:var(--primary);color:#fff}
+  .day.sel .sub{color:#fff}
+
+  .slot-section{margin-top:16px}
+  .slot-section .lbl{font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin-bottom:8px}
+  .slots{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+  .ss{padding:8px 6px;border:1px solid var(--border);border-radius:6px;background:#fff;font-size:12px;font-weight:600;text-align:center;cursor:pointer;font-variant-numeric:tabular-nums}
+  .ss:hover{border-color:var(--primary);color:var(--primary)}
+  .ss.sel{background:var(--primary);color:#fff;border-color:var(--primary)}
+  .ss.taken{background:var(--chip-bg);color:var(--text-subtle);cursor:not-allowed;text-decoration:line-through}
+
+  .mf{padding:12px 22px;background:var(--soft);border-top:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;gap:10px}
+  .mf .left{font-size:11.5px;color:var(--text-subtle)}
+  .mf .actions{display:flex;gap:8px}
+
+  .scope{display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:700;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;margin:24px 32px 6px}
+  .scope::after{content:'';height:1px;background:var(--border);flex:1;width:160px;display:inline-block;margin-left:8px}
+
+  /* Detail drawer card */
+  .detail-side{position:absolute;right:0;top:0;bottom:0;width:340px;background:#fff;border-left:1px solid var(--border);box-shadow:-10px 0 30px rgba(0,0,0,.06);overflow:hidden;display:flex;flex-direction:column}
+  .detail-hd{padding:16px 18px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:flex-start}
+  .detail-hd h3{margin:0;font-size:15px;font-weight:700}
+  .detail-bd{padding:16px 18px;flex:1;overflow:auto}
+  .detail-bd .who-card{display:flex;align-items:center;gap:11px;margin-bottom:14px}
+  .detail-bd .who-card .av{width:42px;height:42px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px}
+  .detail-bd .who-card b{display:block;font-size:14.5px;font-weight:600}
+  .detail-bd .who-card span{font-size:11.5px;color:var(--text-muted)}
+  .detail-bd h4{margin:14px 0 6px;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .detail-bd .kv{font-size:12.5px;color:var(--text);line-height:1.5}
+  .detail-bd .kv b{color:var(--text);font-weight:600}
+  .detail-bd .pill-list{display:flex;flex-wrap:wrap;gap:5px}
+  .detail-bd .pill{background:var(--warn-50);color:var(--warn);font-size:11px;font-weight:500;padding:3px 9px;border-radius:99px}
+  .detail-foot{padding:12px 18px;border-top:1px solid var(--border);background:var(--soft);display:flex;gap:6px}
+  .detail-foot .btn{flex:1;justify-content:center;font-size:12px}
+
+  .with-drawer{position:relative;padding-right:340px}
+</style>
+</head>
+<body>
+
+<!-- VISTA A · Citas del día (default) -->
+<div class="scope">Vista A · Agenda del día</div>
+<div class="app">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>Panel</a>
+      <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Citas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>Bitácoras</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>Pre-evaluaciones<span class="ct">3</span></a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="9"/></svg>Prioridad IA</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21V10l9-7 9 7v11"/><path d="M9 21v-7h6v7"/></svg>Estadísticas</a>
+    </nav>
+    <div class="user">
+      <div class="av">OG</div>
+      <div><b>Dr. Omar González</b><span>Médico general</span></div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="head">
+      <div>
+        <div class="crumb">Citas</div>
+        <h1>Citas</h1>
+        <div class="sub">Gestiona la agenda del consultorio. Hoy tienes 6 citas confirmadas y 1 espacio libre.</div>
+      </div>
+      <div style="display:flex;gap:10px;align-items:flex-end">
+        <button class="btn outline">Exportar agenda</button>
+        <button class="btn primary"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>Nueva cita</button>
+      </div>
+    </div>
+
+    <div class="kpis">
+      <div class="kpi"><div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg></div><div><div class="lbl">Citas hoy</div><div class="v">7</div></div></div>
+      <div class="kpi info"><div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></div><div><div class="lbl">Próxima</div><div class="v">10:30</div></div></div>
+      <div class="kpi warn"><div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16v.01"/></svg></div><div><div class="lbl">Pendientes confirmar</div><div class="v">2</div></div></div>
+      <div class="kpi danger"><div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 9l6 6M15 9l-6 6"/></svg></div><div><div class="lbl">Canceladas hoy</div><div class="v">1</div></div></div>
+    </div>
+
+    <div class="toolbar">
+      <div class="view-pill">
+        <button class="active">Día</button>
+        <button>Semana</button>
+        <button>Mes</button>
+        <button>Lista</button>
+      </div>
+      <div class="nav-day">
+        <button class="nav-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <b>Miércoles 13 mayo 2026</b>
+        <button class="nav-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg></button>
+        <button class="btn ghost sm" style="margin-left:6px">Hoy</button>
+      </div>
+      <div class="spacer"></div>
+      <div class="search">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+        <input placeholder="Buscar alumno...">
+      </div>
+      <select class="filter-sel">
+        <option>Todos los estatus</option><option>Confirmadas</option><option>Pendientes</option><option>Canceladas</option>
+      </select>
+    </div>
+
+    <div class="grid">
+      <div class="card">
+        <div class="card-h"><h2>Agenda de hoy</h2><span class="meta">8:00 – 17:00 · 9 espacios</span></div>
+        <div class="sched">
+          <div class="slot">
+            <div class="h">08:00<small>15 min</small></div>
+            <div class="slot-card info">
+              <div class="av">RV</div>
+              <div class="who"><b>Roberto Vega Méndez</b><span>21770329 · Inscripción · primer consulta</span></div>
+              <span class="badge">Nuevo</span>
+            </div>
+          </div>
+          <div class="slot">
+            <div class="h">09:00<small>15 min</small></div>
+            <div class="slot-card">
+              <div class="av">AP</div>
+              <div class="who"><b>Ana Pérez García</b><span>22501133 · Control post-tratamiento</span></div>
+              <span class="badge">Confirmada</span>
+            </div>
+          </div>
+          <div class="slot empty">
+            <div class="h">10:00<small>15 min</small></div>
+            <div class="slot-card"><span class="add-slot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>Espacio libre · agendar</span></div>
+          </div>
+          <div class="slot" style="position:relative">
+            <div class="now-line" style="top:-1px"><span class="now-label">Ahora · 10:38</span></div>
+            <div class="h">10:30<small>15 min</small></div>
+            <div class="slot-card" style="border-left-width:4px;background:#cce4d7">
+              <div class="av">NC</div>
+              <div class="who"><b>Nestor Castillo Vázquez</b><span>22690495 · Renovación de receta · asma</span></div>
+              <span class="badge">En curso</span>
+            </div>
+          </div>
+          <div class="slot">
+            <div class="h">11:00<small>15 min</small></div>
+            <div class="slot-card warn">
+              <div class="av">LM</div>
+              <div class="who"><b>Luis Mora Hernández</b><span>22301844 · Pre-evaluación IA pendiente</span></div>
+              <span class="badge">Por confirmar</span>
+            </div>
+          </div>
+          <div class="slot">
+            <div class="h">11:30<small>15 min</small></div>
+            <div class="slot-card">
+              <div class="av">DC</div>
+              <div class="who"><b>Daniela Castro Ríos</b><span>23104822 · Dolor de cabeza recurrente</span></div>
+              <span class="badge">Confirmada</span>
+            </div>
+          </div>
+          <div class="slot">
+            <div class="h">12:00<small>30 min</small></div>
+            <div class="slot-card busy">
+              <div class="av">RS</div>
+              <div class="who"><b>Bloqueado</b><span>Almuerzo · no agendar</span></div>
+              <span class="badge" style="background:#e5e7eb;color:#6b7280">Bloque</span>
+            </div>
+          </div>
+          <div class="slot">
+            <div class="h">13:00<small>15 min</small></div>
+            <div class="slot-card">
+              <div class="av">JC</div>
+              <div class="who"><b>Javier Casanova López</b><span>21778302 · Revisión general</span></div>
+              <span class="badge">Confirmada</span>
+            </div>
+          </div>
+          <div class="slot">
+            <div class="h">13:30<small>15 min</small></div>
+            <div class="slot-card warn">
+              <div class="av">MV</div>
+              <div class="who"><b>Mariana Velasco Ruiz</b><span>23001247 · Solicita cambio · oct 14</span></div>
+              <span class="badge">Por confirmar</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:14px">
+        <div class="card">
+          <div class="card-h"><h2>Próxima cita</h2><span class="meta">En 8 minutos</span></div>
+          <div class="next-cita">
+            <div class="av-row">
+              <div class="av">NC</div>
+              <div class="who"><b>Nestor Castillo</b><span>22690495 · Ing. Sistemas</span></div>
+            </div>
+            <div class="row"><span class="k">Hora</span><span class="v">10:30 hrs</span></div>
+            <div class="row"><span class="k">Duración</span><span class="v">15 minutos</span></div>
+            <div class="row"><span class="k">Motivo</span><span class="v">Renovación de receta</span></div>
+            <div class="row"><span class="k">Última visita</span><span class="v">02 abr 2026</span></div>
+            <div class="countdown">10:38 — la cita comienza pronto</div>
+            <div class="actions-row">
+              <button class="btn outline sm">Ver expediente</button>
+              <button class="btn primary sm">Iniciar consulta</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-h"><h2>Mayo 2026</h2></div>
+          <div class="mini-cal">
+            <div class="nav">
+              <button class="nav-btn"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+              <b>Mayo 2026</b>
+              <button class="nav-btn"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg></button>
+            </div>
+            <div class="grid">
+              <div class="dh">L</div><div class="dh">M</div><div class="dh">X</div><div class="dh">J</div><div class="dh">V</div><div class="dh">S</div><div class="dh">D</div>
+              <div class="d past">28</div><div class="d past">29</div><div class="d past">30</div>
+              <div class="d has past"><span>1</span><span class="dot"></span></div>
+              <div class="d has past"><span>2</span><span class="dot"></span></div>
+              <div class="d past">3</div><div class="d past">4</div>
+              <div class="d has past"><span>5</span><span class="dot"></span></div>
+              <div class="d has past"><span>6</span><span class="dot"></span></div>
+              <div class="d has past"><span>7</span><span class="dot"></span></div>
+              <div class="d past">8</div>
+              <div class="d has past"><span>9</span><span class="dot"></span></div>
+              <div class="d past">10</div><div class="d past">11</div>
+              <div class="d has"><span>12</span><span class="dot"></span></div>
+              <div class="d sel has"><span>13</span><span class="dot"></span></div>
+              <div class="d has"><span>14</span><span class="dot"></span></div>
+              <div class="d has"><span>15</span><span class="dot"></span></div>
+              <div class="d">16</div><div class="d">17</div><div class="d">18</div>
+              <div class="d has"><span>19</span><span class="dot"></span></div>
+              <div class="d has"><span>20</span><span class="dot"></span></div>
+              <div class="d">21</div><div class="d has"><span>22</span><span class="dot"></span></div>
+              <div class="d">23</div><div class="d">24</div><div class="d">25</div>
+              <div class="d has"><span>26</span><span class="dot"></span></div>
+              <div class="d has"><span>27</span><span class="dot"></span></div>
+              <div class="d">28</div><div class="d">29</div><div class="d">30</div><div class="d">31</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<!-- VISTA B · Detalle al hacer clic en una cita -->
+<div class="scope">Vista B · Detalle de cita (drawer derecho)</div>
+<div class="app">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>Panel</a>
+      <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Citas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>Bitácoras</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>Pre-evaluaciones<span class="ct">3</span></a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="9"/></svg>Prioridad IA</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21V10l9-7 9 7v11"/><path d="M9 21v-7h6v7"/></svg>Estadísticas</a>
+    </nav>
+    <div class="user">
+      <div class="av">OG</div>
+      <div><b>Dr. Omar González</b><span>Médico general</span></div>
+    </div>
+  </aside>
+
+  <main class="main with-drawer" style="position:relative">
+    <div class="head" style="margin-bottom:14px">
+      <div>
+        <div class="crumb">Citas · Miércoles 13 mayo</div>
+        <h1>Detalle de cita</h1>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-h"><h2>Agenda de hoy</h2><span class="meta">3 de 9 visibles</span></div>
+      <div class="sched">
+        <div class="slot">
+          <div class="h">09:00</div>
+          <div class="slot-card">
+            <div class="av">AP</div>
+            <div class="who"><b>Ana Pérez García</b><span>22501133 · Control post-tratamiento</span></div>
+            <span class="badge">Confirmada</span>
+          </div>
+        </div>
+        <div class="slot">
+          <div class="h">10:30</div>
+          <div class="slot-card" style="background:#cce4d7;border-left-width:4px;box-shadow:inset 0 0 0 2px var(--primary)">
+            <div class="av">NC</div>
+            <div class="who"><b>Nestor Castillo Vázquez</b><span>22690495 · Renovación de receta · asma</span></div>
+            <span class="badge">Seleccionada</span>
+          </div>
+        </div>
+        <div class="slot">
+          <div class="h">11:00</div>
+          <div class="slot-card warn">
+            <div class="av">LM</div>
+            <div class="who"><b>Luis Mora Hernández</b><span>22301844 · Pre-evaluación pendiente</span></div>
+            <span class="badge">Por confirmar</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Drawer -->
+    <aside class="detail-side">
+      <div class="detail-hd">
+        <div>
+          <h3>Cita · 10:30</h3>
+          <span style="font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:600">Mié 13 mayo · Consultorio 2</span>
+        </div>
+        <button class="nav-btn">×</button>
+      </div>
+      <div class="detail-bd">
+        <div class="who-card">
+          <div class="av">NC</div>
+          <div><b>Nestor Castillo Vázquez</b><span>22690495 · Ing. Sistemas · 6° sem</span></div>
+        </div>
+
+        <h4>Motivo</h4>
+        <div class="kv">Renovación de receta para control de asma leve. Sin síntomas activos.</div>
+
+        <h4>Datos clínicos</h4>
+        <div class="kv">Tipo sangre <b>O+</b> · Peso <b>72 kg</b> · Estatura <b>1.75 m</b></div>
+
+        <h4>Alergias</h4>
+        <div class="pill-list">
+          <span class="pill">Penicilina</span>
+          <span class="pill">Aspirina</span>
+        </div>
+
+        <h4>Última visita</h4>
+        <div class="kv">02 abr 2026 · Crisis asmática leve · Salbutamol 100 mcg</div>
+
+        <h4>Recetas activas</h4>
+        <div class="kv">Salbutamol inhalador · vigente hasta 13 jun</div>
+      </div>
+      <div class="detail-foot">
+        <button class="btn ghost sm">Reagendar</button>
+        <button class="btn outline sm">Ver expediente</button>
+        <button class="btn primary sm">Iniciar</button>
+      </div>
+    </aside>
+  </main>
+</div>
+
+<!-- VISTA C · Modal Nueva cita (paso 1 — buscar alumno) -->
+<div class="scope">Vista C · Modal Nueva cita · Paso 1</div>
+<div class="overlay-wrap"><div class="overlay">
+  <div class="modal">
+    <div class="mh">
+      <div class="mh-top">
+        <div>
+          <h2>Nueva cita</h2>
+          <div class="ssub">¿Para qué alumno?</div>
+        </div>
+        <button class="nav-btn">×</button>
+      </div>
+      <div class="steps">
+        <div class="step active"><div class="n">1</div>Alumno</div>
+        <span class="arr">›</span>
+        <div class="step"><div class="n">2</div>Fecha y hora</div>
+        <span class="arr">›</span>
+        <div class="step"><div class="n">3</div>Confirmar</div>
+      </div>
+    </div>
+
+    <div class="mb">
+      <div class="search" style="width:100%;margin-bottom:14px">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+        <input placeholder="Nombre o número de control" value="cas" style="height:38px;font-size:13.5px">
+      </div>
+
+      <h4 style="margin:0 2px 8px;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;display:flex;justify-content:space-between"><span>Resultados</span><span style="font-weight:500;text-transform:none;letter-spacing:0">3 coincidencias</span></h4>
+
+      <div style="display:flex;flex-direction:column;gap:4px">
+        <div style="display:flex;align-items:center;gap:11px;padding:9px 12px;border-radius:8px;background:var(--primary-50);border:1px solid var(--primary-100)">
+          <div style="width:34px;height:34px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px">NC</div>
+          <div style="flex:1"><b style="font-size:13px;display:block">Nestor <span style="background:#fbe49a">Cas</span>tillo</b><span style="font-size:11.5px;color:var(--text-muted);font-variant-numeric:tabular-nums">22690495 · Ing. Sistemas</span></div>
+          <span style="font-size:11px;color:var(--text-muted)">Última cita: 14 abr</span>
+          <div style="width:18px;height:18px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7"/></svg></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:11px;padding:9px 12px;border-radius:8px">
+          <div style="width:34px;height:34px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px">DC</div>
+          <div style="flex:1"><b style="font-size:13px;display:block">Daniela <span style="background:#fbe49a">Cas</span>tro Ríos</b><span style="font-size:11.5px;color:var(--text-muted)">23104822 · Ing. Industrial</span></div>
+          <span style="font-size:11px;color:var(--text-muted)">Última: 28 mar</span>
+          <div style="width:18px;height:18px;border-radius:50%;border:1.5px solid var(--border)"></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:11px;padding:9px 12px;border-radius:8px">
+          <div style="width:34px;height:34px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px">JC</div>
+          <div style="flex:1"><b style="font-size:13px;display:block">Javier <span style="background:#fbe49a">Cas</span>anova López</b><span style="font-size:11.5px;color:var(--text-muted)">21778302 · Lic. Administración</span></div>
+          <span style="font-size:11px;color:var(--text-subtle)">Sin citas previas</span>
+          <div style="width:18px;height:18px;border-radius:50%;border:1.5px solid var(--border)"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mf">
+      <div class="left">Selecciona un alumno para continuar</div>
+      <div class="actions">
+        <button class="btn ghost">Cancelar</button>
+        <button class="btn primary">Continuar ›</button>
+      </div>
+    </div>
+  </div>
+</div></div>
+
+<!-- VISTA D · Modal Nueva cita (paso 2 — fecha y hora) -->
+<div class="scope">Vista D · Modal Nueva cita · Paso 2</div>
+<div class="overlay-wrap"><div class="overlay">
+  <div class="modal">
+    <div class="mh">
+      <div class="mh-top">
+        <div>
+          <h2>Nueva cita</h2>
+          <div class="ssub">Selecciona fecha y horario disponible</div>
+        </div>
+        <button class="nav-btn">×</button>
+      </div>
+      <div class="steps">
+        <div class="step done"><div class="n">1</div>Alumno</div>
+        <span class="arr">›</span>
+        <div class="step active"><div class="n">2</div>Fecha y hora</div>
+        <span class="arr">›</span>
+        <div class="step"><div class="n">3</div>Confirmar</div>
+      </div>
+    </div>
+
+    <div class="mb">
+      <div class="selected-st">
+        <div class="av">NC</div>
+        <div class="who"><b>Nestor Castillo</b><span>22690495 · Ing. Sistemas</span></div>
+        <button class="change">Cambiar</button>
+      </div>
+
+      <div class="cal-nav">
+        <button class="nav-btn"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <b>Mayo 2026</b>
+        <button class="nav-btn"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg></button>
+      </div>
+      <div class="cal-grid">
+        <div class="cal-dow">L</div><div class="cal-dow">M</div><div class="cal-dow">X</div><div class="cal-dow">J</div><div class="cal-dow">V</div><div class="cal-dow">S</div><div class="cal-dow">D</div>
+        <div class="day past"><span class="num">28</span></div><div class="day past"><span class="num">29</span></div><div class="day past"><span class="num">30</span></div>
+        <div class="day past"><span class="num">1</span></div><div class="day past"><span class="num">2</span></div><div class="day past"><span class="num">3</span></div><div class="day past"><span class="num">4</span></div>
+        <div class="day"><span class="num">5</span><span class="sub">7 disp</span></div>
+        <div class="day low"><span class="num">6</span><span class="sub">2 disp</span></div>
+        <div class="day"><span class="num">7</span><span class="sub">5 disp</span></div>
+        <div class="day full"><span class="num">8</span><span class="sub">Lleno</span></div>
+        <div class="day"><span class="num">9</span></div><div class="day"><span class="num">10</span></div>
+        <div class="day"><span class="num">11</span><span class="sub">6 disp</span></div>
+        <div class="day"><span class="num">12</span><span class="sub">8 disp</span></div>
+        <div class="day sel"><span class="num">13</span><span class="sub">5 disp</span></div>
+        <div class="day"><span class="num">14</span><span class="sub">4 disp</span></div>
+        <div class="day low"><span class="num">15</span><span class="sub">1 disp</span></div>
+        <div class="day"><span class="num">16</span></div><div class="day"><span class="num">17</span></div>
+        <div class="day"><span class="num">18</span><span class="sub">7 disp</span></div>
+        <div class="day"><span class="num">19</span><span class="sub">6 disp</span></div>
+      </div>
+
+      <div class="slot-section">
+        <div class="lbl">Horarios — Mié 13 mayo</div>
+        <div class="slots">
+          <div class="ss">08:00</div>
+          <div class="ss taken">08:15</div>
+          <div class="ss">08:30</div>
+          <div class="ss">08:45</div>
+          <div class="ss sel">09:00</div>
+          <div class="ss taken">09:15</div>
+          <div class="ss">09:30</div>
+          <div class="ss taken">09:45</div>
+          <div class="ss">10:00</div>
+          <div class="ss">10:15</div>
+          <div class="ss">10:30</div>
+          <div class="ss">10:45</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mf">
+      <div class="left">Mié 13 mayo · 09:00 – 09:15</div>
+      <div class="actions">
+        <button class="btn ghost">‹ Atrás</button>
+        <button class="btn primary">Continuar ›</button>
+      </div>
+    </div>
+  </div>
+</div></div>
+
+<!-- VISTA E · Modal Nueva cita (paso 3 — confirmar) -->
+<div class="scope">Vista E · Modal Nueva cita · Paso 3</div>
+<div class="overlay-wrap" style="margin-bottom:32px"><div class="overlay">
+  <div class="modal">
+    <div class="mh">
+      <div class="mh-top">
+        <div>
+          <h2>Nueva cita</h2>
+          <div class="ssub">Revisa los datos antes de confirmar</div>
+        </div>
+        <button class="nav-btn">×</button>
+      </div>
+      <div class="steps">
+        <div class="step done"><div class="n">1</div>Alumno</div>
+        <span class="arr">›</span>
+        <div class="step done"><div class="n">2</div>Fecha y hora</div>
+        <span class="arr">›</span>
+        <div class="step active"><div class="n">3</div>Confirmar</div>
+      </div>
+    </div>
+
+    <div class="mb">
+      <div style="background:var(--soft);border:1px solid var(--border);border-radius:10px;overflow:hidden">
+        <div style="padding:14px 16px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center">
+          <span style="color:var(--text-muted);font-weight:500;font-size:12px;text-transform:uppercase;letter-spacing:.4px">Alumno</span>
+          <div style="display:flex;align-items:center;gap:10px">
+            <div style="width:30px;height:30px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:11px">NC</div>
+            <div><b style="font-size:13px;display:block">Nestor Castillo</b><span style="font-size:11px;color:var(--text-muted)">22690495 · Ing. Sistemas</span></div>
+          </div>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--border);font-size:13px"><span style="color:var(--text-muted);font-weight:500;font-size:12px;text-transform:uppercase;letter-spacing:.4px">Fecha</span><span style="font-weight:600">Mié 13 mayo 2026</span></div>
+        <div style="display:flex;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--border);font-size:13px"><span style="color:var(--text-muted);font-weight:500;font-size:12px;text-transform:uppercase;letter-spacing:.4px">Hora</span><span style="font-weight:600;font-variant-numeric:tabular-nums">09:00 – 09:15 hrs</span></div>
+        <div style="display:flex;justify-content:space-between;padding:12px 16px;font-size:13px"><span style="color:var(--text-muted);font-weight:500;font-size:12px;text-transform:uppercase;letter-spacing:.4px">Consultorio</span><span style="font-weight:600">Consultorio 2</span></div>
+      </div>
+
+      <div style="margin-top:16px">
+        <label style="display:block;font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin-bottom:6px">Motivo de la cita</label>
+        <textarea placeholder="Ej. Renovación de receta, seguimiento de tratamiento, revisión general..." style="width:100%;min-height:70px;border:1px solid var(--border);border-radius:9px;padding:10px 12px;font:400 13px 'Inter',sans-serif;color:var(--text);outline:none;resize:vertical"></textarea>
+        <div style="font-size:11.5px;color:var(--text-subtle);margin-top:5px">El alumno verá este motivo en su agenda.</div>
+      </div>
+
+      <div style="margin-top:14px">
+        <label style="display:block;font-size:10.5px;font-weight:600;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;margin-bottom:6px">Notas internas (opcional)</label>
+        <textarea placeholder="Notas visibles solo para personal médico" style="width:100%;min-height:50px;border:1px solid var(--border);border-radius:9px;padding:10px 12px;font:400 13px 'Inter',sans-serif;color:var(--text);outline:none;resize:vertical"></textarea>
+      </div>
+    </div>
+
+    <div class="mf">
+      <div class="left">Se enviará notificación al alumno</div>
+      <div class="actions">
+        <button class="btn ghost">‹ Atrás</button>
+        <button class="btn primary">Confirmar cita</button>
+      </div>
+    </div>
+  </div>
+</div></div>
+
+</body>
+</html>

--- a/frontend/design-reference/Mi Perfil Web Estados.html
+++ b/frontend/design-reference/Mi Perfil Web Estados.html
@@ -1,0 +1,507 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mi perfil — Estados</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#f3f4f6;
+    --bg:#f8fafc; --chip-bg:#f3f4f6;
+    --danger:#dc2626; --danger-50:#fef2f2;
+    --warn:#b45309; --warn-50:#fef3c7;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit;font-size:inherit}
+  input,select,textarea{font-family:inherit;color:inherit;font-size:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar */
+  .sb{width:220px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column;padding:22px 0}
+  .sb .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:28px;height:28px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb nav{display:flex;flex-direction:column;gap:2px;padding:14px 12px 0;flex:1}
+  .sb nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;cursor:pointer;text-decoration:none}
+  .sb nav a:hover{background:rgba(255,255,255,.05);color:#fff}
+  .sb nav a.active{background:rgba(255,255,255,.1);color:#fff;font-weight:600}
+  .sb nav a svg{width:16px;height:16px;stroke-width:1.8;flex-shrink:0;opacity:.95}
+  .sb .user{margin-top:auto;padding:14px 18px 4px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .sb .user b{display:block;font-size:13px;font-weight:600}
+  .sb .user span{font-size:11px;color:rgba(255,255,255,.65);font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;padding:32px}
+  .crumb{font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.5px;font-weight:600;margin-bottom:6px}
+  h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .sub{font-size:13.5px;color:var(--text-muted);margin-top:4px;margin-bottom:22px}
+
+  .grid{display:grid;grid-template-columns:320px 1fr;gap:20px;max-width:1080px;align-items:start}
+  .card{background:#fff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,.08);overflow:hidden}
+
+  /* Identity card (shared) */
+  .id-card{padding:24px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:6px}
+  .id-card .av{width:84px;height:84px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:30px;margin-bottom:6px}
+  .id-card h2{margin:0;font-size:17px;font-weight:700;letter-spacing:-.2px}
+  .id-card .ctrl{font-size:12.5px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  .id-card .career{font-size:12.5px;color:var(--text-muted);margin-top:1px}
+  .id-card .badge{margin-top:10px;display:inline-flex;align-items:center;gap:5px;background:var(--primary-50);color:var(--primary);font-size:11px;font-weight:600;padding:4px 10px;border-radius:99px}
+  .id-card .badge::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--primary)}
+  .id-actions{padding:0 18px 18px;display:flex;flex-direction:column;gap:8px}
+  .btn-out{width:100%;padding:9px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;font:600 13px 'Inter',sans-serif;color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px}
+  .btn-out:hover{border-color:var(--primary);color:var(--primary)}
+  .btn-out svg{width:14px;height:14px;stroke-width:1.8}
+  .btn-out.danger{color:var(--danger);border-color:#fee2e2}
+  .btn-out.danger:hover{border-color:var(--danger);background:#fef2f2}
+
+  /* Tabs */
+  .tabs{display:flex;border-bottom:1px solid var(--border);padding:0 22px}
+  .tab{padding:14px 4px;margin-right:24px;font-size:13px;font-weight:500;color:var(--text-muted);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
+  .tab.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+
+  .section{padding:6px 22px 18px}
+  .section + .section{border-top:1px solid var(--border-soft)}
+  .section h3{margin:18px 0 12px;font-size:11px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;display:flex;align-items:center;justify-content:space-between}
+  .section h3 .hint{font-weight:500;color:var(--text-subtle);text-transform:none;letter-spacing:0;font-size:11.5px}
+  .row{display:grid;grid-template-columns:170px 1fr auto;gap:16px;align-items:center;padding:10px 0;border-bottom:1px solid var(--border-soft)}
+  .row:last-child{border-bottom:none}
+  .row .lab{font-size:12.5px;color:var(--text-muted);font-weight:500}
+  .row .val{font-size:13.5px;color:var(--text);font-weight:500}
+  .row .val.muted{color:var(--text-subtle);font-weight:400}
+  .row .edit{font-size:12px;color:var(--primary);font-weight:600;cursor:pointer;text-decoration:none}
+  .row .edit.locked{color:var(--text-subtle);cursor:not-allowed;display:inline-flex;align-items:center;gap:4px}
+  .row .edit.locked svg{width:11px;height:11px;stroke-width:2}
+  .row .edit:hover:not(.locked){text-decoration:underline}
+
+  /* Notice */
+  .notice{margin:16px 22px 22px;background:var(--primary-50);border-radius:10px;padding:12px 14px;font-size:12.5px;color:var(--primary);font-weight:500;display:flex;align-items:flex-start;gap:10px;line-height:1.4}
+  .notice svg{flex-shrink:0;margin-top:1px}
+  .notice.warn{background:var(--warn-50);color:var(--warn)}
+
+  /* Pills (medicine info) */
+  .pill-list{display:flex;flex-wrap:wrap;gap:6px;margin-top:4px}
+  .pill{background:var(--chip-bg);color:var(--text);font-size:12px;font-weight:500;padding:3px 10px;border-radius:99px}
+  .pill.warn{background:var(--warn-50);color:var(--warn)}
+
+  /* Notifications toggle row */
+  .notif-row{display:grid;grid-template-columns:1fr auto;gap:16px;align-items:flex-start;padding:14px 0;border-bottom:1px solid var(--border-soft)}
+  .notif-row:last-child{border-bottom:none}
+  .notif-row .l{font-size:13.5px;font-weight:600;color:var(--text);margin-bottom:3px}
+  .notif-row .d{font-size:12.5px;color:var(--text-muted);line-height:1.4}
+  .toggle{position:relative;width:38px;height:22px;background:#cbd5e1;border-radius:99px;cursor:pointer;flex-shrink:0;transition:background .15s}
+  .toggle::after{content:'';position:absolute;top:2px;left:2px;width:18px;height:18px;background:#fff;border-radius:50%;transition:transform .15s;box-shadow:0 1px 2px rgba(0,0,0,.2)}
+  .toggle.on{background:var(--primary)}
+  .toggle.on::after{transform:translateX(16px)}
+
+  .channel-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:12px}
+  .channel{display:flex;align-items:center;gap:10px;padding:10px 12px;background:var(--chip-bg);border-radius:8px}
+  .channel svg{width:16px;height:16px;color:var(--text-muted);stroke-width:1.8;flex-shrink:0}
+  .channel b{display:block;font-size:12.5px;font-weight:600}
+  .channel span{display:block;font-size:11.5px;color:var(--text-muted)}
+
+  /* Edit drawer (modal) */
+  .drawer-wrap{position:relative;margin:24px 0;padding:24px;background:rgba(15,30,22,.4);border-radius:16px}
+  .drawer-wrap .drawer{max-width:520px;margin:0 auto;background:#fff;border-radius:14px;box-shadow:0 20px 60px rgba(0,0,0,.18);overflow:hidden}
+  .dh{padding:18px 22px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center}
+  .dh h2{margin:0;font-size:17px;font-weight:700;letter-spacing:-.2px}
+  .dh .close{width:30px;height:30px;border-radius:6px;color:var(--text-subtle);display:flex;align-items:center;justify-content:center;font-size:18px}
+  .dh .close:hover{background:var(--chip-bg);color:var(--text)}
+  .db{padding:20px 22px}
+  .field{margin-bottom:14px}
+  .field label{display:block;font-size:11.5px;font-weight:600;color:var(--text-muted);letter-spacing:.3px;margin-bottom:6px;text-transform:uppercase}
+  .field label .req{color:var(--danger);margin-left:2px}
+  .field input,.field select{width:100%;height:40px;background:#fff;border:1px solid var(--border);border-radius:8px;padding:0 12px;font:500 13.5px 'Inter',sans-serif;outline:none}
+  .field input:focus,.field select:focus{border-color:var(--primary);box-shadow:0 0 0 3px var(--primary-50)}
+  .field .hint{font-size:11.5px;color:var(--text-subtle);margin-top:5px}
+  .field.locked input{background:var(--chip-bg);color:var(--text-subtle);cursor:not-allowed}
+  .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .df{padding:14px 22px;background:var(--chip-bg);border-top:1px solid var(--border);display:flex;justify-content:flex-end;gap:8px}
+  .btn{padding:9px 16px;border-radius:7px;font:600 13px 'Inter',sans-serif;cursor:pointer;display:inline-flex;align-items:center;gap:6px;border:1px solid transparent}
+  .btn.primary{background:var(--primary);color:#fff}
+  .btn.primary:hover{background:var(--primary-600)}
+  .btn.ghost{color:var(--text-muted);background:transparent}
+  .btn.ghost:hover{background:#fff}
+
+  .lock-line{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--warn);background:var(--warn-50);padding:9px 12px;border-radius:8px;margin-bottom:14px;line-height:1.4}
+  .lock-line svg{flex-shrink:0;width:14px;height:14px;stroke-width:1.8}
+
+  /* Password meter */
+  .meter{display:flex;gap:4px;margin-top:8px}
+  .meter span{flex:1;height:4px;border-radius:99px;background:var(--border)}
+  .meter.s2 span:nth-child(-n+2){background:#f59e0b}
+  .meter.s3 span:nth-child(-n+3){background:var(--primary)}
+  .meter.s4 span{background:var(--primary)}
+  .meter-label{font-size:11.5px;color:var(--text-muted);margin-top:5px}
+  .meter-label b{color:var(--primary)}
+  .check-list{margin-top:10px;display:flex;flex-direction:column;gap:5px}
+  .check-list div{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-muted)}
+  .check-list div svg{width:13px;height:13px;flex-shrink:0;stroke-width:2}
+  .check-list .ok{color:var(--primary)}
+  .check-list .ok svg{color:var(--primary)}
+
+  .scope{display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:700;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;margin:0 0 6px;padding-top:8px}
+  .scope::after{content:'';height:1px;background:var(--border);flex:1;width:140px;display:inline-block;margin-left:8px}
+  .frame{border-bottom:1px solid var(--border);padding-bottom:8px}
+</style>
+</head>
+<body>
+
+<div style="padding:24px 32px 0">
+  <div class="scope">Vista A · Tab Información médica</div>
+</div>
+<div class="app frame">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>Inicio</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Mis citas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>Pre-evaluación IA</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+      <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>Mi perfil</a>
+    </nav>
+    <div class="user">
+      <div class="av">NC</div>
+      <div><b>Nestor Castillo</b><span>22690495</span></div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="crumb">Mi perfil</div>
+    <h1>Mi perfil</h1>
+    <div class="sub">Datos personales, información médica y contacto de emergencia</div>
+
+    <div class="grid">
+      <div class="card">
+        <div class="id-card">
+          <div class="av">NC</div>
+          <h2>Nestor Castillo</h2>
+          <div class="ctrl">22690495</div>
+          <div class="career">Ing. Sistemas · 6° semestre</div>
+          <div class="badge">Cuenta activa</div>
+        </div>
+        <div class="id-actions">
+          <button class="btn-out"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 3 4 10.5V20h9.5L21 12.5 11.5 3Z"/><path d="m14 6 4 4"/></svg>Editar información</button>
+          <button class="btn-out"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>Cambiar contraseña</button>
+          <button class="btn-out danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5"/><path d="M21 12H9"/></svg>Cerrar sesión</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="tabs">
+          <div class="tab">Información personal</div>
+          <div class="tab active">Información médica</div>
+          <div class="tab">Notificaciones</div>
+        </div>
+
+        <div class="section">
+          <h3>Datos físicos<span class="hint">Editables por ti</span></h3>
+          <div class="row"><span class="lab">Tipo de sangre</span><span class="val">O+</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Peso</span><span class="val">72 kg</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Estatura</span><span class="val">1.75 m</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Última actualización</span><span class="val muted">12 ene 2026 · por ti</span><span></span></div>
+        </div>
+
+        <div class="section">
+          <h3>Alergias conocidas<span class="hint">Solo el doctor puede modificar</span></h3>
+          <div class="row"><span class="lab">Medicamentos</span><span class="val"><div class="pill-list"><span class="pill warn">Penicilina</span><span class="pill warn">Aspirina</span></div></span><a class="edit locked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>Bloqueado</a></div>
+          <div class="row"><span class="lab">Alimentos</span><span class="val"><div class="pill-list"><span class="pill">Mariscos</span></div></span><a class="edit locked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>Bloqueado</a></div>
+          <div class="row"><span class="lab">Ambientales</span><span class="val muted">Ninguna registrada</span><span></span></div>
+        </div>
+
+        <div class="section">
+          <h3>Padecimientos crónicos<span class="hint">Solo el doctor puede modificar</span></h3>
+          <div class="row"><span class="lab">Diagnósticos</span><span class="val"><div class="pill-list"><span class="pill">Asma leve</span></div></span><a class="edit locked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>Bloqueado</a></div>
+          <div class="row"><span class="lab">Medicamentos crónicos</span><span class="val muted">Ninguno registrado</span><span></span></div>
+        </div>
+
+        <div class="section">
+          <h3>Vacunación</h3>
+          <div class="row"><span class="lab">Esquema básico</span><span class="val">Completo</span><span></span></div>
+          <div class="row"><span class="lab">Influenza</span><span class="val">22 oct 2025</span><span></span></div>
+          <div class="row"><span class="lab">COVID-19</span><span class="val">14 abr 2024 · 4ª dosis</span><span></span></div>
+        </div>
+
+        <div class="notice warn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+          Los campos marcados como <b>Bloqueado</b> solo pueden ser modificados por el doctor durante una consulta. Para reportar un error, agenda una cita.
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<!-- VISTA B — Notificaciones -->
+<div style="padding:24px 32px 0">
+  <div class="scope">Vista B · Tab Notificaciones</div>
+</div>
+<div class="app frame">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>Inicio</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Mis citas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>Pre-evaluación IA</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+      <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>Mi perfil</a>
+    </nav>
+    <div class="user">
+      <div class="av">NC</div>
+      <div><b>Nestor Castillo</b><span>22690495</span></div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="crumb">Mi perfil</div>
+    <h1>Mi perfil</h1>
+    <div class="sub">Datos personales, información médica y contacto de emergencia</div>
+
+    <div class="grid">
+      <div class="card">
+        <div class="id-card">
+          <div class="av">NC</div>
+          <h2>Nestor Castillo</h2>
+          <div class="ctrl">22690495</div>
+          <div class="career">Ing. Sistemas · 6° semestre</div>
+          <div class="badge">Cuenta activa</div>
+        </div>
+        <div class="id-actions">
+          <button class="btn-out"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 3 4 10.5V20h9.5L21 12.5 11.5 3Z"/><path d="m14 6 4 4"/></svg>Editar información</button>
+          <button class="btn-out"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>Cambiar contraseña</button>
+          <button class="btn-out danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5"/><path d="M21 12H9"/></svg>Cerrar sesión</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="tabs">
+          <div class="tab">Información personal</div>
+          <div class="tab">Información médica</div>
+          <div class="tab active">Notificaciones</div>
+        </div>
+
+        <div class="section">
+          <h3>Canales preferidos</h3>
+          <div class="channel-grid">
+            <div class="channel">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+              <div><b>Correo institucional</b><span><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="d0e2e2e6e9e0e4e9e590a4b5b3a6bdfebda8">[email&#160;protected]</a></span></div>
+            </div>
+            <div class="channel">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="2.5" width="10" height="19" rx="2"/><path d="M11 18.5h2"/></svg>
+              <div><b>Push móvil</b><span>App instalada · iPhone 14</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h3>Citas médicas</h3>
+          <div class="notif-row">
+            <div>
+              <div class="l">Recordatorio de cita</div>
+              <div class="d">Te avisamos 24 hrs antes de tu cita y 1 hora antes.</div>
+            </div>
+            <div class="toggle on"></div>
+          </div>
+          <div class="notif-row">
+            <div>
+              <div class="l">Cambios o cancelaciones</div>
+              <div class="d">Cuando el doctor reagende o cancele una cita.</div>
+            </div>
+            <div class="toggle on"></div>
+          </div>
+          <div class="notif-row">
+            <div>
+              <div class="l">Confirmación de asistencia</div>
+              <div class="d">Pedir confirmación 2 hrs antes de cada cita.</div>
+            </div>
+            <div class="toggle"></div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h3>Recetas y resultados</h3>
+          <div class="notif-row">
+            <div>
+              <div class="l">Nueva receta emitida</div>
+              <div class="d">Aviso cuando el doctor emite una receta para ti.</div>
+            </div>
+            <div class="toggle on"></div>
+          </div>
+          <div class="notif-row">
+            <div>
+              <div class="l">Recordatorio de medicamento</div>
+              <div class="d">Avisos según la dosificación de tus recetas activas.</div>
+            </div>
+            <div class="toggle on"></div>
+          </div>
+          <div class="notif-row">
+            <div>
+              <div class="l">Resultados de pre-evaluación IA</div>
+              <div class="d">Cuando el doctor revise tu pre-evaluación.</div>
+            </div>
+            <div class="toggle"></div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h3>Comunicación general</h3>
+          <div class="notif-row">
+            <div>
+              <div class="l">Avisos del servicio médico</div>
+              <div class="d">Días sin atención, campañas de vacunación y horarios especiales.</div>
+            </div>
+            <div class="toggle on"></div>
+          </div>
+          <div class="notif-row">
+            <div>
+              <div class="l">Encuestas y mejora del servicio</div>
+              <div class="d">Recibir encuestas ocasionales después de cada consulta.</div>
+            </div>
+            <div class="toggle"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<!-- VISTA C — Modal editar información -->
+<div style="padding:24px 32px 0">
+  <div class="scope">Vista C · Modal Editar información</div>
+</div>
+<div class="drawer-wrap">
+  <div class="drawer">
+    <div class="dh">
+      <h2>Editar información</h2>
+      <button class="close">×</button>
+    </div>
+    <div class="db">
+      <div class="lock-line">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+        Algunos campos solo pueden ser modificados por servicios escolares o por el doctor.
+      </div>
+
+      <div class="field locked">
+        <label>Nombre completo</label>
+        <input value="Nestor Castillo Vázquez" disabled>
+        <div class="hint">Vinculado a Servicios Escolares.</div>
+      </div>
+
+      <div class="field locked">
+        <label>Número de control</label>
+        <input value="22690495" disabled>
+      </div>
+
+      <div class="field">
+        <label>Correo personal</label>
+        <input value="nestor.cv@gmail.com">
+        <div class="hint">Usado para recuperación de contraseña y avisos.</div>
+      </div>
+
+      <div class="field">
+        <label>Teléfono <span class="req">*</span></label>
+        <input value="55 1234 5678">
+      </div>
+
+      <div class="field-row">
+        <div class="field">
+          <label>Peso (kg)</label>
+          <input value="72" type="number">
+        </div>
+        <div class="field">
+          <label>Estatura (m)</label>
+          <input value="1.75" type="number" step="0.01">
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Tipo de sangre</label>
+        <select>
+          <option>O+</option><option>O-</option><option>A+</option><option>A-</option>
+          <option>B+</option><option>B-</option><option>AB+</option><option>AB-</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label>Contacto de emergencia — Nombre</label>
+        <input value="María Vázquez (madre)">
+      </div>
+
+      <div class="field">
+        <label>Contacto de emergencia — Teléfono</label>
+        <input value="55 8721 4490">
+      </div>
+    </div>
+    <div class="df">
+      <button class="btn ghost">Cancelar</button>
+      <button class="btn primary">Guardar cambios</button>
+    </div>
+  </div>
+</div>
+
+<!-- VISTA D — Cambiar contraseña -->
+<div style="padding:24px 32px 0">
+  <div class="scope">Vista D · Modal Cambiar contraseña</div>
+</div>
+<div class="drawer-wrap" style="padding-bottom:48px">
+  <div class="drawer">
+    <div class="dh">
+      <h2>Cambiar contraseña</h2>
+      <button class="close">×</button>
+    </div>
+    <div class="db">
+      <div class="lock-line" style="background:var(--primary-50);color:var(--primary)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+        Tu sesión se cerrará en todos los dispositivos después de cambiar la contraseña.
+      </div>
+
+      <div class="field">
+        <label>Contraseña actual <span class="req">*</span></label>
+        <input type="password" value="••••••••••">
+      </div>
+
+      <div class="field">
+        <label>Nueva contraseña <span class="req">*</span></label>
+        <input type="password" value="••••••••••••">
+        <div class="meter s3"><span></span><span></span><span></span><span></span></div>
+        <div class="meter-label">Fortaleza: <b>Buena</b></div>
+        <div class="check-list">
+          <div class="ok">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7"/></svg>
+            Mínimo 8 caracteres
+          </div>
+          <div class="ok">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7"/></svg>
+            Mayúsculas y minúsculas
+          </div>
+          <div class="ok">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7"/></svg>
+            Al menos un número
+          </div>
+          <div>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/></svg>
+            Al menos un símbolo (recomendado)
+          </div>
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Confirmar nueva contraseña <span class="req">*</span></label>
+        <input type="password" value="••••••••••••">
+      </div>
+    </div>
+    <div class="df">
+      <button class="btn ghost">Cancelar</button>
+      <button class="btn primary">Actualizar contraseña</button>
+    </div>
+  </div>
+</div>
+
+<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script></body>
+</html>

--- a/frontend/design-reference/Mi Perfil Web.html
+++ b/frontend/design-reference/Mi Perfil Web.html
@@ -1,0 +1,339 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mi perfil</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#f3f4f6;
+    --bg:#f8fafc; --chip-bg:#f3f4f6;
+    --danger:#dc2626;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit;font-size:inherit}
+  input,select,textarea{font-family:inherit;color:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar — same as Recetas */
+  .sb{width:220px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column;padding:22px 0}
+  .sb .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:28px;height:28px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb nav{display:flex;flex-direction:column;gap:2px;padding:14px 12px 0;flex:1}
+  .sb nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;cursor:pointer;text-decoration:none}
+  .sb nav a:hover{background:rgba(255,255,255,.05);color:#fff}
+  .sb nav a.active{background:rgba(255,255,255,.1);color:#fff;font-weight:600}
+  .sb nav a svg{width:16px;height:16px;stroke-width:1.8;flex-shrink:0;opacity:.95}
+  .sb .user{margin-top:auto;padding:14px 18px 4px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .sb .user b{display:block;font-size:13px;font-weight:600}
+  .sb .user span{font-size:11px;color:rgba(255,255,255,.65);font-variant-numeric:tabular-nums}
+
+  .main{flex:1;min-width:0;padding:32px}
+  .crumb{font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.5px;font-weight:600;margin-bottom:6px}
+  h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .sub{font-size:13.5px;color:var(--text-muted);margin-top:4px;margin-bottom:22px}
+
+  .grid{display:grid;grid-template-columns:320px 1fr;gap:20px;max-width:1080px;align-items:start}
+
+  .card{background:#fff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,.08);overflow:hidden}
+
+  /* Identity card */
+  .id-card{padding:24px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:6px}
+  .id-card .av{width:84px;height:84px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:30px;letter-spacing:.5px;margin-bottom:6px}
+  .id-card h2{margin:0;font-size:17px;font-weight:700;letter-spacing:-.2px}
+  .id-card .ctrl{font-size:12.5px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  .id-card .career{font-size:12.5px;color:var(--text-muted);margin-top:1px}
+  .id-card .badge{margin-top:10px;display:inline-flex;align-items:center;gap:5px;background:var(--primary-50);color:var(--primary);font-size:11px;font-weight:600;padding:4px 10px;border-radius:99px}
+  .id-card .badge::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--primary)}
+  .id-actions{padding:0 18px 18px;display:flex;flex-direction:column;gap:8px}
+  .btn-out{width:100%;padding:9px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;font:600 13px 'Inter',sans-serif;color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px}
+  .btn-out:hover{border-color:var(--primary);color:var(--primary)}
+  .btn-out svg{width:14px;height:14px;stroke-width:1.8}
+  .btn-out.danger{color:var(--danger);border-color:#fee2e2}
+  .btn-out.danger:hover{border-color:var(--danger);background:#fef2f2}
+
+  /* Tabs + content */
+  .tabs{display:flex;border-bottom:1px solid var(--border);padding:0 22px}
+  .tab{padding:14px 4px;margin-right:24px;font-size:13px;font-weight:500;color:var(--text-muted);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
+  .tab.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+
+  .section{padding:6px 22px 18px}
+  .section + .section{border-top:1px solid var(--border-soft)}
+  .section h3{margin:18px 0 12px;font-size:11px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .row{display:grid;grid-template-columns:160px 1fr auto;gap:16px;align-items:center;padding:10px 0;border-bottom:1px solid var(--border-soft)}
+  .row:last-child{border-bottom:none}
+  .row .lab{font-size:12.5px;color:var(--text-muted);font-weight:500}
+  .row .val{font-size:13.5px;color:var(--text);font-weight:500}
+  .row .val.muted{color:var(--text-subtle);font-weight:400}
+  .row .edit{font-size:12px;color:var(--primary);font-weight:600;cursor:pointer;text-decoration:none}
+  .row .edit:hover{text-decoration:underline}
+
+  /* Small notice */
+  .notice{margin:16px 22px 22px;background:var(--primary-50);border-radius:10px;padding:12px 14px;font-size:12.5px;color:var(--primary);font-weight:500;display:flex;align-items:flex-start;gap:10px;line-height:1.4}
+  .notice svg{flex-shrink:0;margin-top:1px}
+
+  .scope-label{display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:700;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;margin:0 32px 8px;padding-top:8px}
+  .scope-label::after{content:'';height:1px;background:var(--border);flex:1;width:140px;display:inline-block;margin-left:8px}
+
+  /* Dark mode block */
+  .dark{background:#0f1117;color:#f9fafb}
+  .dark .crumb,.dark .sub{color:#9ca3af}
+  .dark h1{color:#f9fafb}
+  .dark .card{background:#1a1d27;box-shadow:0 1px 3px rgba(0,0,0,.4)}
+  .dark .id-card .av{background:#1e3a2a;color:#86efac}
+  .dark .id-card .ctrl,.dark .id-card .career{color:#9ca3af}
+  .dark .id-card .badge{background:#1e3a2a;color:#86efac}
+  .dark .id-card .badge::before{background:#86efac}
+  .dark .btn-out{background:#1a1d27;border-color:#2d3144;color:#f9fafb}
+  .dark .btn-out:hover{border-color:#86efac;color:#86efac}
+  .dark .btn-out.danger{color:#f87171;border-color:#3a1f1f}
+  .dark .btn-out.danger:hover{border-color:#f87171;background:#2a1518}
+  .dark .tabs{border-bottom-color:#2d3144}
+  .dark .tab{color:#9ca3af}
+  .dark .tab.active{color:#86efac;border-bottom-color:#86efac}
+  .dark .section + .section{border-top-color:#252836}
+  .dark .section h3{color:#9ca3af}
+  .dark .row{border-bottom-color:#252836}
+  .dark .row .lab{color:#9ca3af}
+  .dark .row .val{color:#f9fafb}
+  .dark .row .val.muted{color:#6b7280}
+  .dark .row .edit{color:#86efac}
+  .dark .notice{background:#1e3a2a;color:#86efac}
+  .dark .scope-label{color:#9ca3af}
+  .dark .scope-label::after{background:#2d3144}
+</style>
+</head>
+<body>
+
+<div class="scope-label">Modo claro</div>
+<div class="app" style="border-bottom:1px solid var(--border)">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+        Inicio
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+        Mis citas
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+        Pre-evaluación IA
+      </a>
+      <a>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+        Recetas
+      </a>
+      <a class="active">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+        Mi perfil
+      </a>
+    </nav>
+    <div class="user">
+      <div class="av">NC</div>
+      <div><b>Nestor Castillo</b><span>22690495</span></div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="crumb">Mi perfil</div>
+    <h1>Mi perfil</h1>
+    <div class="sub">Datos personales, información médica y contacto de emergencia</div>
+
+    <div class="grid">
+      <!-- Identity column -->
+      <div class="card">
+        <div class="id-card">
+          <div class="av">NC</div>
+          <h2>Nestor Castillo</h2>
+          <div class="ctrl">22690495</div>
+          <div class="career">Ing. Sistemas · 6° semestre</div>
+          <div class="badge">Cuenta activa</div>
+        </div>
+        <div class="id-actions">
+          <button class="btn-out">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 3 4 10.5V20h9.5L21 12.5 11.5 3Z"/><path d="m14 6 4 4"/></svg>
+            Editar información
+          </button>
+          <button class="btn-out">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+            Cambiar contraseña
+          </button>
+          <button class="btn-out danger">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5"/><path d="M21 12H9"/></svg>
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
+
+      <!-- Tabs column -->
+      <div class="card">
+        <div class="tabs">
+          <div class="tab active">Información personal</div>
+          <div class="tab">Información médica</div>
+          <div class="tab">Notificaciones</div>
+        </div>
+
+        <div class="section">
+          <h3>Datos personales</h3>
+          <div class="row"><span class="lab">Nombre completo</span><span class="val">Nestor Castillo Vázquez</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Número de control</span><span class="val">22690495</span><span></span></div>
+          <div class="row"><span class="lab">Fecha de nacimiento</span><span class="val">14 de marzo, 2004</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Género</span><span class="val">Masculino</span><a class="edit">Editar</a></div>
+        </div>
+
+        <div class="section">
+          <h3>Contacto</h3>
+          <div class="row"><span class="lab">Correo institucional</span><span class="val"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="d0e2e2e6e9e0e4e9e590a4b5b3a6bdfebda8">[email&#160;protected]</a></span><span></span></div>
+          <div class="row"><span class="lab">Correo personal</span><span class="val"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="4c22293f38233e622f3a0c2b212d2520622f2321">[email&#160;protected]</a></span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Teléfono</span><span class="val">55 1234 5678</span><a class="edit">Editar</a></div>
+        </div>
+
+        <div class="section">
+          <h3>Información médica básica</h3>
+          <div class="row"><span class="lab">Tipo de sangre</span><span class="val">O+</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Peso</span><span class="val">72 kg</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Estatura</span><span class="val">1.75 m</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Alergias</span><span class="val muted">Ninguna registrada</span><a class="edit">Agregar</a></div>
+          <div class="row"><span class="lab">Padecimientos</span><span class="val muted">Ninguno registrado</span><a class="edit">Agregar</a></div>
+        </div>
+
+        <div class="section">
+          <h3>Contacto de emergencia</h3>
+          <div class="row"><span class="lab">Nombre</span><span class="val">María Vázquez (madre)</span><a class="edit">Editar</a></div>
+          <div class="row"><span class="lab">Teléfono</span><span class="val">55 8721 4490</span><a class="edit">Editar</a></div>
+        </div>
+
+        <div class="notice">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16.5v.01"/></svg>
+          La información médica solo puede ser modificada por personal autorizado. Si encuentras un error, contacta al servicio médico.
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<!-- DARK -->
+<div class="dark">
+  <div class="scope-label">Modo oscuro</div>
+  <div class="app">
+    <aside class="sb">
+      <div class="brand"><div class="y">Y</div>Yoltec</div>
+      <nav>
+        <a>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+          Inicio
+        </a>
+        <a>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+          Mis citas
+        </a>
+        <a>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+          Pre-evaluación IA
+        </a>
+        <a>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          Recetas
+        </a>
+        <a class="active">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+          Mi perfil
+        </a>
+      </nav>
+      <div class="user">
+        <div class="av">NC</div>
+        <div><b>Nestor Castillo</b><span>22690495</span></div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <div class="crumb">Mi perfil</div>
+      <h1>Mi perfil</h1>
+      <div class="sub">Datos personales, información médica y contacto de emergencia</div>
+
+      <div class="grid">
+        <div class="card">
+          <div class="id-card">
+            <div class="av">NC</div>
+            <h2>Nestor Castillo</h2>
+            <div class="ctrl">22690495</div>
+            <div class="career">Ing. Sistemas · 6° semestre</div>
+            <div class="badge">Cuenta activa</div>
+          </div>
+          <div class="id-actions">
+            <button class="btn-out">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 3 4 10.5V20h9.5L21 12.5 11.5 3Z"/><path d="m14 6 4 4"/></svg>
+              Editar información
+            </button>
+            <button class="btn-out">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+              Cambiar contraseña
+            </button>
+            <button class="btn-out danger">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5"/><path d="M21 12H9"/></svg>
+              Cerrar sesión
+            </button>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="tabs">
+            <div class="tab active">Información personal</div>
+            <div class="tab">Información médica</div>
+            <div class="tab">Notificaciones</div>
+          </div>
+
+          <div class="section">
+            <h3>Datos personales</h3>
+            <div class="row"><span class="lab">Nombre completo</span><span class="val">Nestor Castillo Vázquez</span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Número de control</span><span class="val">22690495</span><span></span></div>
+            <div class="row"><span class="lab">Fecha de nacimiento</span><span class="val">14 de marzo, 2004</span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Género</span><span class="val">Masculino</span><a class="edit">Editar</a></div>
+          </div>
+
+          <div class="section">
+            <h3>Contacto</h3>
+            <div class="row"><span class="lab">Correo institucional</span><span class="val"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="c6f4f4f0fff6f2fff386b2a3a5b0abe8abbe">[email&#160;protected]</a></span><span></span></div>
+            <div class="row"><span class="lab">Correo personal</span><span class="val"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="19777c6a6d766b377a6f597e74787075377a7674">[email&#160;protected]</a></span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Teléfono</span><span class="val">55 1234 5678</span><a class="edit">Editar</a></div>
+          </div>
+
+          <div class="section">
+            <h3>Información médica básica</h3>
+            <div class="row"><span class="lab">Tipo de sangre</span><span class="val">O+</span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Peso</span><span class="val">72 kg</span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Estatura</span><span class="val">1.75 m</span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Alergias</span><span class="val muted">Ninguna registrada</span><a class="edit">Agregar</a></div>
+            <div class="row"><span class="lab">Padecimientos</span><span class="val muted">Ninguno registrado</span><a class="edit">Agregar</a></div>
+          </div>
+
+          <div class="section">
+            <h3>Contacto de emergencia</h3>
+            <div class="row"><span class="lab">Nombre</span><span class="val">María Vázquez (madre)</span><a class="edit">Editar</a></div>
+            <div class="row"><span class="lab">Teléfono</span><span class="val">55 8721 4490</span><a class="edit">Editar</a></div>
+          </div>
+
+          <div class="notice">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16.5v.01"/></svg>
+            La información médica solo puede ser modificada por personal autorizado. Si encuentras un error, contacta al servicio médico.
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script></body>
+</html>

--- a/frontend/design-reference/Mis Recetas Web.html
+++ b/frontend/design-reference/Mis Recetas Web.html
@@ -1,0 +1,375 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mis recetas</title>
+<link rel="icon" href="assets/favicon.ico">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#f3f4f6;
+    --bg:#f8fafc; --chip-bg:#f3f4f6;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
+
+  .app{display:flex;min-height:100vh}
+
+  /* Sidebar */
+  .sb{width:220px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column;padding:22px 0}
+  .sb .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:28px;height:28px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb nav{display:flex;flex-direction:column;gap:2px;padding:14px 12px 0;flex:1}
+  .sb nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;cursor:pointer;text-decoration:none}
+  .sb nav a:hover{background:rgba(255,255,255,.05);color:#fff}
+  .sb nav a.active{background:rgba(255,255,255,.1);color:#fff;font-weight:600}
+  .sb nav a svg{width:16px;height:16px;stroke-width:1.8;flex-shrink:0;opacity:.95}
+  .sb .user{margin-top:auto;padding:14px 18px 4px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .sb .user b{display:block;font-size:13px;font-weight:600}
+  .sb .user span{font-size:11px;color:rgba(255,255,255,.65);font-variant-numeric:tabular-nums}
+
+  /* Main */
+  .main{flex:1;min-width:0;padding:32px}
+  .crumb{font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.5px;font-weight:600;margin-bottom:6px}
+  h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .sub{font-size:13.5px;color:var(--text-muted);margin-top:4px;margin-bottom:22px}
+
+  .search{position:relative;margin-bottom:22px;max-width:560px}
+  .search svg{position:absolute;left:14px;top:50%;transform:translateY(-50%);color:var(--text-subtle)}
+  .search input{width:100%;height:42px;background:var(--chip-bg);border:0;border-radius:8px;padding:0 14px 0 40px;font:500 13.5px 'Inter',sans-serif;color:var(--text);outline:none}
+  .search input::placeholder{color:var(--text-subtle)}
+  .search input:focus{box-shadow:0 0 0 3px var(--primary-50)}
+
+  .list{display:flex;flex-direction:column;gap:16px;max-width:880px}
+
+  .card{background:#fff;border-radius:12px;padding:20px;box-shadow:0 1px 3px rgba(0,0,0,.08);display:flex;flex-direction:column;gap:14px}
+
+  .row-top{display:flex;align-items:center;justify-content:space-between;gap:10px}
+  .date{display:inline-flex;background:var(--chip-bg);color:var(--text-muted);font-size:11px;font-weight:600;padding:4px 10px;border-radius:99px;letter-spacing:.4px;font-variant-numeric:tabular-nums}
+  .doc{font-size:12px;color:var(--text-muted);font-weight:500}
+
+  .sep{height:1px;background:var(--border-soft)}
+
+  .meds{display:flex;flex-direction:column;gap:8px}
+  .med{display:flex;align-items:flex-start;gap:10px;font-size:14px;line-height:1.4}
+  .med svg{width:14px;height:14px;color:var(--text-subtle);flex-shrink:0;margin-top:3px;stroke-width:1.7}
+  .med .name{color:var(--text);font-weight:500}
+  .med .dose{color:var(--text-muted);font-weight:400}
+
+  .notes{font-size:12px;color:var(--text-subtle);font-style:italic;line-height:1.4}
+
+  .detail{display:flex;align-items:center;justify-content:flex-end;gap:4px;font-size:13px;color:var(--primary);font-weight:600;cursor:pointer;text-decoration:none}
+  .detail svg{width:14px;height:14px;stroke-width:2}
+
+  /* Empty state */
+  .empty{background:#fff;border-radius:12px;padding:64px 32px;display:flex;flex-direction:column;align-items:center;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.06);max-width:880px}
+  .empty .ic{width:56px;height:56px;border-radius:50%;background:var(--chip-bg);display:flex;align-items:center;justify-content:center;color:var(--text-subtle);margin-bottom:16px}
+  .empty .ic svg{width:26px;height:26px;stroke-width:1.6}
+  .empty h3{margin:0 0 6px;font-size:16px;font-weight:600}
+  .empty p{margin:0;font-size:13.5px;color:var(--text-muted);max-width:340px;line-height:1.5}
+
+  /* Side-by-side preview (light + dark) */
+  .preview{display:flex;flex-direction:column;gap:24px}
+
+  /* Dark theme block */
+  .dark{background:#0f1117;color:#f9fafb}
+  .dark .main h1{color:#f9fafb}
+  .dark .sub,.dark .crumb{color:#9ca3af}
+  .dark .crumb{color:#9ca3af}
+  .dark .search input{background:#252836;color:#f9fafb}
+  .dark .search input::placeholder{color:#6b7280}
+  .dark .search svg{color:#6b7280}
+  .dark .card{background:#1a1d27;box-shadow:0 1px 3px rgba(0,0,0,.4)}
+  .dark .date{background:#252836;color:#9ca3af}
+  .dark .doc{color:#9ca3af}
+  .dark .sep{background:#252836}
+  .dark .med .name{color:#f9fafb}
+  .dark .med .dose{color:#9ca3af}
+  .dark .med svg{color:#6b7280}
+  .dark .notes{color:#6b7280}
+  .dark .empty{background:#1a1d27}
+  .dark .empty .ic{background:#252836;color:#9ca3af}
+  .dark .empty h3{color:#f9fafb}
+  .dark .empty p{color:#9ca3af}
+
+  .scope-label{position:relative;display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:700;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;margin:0 32px 8px}
+  .scope-label::after{content:'';height:1px;background:var(--border);flex:1;width:120px;display:inline-block;margin-left:8px}
+  .dark .scope-label{color:#9ca3af}
+  .dark .scope-label::after{background:#2d3144}
+
+  .empty-block{margin-top:24px;max-width:880px}
+</style>
+</head>
+<body>
+
+<!-- LIGHT MODE -->
+<div class="preview">
+  <div>
+    <div class="scope-label">Modo claro · Con recetas</div>
+    <div class="app" style="border-bottom:1px solid var(--border)">
+      <aside class="sb">
+        <div class="brand"><div class="y">Y</div>Yoltec</div>
+        <nav>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+            Inicio
+          </a>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+            Mis citas
+          </a>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+            Pre-evaluación IA
+          </a>
+          <a class="active">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+            Recetas
+          </a>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+            Mi perfil
+          </a>
+        </nav>
+        <div class="user">
+          <div class="av">NC</div>
+          <div><b>Nestor Castillo</b><span>22690495</span></div>
+        </div>
+      </aside>
+
+      <main class="main">
+        <div class="crumb">Recetas</div>
+        <h1>Mis recetas</h1>
+        <div class="sub">Historial de recetas médicas emitidas por el doctor</div>
+
+        <div class="search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+          <input placeholder="Buscar por medicamento o doctor...">
+        </div>
+
+        <div class="list">
+          <!-- Card 1 -->
+          <div class="card">
+            <div class="row-top">
+              <span class="date">7 ABR 2026</span>
+              <span class="doc">Dr. Omar Salas</span>
+            </div>
+            <div class="sep"></div>
+            <div class="meds">
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Paracetamol 500 mg</span><span class="dose"> — 1 tableta cada 8 hrs</span></span>
+              </div>
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Amoxicilina 500 mg</span><span class="dose"> — 1 cápsula cada 12 hrs</span></span>
+              </div>
+            </div>
+            <div class="sep"></div>
+            <div class="notes">Tomar con alimentos. Suspender si hay reacciones.</div>
+            <div class="sep"></div>
+            <a class="detail">Ver detalle completo
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+            </a>
+          </div>
+
+          <!-- Card 2 -->
+          <div class="card">
+            <div class="row-top">
+              <span class="date">22 MAR 2026</span>
+              <span class="doc">Dra. Laura Ramírez</span>
+            </div>
+            <div class="sep"></div>
+            <div class="meds">
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Loratadina 10 mg</span><span class="dose"> — 1 tableta cada 24 hrs</span></span>
+              </div>
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Mometasona spray nasal</span><span class="dose"> — 2 aplicaciones al día</span></span>
+              </div>
+            </div>
+            <div class="sep"></div>
+            <div class="notes">Evitar conducir si presenta somnolencia.</div>
+            <div class="sep"></div>
+            <a class="detail">Ver detalle completo
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+            </a>
+          </div>
+
+          <!-- Card 3 -->
+          <div class="card">
+            <div class="row-top">
+              <span class="date">14 FEB 2026</span>
+              <span class="doc">Dr. Javier Mendoza</span>
+            </div>
+            <div class="sep"></div>
+            <div class="meds">
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Ibuprofeno 400 mg</span><span class="dose"> — 1 tableta cada 6 hrs</span></span>
+              </div>
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Omeprazol 20 mg</span><span class="dose"> — 1 cápsula en ayunas</span></span>
+              </div>
+            </div>
+            <div class="sep"></div>
+            <div class="notes">Mantener reposo relativo durante 48 horas.</div>
+            <div class="sep"></div>
+            <a class="detail">Ver detalle completo
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+            </a>
+          </div>
+        </div>
+
+        <div class="empty empty-block">
+          <div class="ic">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          </div>
+          <h3>No tienes recetas activas</h3>
+          <p>Tus recetas médicas aparecerán aquí cuando el doctor las emita.</p>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <!-- DARK MODE -->
+  <div class="dark">
+    <div class="scope-label">Modo oscuro</div>
+    <div class="app">
+      <aside class="sb">
+        <div class="brand"><div class="y">Y</div>Yoltec</div>
+        <nav>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+            Inicio
+          </a>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+            Mis citas
+          </a>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+            Pre-evaluación IA
+          </a>
+          <a class="active">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+            Recetas
+          </a>
+          <a>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+            Mi perfil
+          </a>
+        </nav>
+        <div class="user">
+          <div class="av">NC</div>
+          <div><b>Nestor Castillo</b><span>22690495</span></div>
+        </div>
+      </aside>
+
+      <main class="main">
+        <div class="crumb">Recetas</div>
+        <h1>Mis recetas</h1>
+        <div class="sub">Historial de recetas médicas emitidas por el doctor</div>
+
+        <div class="search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+          <input placeholder="Buscar por medicamento o doctor...">
+        </div>
+
+        <div class="list">
+          <div class="card">
+            <div class="row-top">
+              <span class="date">7 ABR 2026</span>
+              <span class="doc">Dr. Omar Salas</span>
+            </div>
+            <div class="sep"></div>
+            <div class="meds">
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Paracetamol 500 mg</span><span class="dose"> — 1 tableta cada 8 hrs</span></span>
+              </div>
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Amoxicilina 500 mg</span><span class="dose"> — 1 cápsula cada 12 hrs</span></span>
+              </div>
+            </div>
+            <div class="sep"></div>
+            <div class="notes">Tomar con alimentos. Suspender si hay reacciones.</div>
+            <div class="sep"></div>
+            <a class="detail">Ver detalle completo
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+            </a>
+          </div>
+
+          <div class="card">
+            <div class="row-top">
+              <span class="date">22 MAR 2026</span>
+              <span class="doc">Dra. Laura Ramírez</span>
+            </div>
+            <div class="sep"></div>
+            <div class="meds">
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Loratadina 10 mg</span><span class="dose"> — 1 tableta cada 24 hrs</span></span>
+              </div>
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Mometasona spray nasal</span><span class="dose"> — 2 aplicaciones al día</span></span>
+              </div>
+            </div>
+            <div class="sep"></div>
+            <div class="notes">Evitar conducir si presenta somnolencia.</div>
+            <div class="sep"></div>
+            <a class="detail">Ver detalle completo
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+            </a>
+          </div>
+
+          <div class="card">
+            <div class="row-top">
+              <span class="date">14 FEB 2026</span>
+              <span class="doc">Dr. Javier Mendoza</span>
+            </div>
+            <div class="sep"></div>
+            <div class="meds">
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Ibuprofeno 400 mg</span><span class="dose"> — 1 tableta cada 6 hrs</span></span>
+              </div>
+              <div class="med">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+                <span><span class="name">Omeprazol 20 mg</span><span class="dose"> — 1 cápsula en ayunas</span></span>
+              </div>
+            </div>
+            <div class="sep"></div>
+            <div class="notes">Mantener reposo relativo durante 48 horas.</div>
+            <div class="sep"></div>
+            <a class="detail">Ver detalle completo
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+            </a>
+          </div>
+        </div>
+
+        <div class="empty empty-block">
+          <div class="ic">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          </div>
+          <h3>No tienes recetas activas</h3>
+          <p>Tus recetas médicas aparecerán aquí cuando el doctor las emita.</p>
+        </div>
+      </main>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/frontend/design-reference/Prioridad IA Doctor.html
+++ b/frontend/design-reference/Prioridad IA Doctor.html
@@ -10,327 +10,470 @@
   @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
   @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
   :root{
-    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f1ec; --primary-100:#d1e3d8;
-    --danger:#dc2626; --danger-50:#fef2f2; --danger-100:#fecaca; --danger-700:#991b1b;
-    --warn:#ea580c; --warn-50:#fff7ed; --warn-100:#fed7aa; --warn-700:#9a3412;
-    --info:#3b82f6; --info-50:#eff6ff; --info-700:#1e40af;
-    --bg:#f7f9f8; --surface:#fff;
-    --border:#e2e8e5; --border-strong:#cdd9d3;
-    --text:#1a2e25; --text-muted:#4a6859; --text-subtle:#7b8f86;
-    --soft:#f9fafb;
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee; --primary-100:#d1e3d8;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#f3f4f6;
+    --bg:#f8fafc; --chip-bg:#f3f4f6; --soft:#f9fafb;
+    --danger:#dc2626; --danger-50:#fef2f2; --danger-100:#fecaca;
+    --warn:#b45309; --warn-50:#fef3c7;
+    --info:#1d4ed8; --info-50:#dbeafe;
   }
   *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
-  html,body,#app{margin:0;padding:0;min-height:100vh}
-  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);background:var(--bg)}
-  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit}
-  input,select{font-family:inherit}
-  a{color:var(--primary);text-decoration:none;font-weight:600;cursor:pointer}
-  a:hover{text-decoration:underline}
+  html,body{margin:0;padding:0;min-height:100vh;background:var(--bg);font-family:'Inter',system-ui,sans-serif;color:var(--text)}
+  button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit;font-size:inherit}
+  input,select{font-family:inherit;color:inherit}
 
   .app{display:flex;min-height:100vh}
 
-  /* Sidebar (same as Pre-evaluaciones) */
-  .sb{width:240px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column}
-  .sb .brand{padding:22px 22px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(255,255,255,.1)}
-  .sb .y{width:32px;height:32px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
-  .sb .brand b{font-size:17px;font-weight:700;letter-spacing:-.3px}
-  .sb .brand span{font-size:11px;opacity:.7;display:block;margin-top:1px}
-  .sb nav{padding:14px 0;display:flex;flex-direction:column;gap:1px;flex:1}
-  .sb nav a{padding:11px 22px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;display:flex;align-items:center;gap:12px;border-left:3px solid transparent;text-decoration:none}
-  .sb nav a:hover{background:rgba(255,255,255,.05);text-decoration:none}
-  .sb nav a.active{background:rgba(255,255,255,.08);color:#fff;border-left-color:#86efac;font-weight:600}
-  .sb nav a .ic{font-size:14px;width:16px;text-align:center}
-  .sb nav a .ct{margin-left:auto;background:var(--danger);color:#fff;font-size:10.5px;font-weight:700;padding:1px 7px;border-radius:999px;min-width:18px;text-align:center}
-  .sb .user{padding:16px 22px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
-  .sb .av{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px}
-  .sb .user b{display:block;font-size:13px;font-weight:600;line-height:1.2}
-  .sb .user span{font-size:11.5px;opacity:.7;display:block;margin-top:2px}
+  /* Sidebar Doctor */
+  .sb{width:240px;flex-shrink:0;background:var(--primary);color:#fff;display:flex;flex-direction:column;padding:22px 0}
+  .sb .brand{display:flex;align-items:center;gap:10px;padding:0 22px 24px;font-weight:700;font-size:16px;border-bottom:1px solid rgba(255,255,255,.1)}
+  .sb .y{width:28px;height:28px;border-radius:7px;background:#fff;color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px}
+  .sb nav{display:flex;flex-direction:column;gap:2px;padding:14px 12px 0;flex:1}
+  .sb nav a{display:flex;align-items:center;gap:11px;padding:10px 12px;color:rgba(255,255,255,.85);font-size:13.5px;font-weight:500;border-radius:8px;cursor:pointer;text-decoration:none}
+  .sb nav a:hover{background:rgba(255,255,255,.05);color:#fff}
+  .sb nav a.active{background:rgba(255,255,255,.1);color:#fff;font-weight:600}
+  .sb nav a svg{width:16px;height:16px;stroke-width:1.8;flex-shrink:0}
+  .sb nav a .ct{margin-left:auto;background:var(--danger);color:#fff;font-size:10.5px;font-weight:700;padding:1px 6px;border-radius:99px}
+  .sb .user{margin-top:auto;padding:14px 18px 4px;border-top:1px solid rgba(255,255,255,.1);display:flex;align-items:center;gap:11px}
+  .sb .user .av{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.18);display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12.5px}
+  .sb .user b{display:block;font-size:13px;font-weight:600}
+  .sb .user span{font-size:11px;color:rgba(255,255,255,.65)}
 
-  /* Main */
-  .main{flex:1;min-width:0;display:flex;flex-direction:column}
-  .header{padding:28px 36px 24px;background:#fff;border-bottom:1px solid var(--border)}
-  .head-top{display:flex;justify-content:space-between;align-items:flex-start;gap:20px}
-  .crumb{font-size:12px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:500;margin-bottom:6px}
-  h1{margin:0 0 4px;font-size:24px;font-weight:700;letter-spacing:-.4px}
-  .sub{font-size:13.5px;color:var(--text-muted)}
+  .main{flex:1;min-width:0;padding:28px 32px 32px}
+  .head{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:18px;gap:14px;flex-wrap:wrap}
+  .crumb{font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.5px;font-weight:600;margin-bottom:6px}
+  h1{margin:0;font-size:24px;font-weight:700;letter-spacing:-.4px}
+  .sub{font-size:13.5px;color:var(--text-muted);margin-top:4px;max-width:640px}
 
-  .banner{display:flex;align-items:flex-start;gap:11px;background:var(--info-50);border-left:3px solid var(--info);border-radius:0 8px 8px 0;padding:12px 16px;margin-top:18px;color:#1e3a8a;font-size:13px;line-height:1.55}
-  .banner .ic{width:18px;height:18px;border-radius:50%;background:var(--info);color:#fff;display:inline-flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;flex-shrink:0;margin-top:1px}
-  .banner b{font-weight:600;color:#1e3a8a}
-
-  .btn{padding:9px 14px;border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:all .15s;white-space:nowrap;border:1px solid transparent}
+  .btn{padding:9px 14px;border-radius:7px;font:600 13px 'Inter',sans-serif;cursor:pointer;display:inline-flex;align-items:center;gap:7px;border:1px solid transparent;white-space:nowrap}
   .btn.primary{background:var(--primary);color:#fff}
   .btn.primary:hover{background:var(--primary-600)}
   .btn.outline{background:#fff;color:var(--primary);border-color:var(--primary)}
   .btn.outline:hover{background:var(--primary-50)}
-  .btn.ghost{color:var(--text-muted)}
-  .btn.ghost:hover{background:var(--bg)}
-  .btn.sm{padding:6px 12px;font-size:12.5px}
+  .btn.ghost{color:var(--text-muted);background:transparent}
+  .btn.ghost:hover{background:var(--chip-bg);color:var(--text)}
+  .btn.sm{padding:6px 11px;font-size:12.5px}
 
-  .content{padding:24px 36px 60px;flex:1}
+  /* Info banner */
+  .banner{display:flex;align-items:flex-start;gap:11px;background:var(--info-50);border-left:3px solid var(--info);border-radius:0 8px 8px 0;padding:12px 16px;margin-bottom:18px;font-size:13px;color:#1e3a8a;line-height:1.5}
+  .banner svg{flex-shrink:0;color:var(--info);width:18px;height:18px;stroke-width:1.8;margin-top:1px}
+  .banner b{color:#1e3a8a;font-weight:600}
 
-  /* KPI mini cards */
-  .kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-bottom:24px}
-  .kpi{border-radius:12px;padding:18px 20px;border:1px solid var(--border);position:relative;overflow:hidden}
-  .kpi .lbl{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;display:flex;align-items:center;gap:7px}
+  /* KPIs */
+  .kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-bottom:20px}
+  .kpi{border-radius:12px;padding:18px 20px;border:1px solid var(--border-soft);position:relative;overflow:hidden}
+  .kpi .lbl{font-size:11px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;display:flex;align-items:center;gap:7px}
   .kpi .lbl .dot{width:8px;height:8px;border-radius:50%}
-  .kpi .n{font-size:42px;font-weight:700;letter-spacing:-1px;line-height:1;margin-top:14px;font-variant-numeric:tabular-nums}
+  .kpi .n{font-size:38px;font-weight:700;letter-spacing:-1px;line-height:1;margin-top:12px;font-variant-numeric:tabular-nums}
   .kpi .foot{font-size:12px;margin-top:8px;display:flex;justify-content:space-between;align-items:baseline}
   .kpi .foot b{font-weight:600}
-  .kpi.red{background:var(--danger-50);border-color:#fecaca}
-  .kpi.red .lbl,.kpi.red .n,.kpi.red .foot b{color:var(--danger-700)}
-  .kpi.red .dot{background:var(--danger)}
-  .kpi.red .foot{color:#b91c1c}
-  .kpi.orange{background:var(--warn-50);border-color:#fed7aa}
-  .kpi.orange .lbl,.kpi.orange .n,.kpi.orange .foot b{color:var(--warn-700)}
-  .kpi.orange .dot{background:var(--warn)}
-  .kpi.orange .foot{color:#c2410c}
-  .kpi.gray{background:var(--soft);border-color:var(--border)}
-  .kpi.gray .lbl,.kpi.gray .n,.kpi.gray .foot b{color:var(--text-muted)}
-  .kpi.gray .dot{background:var(--text-subtle)}
-  .kpi.gray .foot{color:var(--text-subtle)}
+  .kpi.alta{background:var(--danger-50);border-color:#fecaca}
+  .kpi.alta .lbl,.kpi.alta .n,.kpi.alta .foot b{color:#991b1b}
+  .kpi.alta .dot{background:var(--danger)}
+  .kpi.alta .foot{color:#b91c1c}
+  .kpi.media{background:var(--warn-50);border-color:#fde68a}
+  .kpi.media .lbl,.kpi.media .n,.kpi.media .foot b{color:#92400e}
+  .kpi.media .dot{background:#d97706}
+  .kpi.media .foot{color:#b45309}
+  .kpi.baja{background:var(--primary-50);border-color:var(--primary-100)}
+  .kpi.baja .lbl,.kpi.baja .n,.kpi.baja .foot b{color:var(--primary)}
+  .kpi.baja .dot{background:var(--primary)}
+  .kpi.baja .foot{color:var(--primary)}
+
+  /* Toolbar */
+  .toolbar{background:#fff;border:1px solid var(--border-soft);border-radius:10px;padding:12px 14px;display:flex;gap:10px;align-items:center;margin-bottom:14px;flex-wrap:wrap}
+  .pill-tabs{display:inline-flex;background:var(--chip-bg);border-radius:8px;padding:3px;gap:2px}
+  .pill-tabs button{padding:6px 12px;font:600 12.5px 'Inter',sans-serif;color:var(--text-muted);border-radius:6px}
+  .pill-tabs button.active{background:#fff;color:var(--text);box-shadow:0 1px 2px rgba(0,0,0,.06)}
+  .spacer{flex:1}
+  .search{position:relative;width:240px}
+  .search svg{position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-subtle)}
+  .search input{width:100%;height:34px;background:var(--soft);border:1px solid var(--border);border-radius:7px;padding:0 12px 0 36px;font:500 12.5px 'Inter',sans-serif;outline:none}
+  .search input:focus{border-color:var(--primary);box-shadow:0 0 0 3px var(--primary-50)}
+  .filter-sel{height:34px;padding:0 30px 0 12px;background:#fff;border:1px solid var(--border);border-radius:7px;font:500 12.5px 'Inter',sans-serif;color:var(--text);appearance:none;background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");background-repeat:no-repeat;background-position:right 10px center}
 
   /* Table */
-  .table-wrap{background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(26,92,58,.04)}
-  .table-head{padding:16px 22px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border);gap:12px;flex-wrap:wrap}
-  .table-head h2{margin:0;font-size:15px;font-weight:600}
-  .table-head .meta{font-size:12px;color:var(--text-subtle)}
-  .table-head .meta b{color:var(--text-muted);font-weight:600}
-  .th-actions{display:flex;gap:8px;align-items:center}
-  .pill-tabs{display:flex;background:var(--bg);border-radius:7px;padding:3px;gap:1px}
-  .pill-tabs button{padding:6px 12px;border-radius:5px;font-size:12px;font-weight:500;color:var(--text-muted)}
-  .pill-tabs button.active{background:#fff;color:var(--text);box-shadow:0 1px 2px rgba(0,0,0,.06)}
+  .table-wrap{background:#fff;border:1px solid var(--border-soft);border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+  .table-h{padding:14px 18px;border-bottom:1px solid var(--border-soft);display:flex;justify-content:space-between;align-items:center}
+  .table-h h2{margin:0;font-size:14px;font-weight:600}
+  .table-h .meta{font-size:11.5px;color:var(--text-subtle);font-weight:500}
 
-  table{width:100%;border-collapse:collapse;font-size:13.5px}
-  thead th{text-align:left;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;background:var(--soft);padding:11px 22px;border-bottom:1px solid var(--border);white-space:nowrap}
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  thead th{text-align:left;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase;background:var(--soft);padding:11px 22px;border-bottom:1px solid var(--border-soft);white-space:nowrap}
   thead th.num{text-align:right}
   thead th .so{margin-left:4px;color:var(--text-subtle);font-size:9px}
-  tbody td{padding:14px 22px;border-bottom:1px solid var(--border);vertical-align:middle}
+  tbody td{padding:13px 22px;border-bottom:1px solid var(--border-soft);vertical-align:middle}
   tbody tr:last-child td{border-bottom:none}
-  tbody tr:hover{background:var(--soft)}
+  tbody tr:hover{background:var(--soft);cursor:pointer}
 
   .who{display:flex;align-items:center;gap:11px;min-width:200px}
-  .who .av{width:36px;height:36px;border-radius:50%;background:var(--primary-50);color:var(--primary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12.5px;flex-shrink:0}
+  .who .av{width:34px;height:34px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px;flex-shrink:0}
   .who b{display:block;font-size:13.5px;font-weight:600}
   .who span{font-size:11.5px;color:var(--text-subtle);font-variant-numeric:tabular-nums}
 
-  .symp{color:var(--text-muted);max-width:340px;display:flex;align-items:center;gap:6px;font-size:13px}
-  .symp .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:280px}
+  .symp{color:var(--text-muted);max-width:340px;font-size:13px;line-height:1.4}
+  .symp .tx{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:340px}
+  .symp .ver{color:var(--primary);font-weight:600;font-size:12px}
 
-  .score{font-weight:700;font-size:14.5px;font-variant-numeric:tabular-nums;text-align:right;white-space:nowrap}
+  .score{text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums;font-weight:700;font-size:14.5px}
   .score small{font-weight:500;color:var(--text-subtle);font-size:11.5px;margin-left:3px}
-  .score .bar{display:inline-block;vertical-align:middle;width:60px;height:5px;background:var(--bg);border-radius:999px;margin-right:9px;overflow:hidden;border:1px solid var(--border)}
-  .score .bar i{display:block;height:100%}
+  .bar{display:inline-block;vertical-align:middle;width:64px;height:5px;background:var(--chip-bg);border-radius:99px;margin-right:9px;overflow:hidden;border:1px solid var(--border)}
+  .bar i{display:block;height:100%}
 
-  .b{display:inline-flex;padding:4px 10px;border-radius:999px;font-size:11px;font-weight:700;align-items:center;gap:5px;text-transform:uppercase;letter-spacing:.3px;border:1px solid transparent}
+  .b{display:inline-flex;padding:4px 10px;border-radius:99px;font-size:11px;font-weight:700;align-items:center;gap:5px;text-transform:uppercase;letter-spacing:.3px;border:1px solid transparent}
   .b .dot{width:6px;height:6px;border-radius:50%;background:currentColor}
-  .b.red{background:var(--danger-50);color:var(--danger-700);border-color:#fecaca}
-  .b.orange{background:var(--warn-50);color:var(--warn-700);border-color:#fed7aa}
-  .b.gray{background:var(--soft);color:var(--text-muted);border-color:var(--border)}
+  .b.alta{background:var(--danger-50);color:#991b1b;border-color:#fecaca}
+  .b.media{background:var(--warn-50);color:#92400e;border-color:#fde68a}
+  .b.baja{background:var(--primary-50);color:var(--primary);border-color:var(--primary-100)}
 
-  .date{color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap}
+  .date{color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap;font-size:12.5px}
   .date.muted{color:var(--text-subtle);font-style:italic}
 
-  .footnote{margin-top:14px;padding:10px 14px;font-size:11.5px;color:var(--text-subtle);display:flex;align-items:center;gap:8px}
-  .footnote .ic{width:14px;height:14px;border-radius:50%;border:1.5px solid var(--text-subtle);display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:700;flex-shrink:0}
+  /* Footer table */
+  .pag{display:flex;justify-content:space-between;align-items:center;padding:13px 22px;border-top:1px solid var(--border-soft);font-size:12px;color:var(--text-subtle)}
+  .pag .pages{display:flex;gap:4px}
+  .pag .pages button{width:30px;height:30px;border:1px solid var(--border);background:#fff;color:var(--text);border-radius:6px;font:500 12.5px 'Inter',sans-serif;cursor:pointer}
+  .pag .pages button.active{background:var(--primary);color:#fff;border-color:var(--primary);font-weight:600}
 
-  .updated{font-size:11.5px;color:var(--text-subtle);margin-top:8px;text-align:right}
+  .footnote{margin-top:14px;padding:10px 14px;font-size:11.5px;color:var(--text-subtle);display:flex;align-items:flex-start;gap:8px;line-height:1.4}
+  .footnote svg{width:14px;height:14px;flex-shrink:0;margin-top:1px;stroke-width:1.8}
+
+  /* DRAWER (detail) */
+  .scope{display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:700;color:var(--text-muted);letter-spacing:.5px;text-transform:uppercase;margin:24px 32px 6px}
+  .scope::after{content:'';height:1px;background:var(--border);flex:1;width:160px;display:inline-block;margin-left:8px}
+
+  .with-drawer{position:relative;padding-right:380px}
+  .detail-side{position:absolute;right:32px;top:0;bottom:0;width:360px;background:#fff;border:1px solid var(--border);border-radius:12px;box-shadow:0 6px 24px rgba(0,0,0,.06);overflow:hidden;display:flex;flex-direction:column}
+  .detail-hd{padding:16px 18px;border-bottom:1px solid var(--border-soft);display:flex;justify-content:space-between;align-items:flex-start}
+  .detail-hd h3{margin:0;font-size:15px;font-weight:700}
+  .detail-hd .meta{font-size:11px;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.4px;font-weight:600}
+  .detail-bd{padding:16px 18px;flex:1;overflow:auto}
+  .detail-bd .who-card{display:flex;align-items:center;gap:11px;margin-bottom:14px}
+  .detail-bd .who-card .av{width:42px;height:42px;border-radius:50%;background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px}
+  .detail-bd h4{margin:14px 0 6px;font-size:10.5px;font-weight:700;color:var(--text-subtle);letter-spacing:.5px;text-transform:uppercase}
+  .detail-bd .kv{font-size:12.5px;color:var(--text);line-height:1.5}
+  .detail-bd .kv b{color:var(--text);font-weight:600}
+  .breakdown{display:flex;flex-direction:column;gap:8px}
+  .br-row{display:grid;grid-template-columns:1fr auto;gap:6px;font-size:12.5px}
+  .br-row .lbl{color:var(--text-muted)}
+  .br-row .val{font-weight:600;color:var(--text);font-variant-numeric:tabular-nums}
+  .br-row .bar2{grid-column:1/-1;height:4px;background:var(--chip-bg);border-radius:99px;overflow:hidden}
+  .br-row .bar2 i{display:block;height:100%;background:var(--primary);border-radius:99px}
+  .br-row.alta .bar2 i{background:var(--danger)}
+  .br-row.media .bar2 i{background:#d97706}
+  .detail-foot{padding:12px 18px;border-top:1px solid var(--border-soft);background:var(--soft);display:flex;gap:6px}
+  .detail-foot .btn{flex:1;justify-content:center;font-size:12px}
+
+  .pills{display:flex;flex-wrap:wrap;gap:5px;margin-top:4px}
+  .pill{font-size:11px;font-weight:500;padding:3px 9px;border-radius:99px;background:var(--chip-bg);color:var(--text-muted)}
+  .pill.warn{background:var(--warn-50);color:var(--warn)}
+  .pill.danger{background:var(--danger-50);color:#991b1b}
 </style>
 </head>
 <body>
-<div id="app"></div>
 
-<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<!-- VISTA A · Listado -->
+<div class="scope">Vista A · Lista de pacientes clasificados</div>
+<div class="app">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>Panel</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Citas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>Bitácoras</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>Pre-evaluaciones<span class="ct">3</span></a>
+      <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="9"/></svg>Prioridad IA</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21V10l9-7 9 7v11"/><path d="M9 21v-7h6v7"/></svg>Estadísticas</a>
+    </nav>
+    <div class="user">
+      <div class="av">OG</div>
+      <div><b>Dr. Omar González</b><span>Médico general</span></div>
+    </div>
+  </aside>
 
-<script type="text/babel">
-function Sidebar(){
-  const items=[
-    ['panel','Panel','▦'],
-    ['citas','Citas','⊞'],
-    ['bit','Bitácoras','≡'],
-    ['rec','Recetas','℞'],
-    ['pe','Pre-evaluaciones','◔',false,3],
-    ['pri','Prioridad IA','◉',true],
-    ['est','Estadísticas','◊'],
-  ];
-  return (
-    <aside className="sb">
-      <div className="brand"><div className="y">Y</div><div><b>Yoltec</b><span>Panel médico</span></div></div>
-      <nav>{items.map(([k,l,i,a,n])=>(<a key={k} className={a?'active':''}><span className="ic">{i}</span>{l}{n?<span className="ct">{n}</span>:null}</a>))}</nav>
-      <div className="user"><div className="av">OG</div><div><b>Dr. Omar González</b><span>Médico general</span></div></div>
-    </aside>
-  );
-}
-
-const ROWS=[
-  {
-    av:'LF', nombre:'Lucía Fuentes Ortiz', ctrl:'21450923',
-    sintomas:'Dolor abdominal en fosa iliaca derecha 6/10, náusea sin vómito, sin fiebre desde anoche.',
-    score:21, pri:'ALTA', cita:'2 may 2026',
-    factores:'Síntomas agudos + inasistencias previas (3)'
-  },
-  {
-    av:'AP', nombre:'Ana Pérez García', ctrl:'22690495',
-    sintomas:'Odinofagia intensa 3 días, fiebre 38.4 °C, alergia confirmada a penicilina.',
-    score:18, pri:'ALTA', cita:'10 abr 2026',
-    factores:'Alergia medicamentosa + fiebre alta'
-  },
-  {
-    av:'DK', nombre:'Diego Kuri Salazar', ctrl:'22034512',
-    sintomas:'Crisis asmática leve esta mañana, sibilancias audibles, usa inhalador.',
-    score:16, pri:'ALTA', cita:'15 mar 2026',
-    factores:'Asma crónica + síntomas activos'
-  },
-  {
-    av:'RM', nombre:'Raúl Mendoza Vidal', ctrl:'22134781',
-    sintomas:'Cefalea pulsátil derecha con fotofobia y náusea, 2 días de evolución, recurrente.',
-    score:13, pri:'MEDIA', cita:'28 abr 2026',
-    factores:'Recurrencia mensual'
-  },
-  {
-    av:'KB', nombre:'Karla Bárcenas Ríos', ctrl:'21897603',
-    sintomas:'Dolor lumbar mecánico 4 días, irradia a glúteo derecho, sin parestesias.',
-    score:11, pri:'MEDIA', cita:'sin citas',
-    factores:'Primera consulta, sin antecedentes'
-  },
-  {
-    av:'JS', nombre:'Jorge Salinas Méndez', ctrl:'22789012',
-    sintomas:'Tos seca persistente 5 días, irritación faríngea leve, sin fiebre.',
-    score:9, pri:'MEDIA', cita:'5 may 2026',
-    factores:'Síntomas leves controlados'
-  },
-  {
-    av:'MC', nombre:'María Carrillo López', ctrl:'21567890',
-    sintomas:'Revisión de control hipertensión arterial — sin síntomas nuevos.',
-    score:6, pri:'BAJA', cita:'3 may 2026',
-    factores:'Control rutinario'
-  },
-  {
-    av:'IT', nombre:'Iván Torres Ramírez', ctrl:'23012398',
-    sintomas:'Solicita constancia médica para clase de educación física.',
-    score:3, pri:'BAJA', cita:'1 may 2026',
-    factores:'Trámite administrativo'
-  },
-];
-
-function priClass(p){return p==='ALTA'?'red':p==='MEDIA'?'orange':'gray'}
-function priFill(p){return p==='ALTA'?'#dc2626':p==='MEDIA'?'#ea580c':'#94a3b8'}
-
-function Row({r}){
-  const pct=Math.min(100,(r.score/22)*100);
-  return (
-    <tr>
-      <td>
-        <div className="who">
-          <div className="av">{r.av}</div>
-          <div><b>{r.nombre}</b><span>No. {r.ctrl}</span></div>
+  <main class="main">
+    <div class="head">
+      <div>
+        <div class="crumb">Servicio médico · Triage</div>
+        <h1>Clasificación de Prioridad IA</h1>
+        <div class="sub">Herramienta de apoyo. La decisión final es del doctor.</div>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+        <div style="display:flex;gap:8px">
+          <button class="btn outline">Exportar</button>
+          <button class="btn primary">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg>
+            Actualizar clasificación
+          </button>
         </div>
-      </td>
-      <td>
-        <div className="symp" title={r.sintomas}>
-          <span className="tx">{r.sintomas}</span>
-          <a>ver más</a>
-        </div>
-      </td>
-      <td className="score">
-        <span className="bar"><i style={{width:pct+'%',background:priFill(r.pri)}}/></span>
-        {r.score}<small>pts</small>
-      </td>
-      <td><span className={'b '+priClass(r.pri)}><span className="dot"></span>{r.pri}</span></td>
-      <td className={r.cita==='sin citas'?'date muted':'date'}>{r.cita==='sin citas'?'Sin citas':r.cita}</td>
-      <td><button className="btn outline sm">Ver ficha</button></td>
-    </tr>
-  );
-}
+        <div style="font-size:11.5px;color:var(--text-subtle)">Última actualización: hoy, 09:14</div>
+      </div>
+    </div>
 
-function App(){
-  return (
-    <div className="app">
-      <Sidebar/>
-      <div className="main">
-        <div className="header">
-          <div className="head-top">
-            <div>
-              <div className="crumb">Servicio médico · Triage</div>
-              <h1>Clasificación de Prioridad IA</h1>
-              <div className="sub">Herramienta de apoyo. La decisión final es del doctor.</div>
-            </div>
-            <div style={{display:'flex',flexDirection:'column',alignItems:'flex-end',gap:6}}>
-              <button className="btn primary">↻ Actualizar clasificación</button>
-              <div className="updated">Última actualización: hoy, 09:14</div>
-            </div>
-          </div>
-          <div className="banner">
-            <span className="ic">i</span>
-            <span>La puntuación se calcula con base en <b>síntomas reportados</b>, <b>historial de inasistencias</b> y <b>condiciones crónicas registradas</b>. Pondera severidad, frecuencia y cronicidad para sugerir un orden de atención.</span>
-          </div>
-        </div>
+    <div class="banner">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16v.01"/></svg>
+      <span>La puntuación se calcula con base en <b>síntomas reportados</b>, <b>historial de inasistencias</b> y <b>condiciones crónicas registradas</b>. Pondera severidad, frecuencia y cronicidad para sugerir un orden de atención.</span>
+    </div>
 
-        <div className="content">
-          <div className="kpis">
-            <div className="kpi red">
-              <div className="lbl"><span className="dot"></span>Alta prioridad</div>
-              <div className="n">3</div>
-              <div className="foot"><span><b>≥15 pts</b></span><span>+1 vs ayer</span></div>
-            </div>
-            <div className="kpi orange">
-              <div className="lbl"><span className="dot"></span>Media prioridad</div>
-              <div className="n">7</div>
-              <div className="foot"><span><b>8 – 14 pts</b></span><span>−2 vs ayer</span></div>
-            </div>
-            <div className="kpi gray">
-              <div className="lbl"><span className="dot"></span>Baja prioridad</div>
-              <div className="n">12</div>
-              <div className="foot"><span><b>&lt;8 pts</b></span><span>=  vs ayer</span></div>
-            </div>
-          </div>
+    <div class="kpis">
+      <div class="kpi alta">
+        <div class="lbl"><span class="dot"></span>Alta prioridad</div>
+        <div class="n">3</div>
+        <div class="foot"><span><b>≥15 pts</b></span><span>+1 vs ayer</span></div>
+      </div>
+      <div class="kpi media">
+        <div class="lbl"><span class="dot"></span>Media prioridad</div>
+        <div class="n">7</div>
+        <div class="foot"><span><b>8 – 14 pts</b></span><span>−2 vs ayer</span></div>
+      </div>
+      <div class="kpi baja">
+        <div class="lbl"><span class="dot"></span>Baja prioridad</div>
+        <div class="n">12</div>
+        <div class="foot"><span><b>&lt;8 pts</b></span><span>= vs ayer</span></div>
+      </div>
+    </div>
 
-          <div className="table-wrap">
-            <div className="table-head">
-              <div>
-                <h2>Alumnos clasificados</h2>
-                <div className="meta"><b>22</b> alumnos analizados · ordenado por score descendente</div>
-              </div>
-              <div className="th-actions">
-                <div className="pill-tabs">
-                  <button className="active">Todos</button>
-                  <button>Alta</button>
-                  <button>Media</button>
-                  <button>Baja</button>
-                </div>
-                <button className="btn ghost sm">Exportar</button>
-              </div>
-            </div>
-            <table>
-              <thead>
-                <tr>
-                  <th>Alumno</th>
-                  <th>Síntomas</th>
-                  <th className="num">Score <span className="so">▼</span></th>
-                  <th>Prioridad</th>
-                  <th>Última cita</th>
-                  <th>Acción</th>
-                </tr>
-              </thead>
-              <tbody>
-                {ROWS.map((r,i)=><Row key={i} r={r}/>)}
-              </tbody>
-            </table>
-          </div>
+    <div class="toolbar">
+      <div class="pill-tabs">
+        <button class="active">Todos</button>
+        <button>Alta</button>
+        <button>Media</button>
+        <button>Baja</button>
+      </div>
+      <div class="spacer"></div>
+      <div class="search">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+        <input placeholder="Buscar alumno...">
+      </div>
+      <select class="filter-sel">
+        <option>Todas las carreras</option><option>Ing. Sistemas</option><option>Ing. Industrial</option><option>Lic. Administración</option>
+      </select>
+    </div>
 
-          <div className="footnote">
-            <span className="ic">i</span>
-            Los resultados son orientativos y de apoyo al criterio médico. La clasificación no sustituye la evaluación clínica ni constituye un diagnóstico.
-          </div>
+    <div class="table-wrap">
+      <div class="table-h">
+        <div><h2>Alumnos clasificados</h2></div>
+        <div class="meta"><b>22</b> alumnos analizados · ordenado por score descendente</div>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Alumno</th>
+            <th>Síntomas</th>
+            <th class="num">Score <span class="so">▼</span></th>
+            <th>Prioridad</th>
+            <th>Última cita</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><div class="who"><div class="av">LF</div><div><b>Lucía Fuentes Ortiz</b><span>21450923</span></div></div></td>
+            <td class="symp"><span class="tx">Dolor abdominal en fosa iliaca derecha 6/10, náusea, sin fiebre…</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:95%;background:var(--danger)"></i></span>21<small>pts</small></td>
+            <td><span class="b alta"><span class="dot"></span>Alta</span></td>
+            <td class="date">02 may 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">AP</div><div><b>Ana Pérez García</b><span>22690495</span></div></div></td>
+            <td class="symp"><span class="tx">Odinofagia intensa 3 días, fiebre 38.4 °C, alergia a penicilina…</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:82%;background:var(--danger)"></i></span>18<small>pts</small></td>
+            <td><span class="b alta"><span class="dot"></span>Alta</span></td>
+            <td class="date">10 abr 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">DK</div><div><b>Diego Kuri Salazar</b><span>22034512</span></div></div></td>
+            <td class="symp"><span class="tx">Crisis asmática leve, sibilancias audibles, usa inhalador…</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:73%;background:var(--danger)"></i></span>16<small>pts</small></td>
+            <td><span class="b alta"><span class="dot"></span>Alta</span></td>
+            <td class="date">15 mar 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">RM</div><div><b>Raúl Mendoza Vidal</b><span>22134781</span></div></div></td>
+            <td class="symp"><span class="tx">Cefalea pulsátil con fotofobia y náusea, 2 días, recurrente.</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:60%;background:#d97706"></i></span>13<small>pts</small></td>
+            <td><span class="b media"><span class="dot"></span>Media</span></td>
+            <td class="date">28 abr 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">KB</div><div><b>Karla Bárcenas Ríos</b><span>21897603</span></div></div></td>
+            <td class="symp"><span class="tx">Dolor lumbar mecánico 4 días, irradia a glúteo derecho.</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:50%;background:#d97706"></i></span>11<small>pts</small></td>
+            <td><span class="b media"><span class="dot"></span>Media</span></td>
+            <td class="date muted">sin citas</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">JS</div><div><b>Jorge Salinas Méndez</b><span>22789012</span></div></div></td>
+            <td class="symp"><span class="tx">Tos seca persistente 5 días, irritación faríngea leve.</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:41%;background:#d97706"></i></span>9<small>pts</small></td>
+            <td><span class="b media"><span class="dot"></span>Media</span></td>
+            <td class="date">5 may 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">MC</div><div><b>María Carrillo López</b><span>21567890</span></div></div></td>
+            <td class="symp"><span class="tx">Revisión de control hipertensión arterial — sin síntomas nuevos.</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:28%;background:var(--primary)"></i></span>6<small>pts</small></td>
+            <td><span class="b baja"><span class="dot"></span>Baja</span></td>
+            <td class="date">3 may 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">IT</div><div><b>Iván Torres Ramírez</b><span>23012398</span></div></div></td>
+            <td class="symp"><span class="tx">Solicita constancia médica para clase de educación física.</span><a class="ver">ver más</a></td>
+            <td class="score"><span class="bar"><i style="width:14%;background:var(--primary)"></i></span>3<small>pts</small></td>
+            <td><span class="b baja"><span class="dot"></span>Baja</span></td>
+            <td class="date">1 may 2026</td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="pag">
+        <span>Mostrando 1–8 de 22 alumnos</span>
+        <div class="pages">
+          <button>‹</button>
+          <button class="active">1</button>
+          <button>2</button>
+          <button>3</button>
+          <button>›</button>
         </div>
       </div>
     </div>
-  );
-}
 
-ReactDOM.createRoot(document.getElementById('app')).render(<App/>);
-</script>
+    <div class="footnote">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16v.01"/></svg>
+      Los resultados son orientativos y de apoyo al criterio médico. La clasificación no sustituye la evaluación clínica ni constituye un diagnóstico.
+    </div>
+  </main>
+</div>
+
+<!-- VISTA B · Detalle drawer -->
+<div class="scope">Vista B · Detalle de clasificación (drawer)</div>
+<div class="app">
+  <aside class="sb">
+    <div class="brand"><div class="y">Y</div>Yoltec</div>
+    <nav>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>Panel</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Citas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z"/><path d="M14 3v6h6M8 13h8M8 17h6"/></svg>Bitácoras</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>Pre-evaluaciones<span class="ct">3</span></a>
+      <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="9"/></svg>Prioridad IA</a>
+      <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21V10l9-7 9 7v11"/><path d="M9 21v-7h6v7"/></svg>Estadísticas</a>
+    </nav>
+    <div class="user">
+      <div class="av">OG</div>
+      <div><b>Dr. Omar González</b><span>Médico general</span></div>
+    </div>
+  </aside>
+
+  <main class="main with-drawer" style="position:relative">
+    <div class="head" style="margin-bottom:14px">
+      <div>
+        <div class="crumb">Prioridad IA · Detalle</div>
+        <h1>Lucía Fuentes Ortiz</h1>
+        <div class="sub">Análisis detallado del score y factores ponderados.</div>
+      </div>
+    </div>
+
+    <div class="table-wrap">
+      <div class="table-h"><div><h2>Alumnos clasificados</h2></div><div class="meta">3 de 22 visibles</div></div>
+      <table>
+        <thead><tr><th>Alumno</th><th>Síntomas</th><th class="num">Score</th><th>Prioridad</th><th></th></tr></thead>
+        <tbody>
+          <tr style="background:var(--primary-50);box-shadow:inset 3px 0 0 var(--primary)">
+            <td><div class="who"><div class="av">LF</div><div><b>Lucía Fuentes Ortiz</b><span>21450923</span></div></div></td>
+            <td class="symp"><span class="tx">Dolor abdominal en fosa iliaca derecha 6/10, náusea, sin fiebre…</span></td>
+            <td class="score"><span class="bar"><i style="width:95%;background:var(--danger)"></i></span>21<small>pts</small></td>
+            <td><span class="b alta"><span class="dot"></span>Alta</span></td>
+            <td><button class="btn primary sm">Seleccionada</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">AP</div><div><b>Ana Pérez García</b><span>22690495</span></div></div></td>
+            <td class="symp"><span class="tx">Odinofagia intensa 3 días, fiebre 38.4 °C, alergia a penicilina…</span></td>
+            <td class="score"><span class="bar"><i style="width:82%;background:var(--danger)"></i></span>18<small>pts</small></td>
+            <td><span class="b alta"><span class="dot"></span>Alta</span></td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+          <tr>
+            <td><div class="who"><div class="av">DK</div><div><b>Diego Kuri Salazar</b><span>22034512</span></div></div></td>
+            <td class="symp"><span class="tx">Crisis asmática leve, sibilancias audibles, usa inhalador…</span></td>
+            <td class="score"><span class="bar"><i style="width:73%;background:var(--danger)"></i></span>16<small>pts</small></td>
+            <td><span class="b alta"><span class="dot"></span>Alta</span></td>
+            <td><button class="btn outline sm">Ver ficha</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <aside class="detail-side">
+      <div class="detail-hd">
+        <div>
+          <h3>Prioridad alta</h3>
+          <span class="meta">Score 21 / 25</span>
+        </div>
+        <button class="btn ghost sm">×</button>
+      </div>
+      <div class="detail-bd">
+        <div class="who-card">
+          <div class="av">LF</div>
+          <div><b style="font-size:14.5px;display:block">Lucía Fuentes Ortiz</b><span style="font-size:11.5px;color:var(--text-muted)">21450923 · Lic. Administración · 5°</span></div>
+        </div>
+
+        <h4>Síntomas reportados</h4>
+        <div class="kv">Dolor abdominal en fosa iliaca derecha de inicio gradual desde anoche, intensidad <b>6/10</b>. Sin fiebre. Náusea sin vómito.</div>
+        <div class="pills">
+          <span class="pill danger">Dolor FID</span>
+          <span class="pill warn">Náusea</span>
+          <span class="pill">6/10</span>
+          <span class="pill">Aguda</span>
+        </div>
+
+        <h4>Factores que aumentan el score</h4>
+        <div class="breakdown">
+          <div class="br-row alta">
+            <span class="lbl">Severidad de síntomas</span>
+            <span class="val">+8</span>
+            <span class="bar2"><i style="width:80%"></i></span>
+          </div>
+          <div class="br-row media">
+            <span class="lbl">Inasistencias previas (3)</span>
+            <span class="val">+5</span>
+            <span class="bar2"><i style="width:50%"></i></span>
+          </div>
+          <div class="br-row alta">
+            <span class="lbl">Tiempo sin atención</span>
+            <span class="val">+5</span>
+            <span class="bar2"><i style="width:50%"></i></span>
+          </div>
+          <div class="br-row">
+            <span class="lbl">Edad / factor demográfico</span>
+            <span class="val">+3</span>
+            <span class="bar2"><i style="width:30%"></i></span>
+          </div>
+        </div>
+
+        <h4>Recomendación de la IA</h4>
+        <div class="kv">Atención prioritaria en las próximas <b>24 hrs</b>. Sospechar valoración quirúrgica si dolor empeora.</div>
+
+        <h4>Cita propuesta</h4>
+        <div class="kv">Hoy <b>13 mayo</b> · primer espacio disponible <b>09:00 hrs</b></div>
+      </div>
+      <div class="detail-foot">
+        <button class="btn ghost sm">Cerrar</button>
+        <button class="btn outline sm">Ver ficha</button>
+        <button class="btn primary sm">Agendar</button>
+      </div>
+    </aside>
+  </main>
+</div>
+
 </body>
 </html>

--- a/frontend/src/app/components/admin/admin-login/admin-login.component.ts
+++ b/frontend/src/app/components/admin/admin-login/admin-login.component.ts
@@ -54,6 +54,7 @@ export class AdminLoginComponent implements OnDestroy {
       .subscribe({
         next: (res) => {
           localStorage.setItem('auth_token', res.token);
+          localStorage.setItem('user_data', JSON.stringify(res.user));
           this.router.navigate(['/admin-dashboard']);
         },
         error: (err: HttpErrorResponse) => {

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -387,7 +387,8 @@ tr:last-child td { border-bottom: 0; }
   color: #374151;
 }
 
-.field input {
+.field input,
+.field select {
   height: 40px;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
@@ -400,9 +401,17 @@ tr:last-child td { border-bottom: 0; }
   box-sizing: border-box;
 }
 
-.field input:focus {
+.field input:focus,
+.field select:focus {
   border-color: #1a5c3a;
   box-shadow: 0 0 0 3px rgba(26, 92, 58, 0.12);
+}
+
+.field-hint {
+  font-weight: 400;
+  color: #6b7280;
+  font-size: 11px;
+  margin-left: 4px;
 }
 
 .form-error {

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -202,6 +202,13 @@
 .cal-cell.muted { background: #fafbfb; }
 .cal-cell.muted .day-num { color: #9ca3af; }
 
+.cal-cell.past {
+  background: #f3f4f6;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.cal-cell.past .day-num { color: #9ca3af; text-decoration: line-through; }
+
 .cal-cell.special {
   background: #fee2e2;
   border-color: #fecaca;
@@ -256,6 +263,11 @@
   background: #fee2e2;
   border: 1px solid #fecaca;
   flex-shrink: 0;
+}
+
+.swatch.swatch-past {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
 }
 
 /* Tabla */

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.html
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.html
@@ -43,6 +43,7 @@
               <div class="cal-cell"
                 *ngFor="let day of row"
                 [class.muted]="!day.isCurrentMonth"
+                [class.past]="day.isPast && !day.dia"
                 [class.special]="day.dia"
                 [class.selected]="day.date === selectedDate"
                 (click)="selectDay(day)">
@@ -55,6 +56,10 @@
             <div class="legend-item">
               <span class="swatch"></span>
               Día especial
+            </div>
+            <div class="legend-item">
+              <span class="swatch swatch-past"></span>
+              Día pasado (no editable)
             </div>
           </div>
         </div>

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.html
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.html
@@ -48,7 +48,7 @@
                 [class.selected]="day.date === selectedDate"
                 (click)="selectDay(day)">
                 <span class="day-num">{{ day.label }}</span>
-                <span class="day-tag" *ngIf="day.dia && day.isCurrentMonth">{{ day.dia.motivo }}</span>
+                <span class="day-tag" *ngIf="day.dia && day.isCurrentMonth">{{ day.dia.etiqueta || tipoLabel(day.dia.tipo) }}</span>
               </div>
             </ng-container>
           </div>
@@ -85,14 +85,16 @@
           <thead>
             <tr>
               <th>Fecha</th>
-              <th>Motivo</th>
+              <th>Tipo</th>
+              <th>Etiqueta</th>
               <th></th>
             </tr>
           </thead>
           <tbody>
             <tr *ngFor="let dia of dias">
               <td class="td-date">{{ formatFecha(dia.fecha) }}</td>
-              <td class="td-motivo">{{ dia.motivo }}</td>
+              <td class="td-motivo">{{ tipoLabel(dia.tipo) }}</td>
+              <td class="td-motivo">{{ dia.etiqueta || '—' }}</td>
               <td class="td-action">
                 <button class="btn-delete" (click)="askEliminar(dia)">Eliminar</button>
               </td>
@@ -114,8 +116,14 @@
       <input type="date" [(ngModel)]="form.fecha">
     </div>
     <div class="field">
-      <label>Motivo</label>
-      <input type="text" [(ngModel)]="form.motivo" placeholder="ej. Día del maestro" maxlength="120">
+      <label>Tipo</label>
+      <select [(ngModel)]="form.tipo">
+        <option *ngFor="let t of tiposDia" [value]="t.value">{{ t.label }}</option>
+      </select>
+    </div>
+    <div class="field">
+      <label>Etiqueta <span class="field-hint">(opcional)</span></label>
+      <input type="text" [(ngModel)]="form.etiqueta" placeholder="ej. Día del maestro" maxlength="200">
     </div>
     <p class="form-error" *ngIf="formError">{{ formError }}</p>
     <div class="modal-actions">
@@ -131,7 +139,7 @@
 <div class="modal-backdrop" *ngIf="confirmDeleteId" (click)="cancelEliminar()">
   <div class="modal modal-sm" (click)="$event.stopPropagation()">
     <h3 class="modal-title">¿Eliminar día especial?</h3>
-    <p class="modal-desc">Se eliminará <strong>{{ confirmDeleteMotivo }}</strong>. Esta acción no se puede deshacer.</p>
+    <p class="modal-desc">Se eliminará <strong>{{ confirmDeleteEtiqueta }}</strong>. Esta acción no se puede deshacer.</p>
     <div class="modal-actions">
       <button class="btn-ghost" (click)="cancelEliminar()">Cancelar</button>
       <button class="btn-danger" (click)="confirmarEliminar()">Eliminar</button>

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
@@ -12,6 +12,7 @@ interface CalDay {
   date: string;
   label: number;
   isCurrentMonth: boolean;
+  isPast: boolean;
   dia: DiaEspecialItem | null;
 }
 
@@ -95,6 +96,9 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
     const daysBack = dow === 0 ? 6 : dow - 1;
     const cursor = new Date(year, month, 1 - daysBack);
 
+    const today = new Date();
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth()+1).padStart(2,'0')}-${String(today.getDate()).padStart(2,'0')}`;
+
     const diasMap = new Map(this.dias.map(d => [d.fecha, d]));
     const rows: CalDay[][] = [];
 
@@ -103,7 +107,13 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
       for (let d = 0; d < 7; d++) {
         if (cursor.getDay() !== 0) {
           const ds = `${cursor.getFullYear()}-${String(cursor.getMonth()+1).padStart(2,'0')}-${String(cursor.getDate()).padStart(2,'0')}`;
-          row.push({ date: ds, label: cursor.getDate(), isCurrentMonth: cursor.getMonth() === month, dia: diasMap.get(ds) ?? null });
+          row.push({
+            date: ds,
+            label: cursor.getDate(),
+            isCurrentMonth: cursor.getMonth() === month,
+            isPast: ds < todayStr,
+            dia: diasMap.get(ds) ?? null
+          });
         }
         cursor.setDate(cursor.getDate() + 1);
       }
@@ -113,6 +123,7 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
   }
 
   selectDay(day: CalDay): void {
+    if (day.isPast && !day.dia) return;
     this.selectedDate = day.date;
     this.openModalAgregar(day.date);
   }

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
@@ -79,7 +79,8 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
       catchError(() => of([])),
       finalize(() => { this.isLoading = false; })
     ).subscribe(data => {
-      this.dias = data;
+      // Backend cast 'date' serializa como ISO — normalizar a YYYY-MM-DD
+      this.dias = data.map(d => ({ ...d, fecha: (d.fecha || '').split('T')[0] }));
       this.buildCalGrid();
     });
   }
@@ -197,9 +198,11 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
 
   // ===== HELPERS =====
 
-  // Convierte YYYY-MM-DD a formato legible en español
+  // Convierte YYYY-MM-DD (o ISO) a formato legible en español
   formatFecha(fecha: string): string {
-    const [y, m, d] = fecha.split('-').map(Number);
+    if (!fecha) return '';
+    const [y, m, d] = fecha.split('T')[0].split('-').map(Number);
+    if (!y || !m || !d) return fecha;
     return new Intl.DateTimeFormat('es-MX', { day: '2-digit', month: 'short', year: 'numeric' }).format(new Date(y, m - 1, d));
   }
 

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
@@ -6,7 +6,7 @@ import { Subject, of } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
 import { AuthService } from '../../../services/auth.service';
 import { AdminSidebarComponent } from '../shared/admin-sidebar.component';
-import { DiasEspecialesService, DiaEspecialItem } from './dias-especiales.service';
+import { DiasEspecialesService, DiaEspecialItem, TipoDiaEspecial } from './dias-especiales.service';
 
 interface CalDay {
   date: string;
@@ -38,13 +38,20 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
 
   // Modal agregar
   showModalAgregar = false;
-  form = { fecha: '', motivo: '' };
+  form: { fecha: string; tipo: TipoDiaEspecial; etiqueta: string } = { fecha: '', tipo: 'holiday', etiqueta: '' };
   formError: string | null = null;
   isSubmitting = false;
 
+  // Catálogo de tipos para el select
+  readonly tiposDia: { value: TipoDiaEspecial; label: string }[] = [
+    { value: 'holiday',  label: 'Festivo (sin atención)' },
+    { value: 'vacation', label: 'Vacaciones (sin atención)' },
+    { value: 'reduced',  label: 'Horario reducido' },
+  ];
+
   // Modal eliminar
   confirmDeleteId: number | null = null;
-  confirmDeleteMotivo = '';
+  confirmDeleteEtiqueta = '';
 
   constructor(
     private router: Router,
@@ -65,7 +72,9 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
 
   loadDias(): void {
     this.isLoading = true;
-    this.service.getDias().pipe(
+    const month = this.calCurrentMonth.getMonth() + 1;
+    const year = this.calCurrentMonth.getFullYear();
+    this.service.getDias(month, year).pipe(
       takeUntil(this.destroy$),
       catchError(() => of([])),
       finalize(() => { this.isLoading = false; })
@@ -86,7 +95,7 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
       this.calCurrentMonth.getFullYear(),
       this.calCurrentMonth.getMonth() + dir, 1
     );
-    this.buildCalGrid();
+    this.loadDias();
   }
 
   private buildCalGrid(): void {
@@ -132,7 +141,7 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
 
   openModalAgregar(fecha = ''): void {
     this.formError = null;
-    this.form = { fecha, motivo: '' };
+    this.form = { fecha, tipo: 'holiday', etiqueta: '' };
     this.showModalAgregar = true;
   }
 
@@ -144,10 +153,14 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
 
   submitAgregar(): void {
     if (!this.form.fecha) { this.formError = 'Selecciona una fecha.'; return; }
-    if (this.form.motivo.trim().length < 3) { this.formError = 'El motivo debe tener al menos 3 caracteres.'; return; }
+    if (!this.form.tipo) { this.formError = 'Selecciona el tipo de día.'; return; }
     this.isSubmitting = true;
     this.formError = null;
-    this.service.agregar(this.form.fecha, this.form.motivo.trim()).pipe(
+    this.service.agregar({
+      fecha: this.form.fecha,
+      tipo: this.form.tipo,
+      etiqueta: this.form.etiqueta.trim() || null,
+    }).pipe(
       takeUntil(this.destroy$),
       catchError(err => { this.formError = err?.error?.message ?? 'Error al guardar.'; return of(null); }),
       finalize(() => { this.isSubmitting = false; })
@@ -160,12 +173,16 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
 
   askEliminar(dia: DiaEspecialItem): void {
     this.confirmDeleteId = dia.id;
-    this.confirmDeleteMotivo = dia.motivo;
+    this.confirmDeleteEtiqueta = dia.etiqueta || this.tipoLabel(dia.tipo);
   }
 
   cancelEliminar(): void {
     this.confirmDeleteId = null;
-    this.confirmDeleteMotivo = '';
+    this.confirmDeleteEtiqueta = '';
+  }
+
+  tipoLabel(tipo: TipoDiaEspecial): string {
+    return this.tiposDia.find(t => t.value === tipo)?.label ?? tipo;
   }
 
   confirmarEliminar(): void {

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.service.ts
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.service.ts
@@ -1,17 +1,27 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from '../../../../environments/environment';
+
+export type TipoDiaEspecial = 'holiday' | 'vacation' | 'reduced';
 
 export interface DiaEspecialItem {
   id: number;
   fecha: string;
-  motivo: string;
+  tipo: TipoDiaEspecial;
+  etiqueta: string | null;
+}
+
+export interface DiaEspecialPayload {
+  fecha: string;
+  tipo: TipoDiaEspecial;
+  etiqueta?: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
 export class DiasEspecialesService {
-  private base = `${environment.apiUrl}/admin/dias-especiales`;
+  private base = `${environment.apiUrl}/admin/calendario`;
 
   constructor(private http: HttpClient) {}
 
@@ -20,17 +30,20 @@ export class DiasEspecialesService {
     return { headers: new HttpHeaders({ Authorization: `Bearer ${token}` }) };
   }
 
-  // GET /api/admin/dias-especiales → lista completa
-  getDias(): Observable<DiaEspecialItem[]> {
-    return this.http.get<DiaEspecialItem[]>(this.base, this.headers());
+  // GET /api/admin/calendario?month=X&year=Y → días del mes
+  getDias(month: number, year: number): Observable<DiaEspecialItem[]> {
+    const params = new HttpParams().set('month', month).set('year', year);
+    return this.http.get<{ dias: DiaEspecialItem[] }>(this.base, { ...this.headers(), params })
+      .pipe(map(res => res.dias));
   }
 
-  // POST /api/admin/dias-especiales → agregar
-  agregar(fecha: string, motivo: string): Observable<DiaEspecialItem> {
-    return this.http.post<DiaEspecialItem>(this.base, { fecha, motivo }, this.headers());
+  // POST /api/admin/calendario → registra/actualiza día especial
+  agregar(payload: DiaEspecialPayload): Observable<DiaEspecialItem> {
+    return this.http.post<{ dia: DiaEspecialItem }>(this.base, payload, this.headers())
+      .pipe(map(res => res.dia));
   }
 
-  // DELETE /api/admin/dias-especiales/{id} → eliminar
+  // DELETE /api/admin/calendario/{id} → eliminar
   eliminar(id: number): Observable<void> {
     return this.http.delete<void>(`${this.base}/${id}`, this.headers());
   }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
@@ -738,29 +738,719 @@
 
 .sin-dato { color: var(--yol-text-subtle); font-size: var(--yol-fs-sm); }
 
-/* ── Dark mode ──────────────────────────────────── */
-:host-context(.dark) .week-grid-card,
-:host-context(.dark) .citas-column,
-:host-context(.dark) .form-card,
-:host-context(.dark) .filtros-bar { background: #1a2e25; border-color: #2a4030; }
-
-:host-context(.dark) .calendar-card { background: #0f1a15; border-color: #2a4030; }
-:host-context(.dark) .calendar-day  { background: #1a2e25; border-color: #2a4030; color: #e8f5ee; }
-
-:host-context(.dark) .cita-card { background: #0f1a15; border-color: #2a4030; }
-
-:host-context(.dark) .modal,
-:host-context(.dark) .modal-consulta,
-:host-context(.dark) .modal-perfil-alumno { background: #1a2e25; border-color: #2a4030; }
-
-:host-context(.dark) .slot-button  { background: #1a2e25; border-color: #2a4030; color: #a8c4b4; }
-:host-context(.dark) .search-input { background: #0f1a15; border-color: #2a4030; color: #e8f5ee; }
-:host-context(.dark) .filtro-select,
-:host-context(.dark) .filtro-fecha { background: #0f1a15; border-color: #2a4030; color: #e8f5ee; }
-
-/* ── Responsive ─────────────────────────────────── */
+/* ── Responsive (legacy) ────────────────────────── */
 @media (max-width: 900px) {
   .citas-layout { grid-template-columns: 1fr; }
   .filtros-bar  { flex-direction: column; align-items: stretch; }
   .week-grid-table { min-width: 600px; }
+}
+
+/* ══════════════════════════════════════════════════
+   DS v2 — Nuevos elementos Citas
+   ══════════════════════════════════════════════════ */
+
+/* ── Overlay drawer ─────────────────────────────── */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.35);
+  z-index: 99;
+}
+
+/* ── Header ─────────────────────────────────────── */
+.citas-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: var(--yol-s-4);
+}
+
+.citas-header .crumb {
+  font-size: 11px;
+  color: var(--yol-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.citas-header h1 {
+  margin: 0;
+  font-size: var(--yol-fs-h1);
+  font-weight: 700;
+  color: var(--yol-text);
+  letter-spacing: -.4px;
+}
+
+/* ── KPI bar ─────────────────────────────────────── */
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+
+.kpi {
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  padding: 16px 18px;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  box-shadow: var(--yol-shadow-xs);
+}
+
+.kpi-ic {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.kpi-lbl {
+  font-size: 11px;
+  color: var(--yol-text-muted);
+  font-weight: 600;
+  letter-spacing: .3px;
+  text-transform: uppercase;
+}
+
+.kpi-v {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--yol-text);
+  letter-spacing: -.5px;
+  line-height: 1;
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.kpi-info .kpi-ic  { background: #dbeafe; color: #1d4ed8; }
+.kpi-warn .kpi-ic  { background: var(--yol-warn-surface); color: var(--yol-warn); }
+.kpi-danger .kpi-ic { background: var(--yol-cancel-surface); color: var(--yol-danger); }
+
+/* ── Próxima cita hero ──────────────────────────── */
+.proxima-hero {
+  background: linear-gradient(135deg, var(--yol-primary-600, #0f5132), var(--yol-primary) 60%, #2e8b57);
+  color: #fff;
+  border-radius: var(--yol-r-lg);
+  padding: 20px 24px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  box-shadow: 0 6px 24px rgba(27,107,69,.2);
+}
+
+.av-hero {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: rgba(255,255,255,.18);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 20px;
+  flex-shrink: 0;
+  border: 2px solid rgba(255,255,255,.2);
+}
+
+.proxima-info { flex: 1; min-width: 0; }
+
+.proxima-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  color: rgba(255,255,255,.75);
+  margin-bottom: 4px;
+}
+
+.proxima-name {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -.2px;
+  margin-bottom: 4px;
+}
+
+.proxima-meta {
+  font-size: 13px;
+  color: rgba(255,255,255,.8);
+}
+
+.proxima-hora-block { text-align: center; margin-right: 8px; }
+
+.hora-big {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -1px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.proxima-actions { display: flex; gap: 8px; flex-shrink: 0; }
+
+.btn-hero-outline {
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255,255,255,.4);
+  padding: 8px 14px;
+  border-radius: var(--yol-r-pill);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+  transition: background var(--yol-duration-normal);
+}
+
+.btn-hero-outline:hover { background: rgba(255,255,255,.1); }
+
+.btn-hero-white {
+  background: #fff;
+  color: var(--yol-primary);
+  border: none;
+  padding: 8px 14px;
+  border-radius: var(--yol-r-pill);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+  transition: background var(--yol-duration-normal);
+}
+
+.btn-hero-white:hover { background: var(--yol-primary-50); }
+
+/* ── Buscador + filtros integrado ───────────────── */
+.citas-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 9px 14px;
+  box-shadow: var(--yol-shadow-xs);
+  flex-wrap: wrap;
+}
+
+.citas-search-bar .search-ic {
+  color: var(--yol-text-subtle);
+  font-size: 15px;
+  flex-shrink: 0;
+}
+
+.citas-search-bar input {
+  flex: 1;
+  min-width: 160px;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 13.5px;
+  color: var(--yol-text);
+  font-family: var(--yol-font);
+}
+
+.citas-search-bar input::placeholder { color: var(--yol-text-subtle); }
+
+.filtros-inline {
+  display: flex;
+  gap: var(--yol-s-2);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.filtro-select-sm,
+.filtro-fecha-sm {
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 5px 8px;
+  font: 500 12px var(--yol-font);
+  color: var(--yol-text);
+  outline: none;
+  cursor: pointer;
+}
+
+.btn-limpiar-sm {
+  background: transparent;
+  border: 1px solid var(--yol-danger);
+  color: var(--yol-danger);
+  border-radius: var(--yol-r-md);
+  padding: 5px 10px;
+  font: 600 12px var(--yol-font);
+  cursor: pointer;
+}
+
+.btn-limpiar-sm:hover { background: var(--yol-danger); color: #fff; }
+
+/* ── Loading / error / vacío ────────────────────── */
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--yol-s-2);
+  padding: var(--yol-s-8) var(--yol-s-6);
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-lg);
+  border: 1px dashed var(--yol-border);
+  color: var(--yol-text-muted);
+  font-size: var(--yol-fs-sm);
+  text-align: center;
+}
+
+.placeholder-ic { font-size: 28px; color: var(--yol-border); }
+
+.msg-error {
+  background: var(--yol-cancel-surface);
+  border: 1px solid #fecaca;
+  border-left: 4px solid var(--yol-danger);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  color: var(--yol-danger);
+  font-size: var(--yol-fs-sm);
+}
+
+/* ── Tabla de citas (rows) ──────────────────────── */
+.table-wrap {
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  box-shadow: var(--yol-shadow-xs);
+  overflow: hidden;
+}
+
+.table-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--yol-bg);
+  border-bottom: 1px solid var(--yol-border);
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
+}
+
+.table-section-head b { color: var(--yol-text); }
+
+.historial-head {
+  margin-top: 0;
+  border-top: 2px solid var(--yol-border);
+}
+
+.cita-row {
+  display: grid;
+  grid-template-columns: 40px 1fr auto auto 1.2fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--yol-border);
+  cursor: pointer;
+  transition: background var(--yol-duration-normal);
+  min-width: 0;
+}
+
+.cita-row:last-child { border-bottom: none; }
+.cita-row:hover { background: var(--yol-bg); }
+.cita-row.sel  { background: var(--yol-primary-50); }
+
+/* Avatar */
+.av {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.av-muted { background: var(--yol-bg); color: var(--yol-text-muted); }
+.av-md    { width: 44px; height: 44px; font-size: 14px; }
+
+/* Who */
+.who {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.who b {
+  font-size: var(--yol-fs-sm);
+  font-weight: 600;
+  color: var(--yol-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.who span {
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+}
+
+/* Badge fecha */
+.badge-fecha {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.dot-verde {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--yol-primary);
+  flex-shrink: 0;
+}
+
+.badge-fecha-muted { color: var(--yol-text-subtle); }
+.badge-fecha-muted .dot-verde { background: var(--yol-text-subtle); }
+
+/* Estatus chips */
+.estatus-chip {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: var(--yol-r-pill);
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .3px;
+  white-space: nowrap;
+}
+
+.chip-programada { background: var(--yol-primary-50); color: var(--yol-primary); }
+.chip-atendida   { background: var(--yol-ok-surface);     color: var(--yol-primary); }
+.chip-cancelada  { background: var(--yol-cancel-surface); color: var(--yol-danger); }
+.chip-no-asistio { background: var(--yol-warn-surface);   color: var(--yol-warn); }
+
+/* Motivo col */
+.motivo-col {
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+  min-width: 0;
+}
+
+/* Row actions */
+.row-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* ── Botones pequeños ───────────────────────────── */
+.btn-sm {
+  padding: 6px 12px;
+  border-radius: var(--yol-r-md);
+  font: 600 var(--yol-fs-label) var(--yol-font);
+  cursor: pointer;
+  border: none;
+  transition: opacity var(--yol-duration-normal), background var(--yol-duration-normal);
+  white-space: nowrap;
+}
+
+.btn-sm:disabled { opacity: .5; cursor: default; }
+
+.pagination-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--yol-space-md);
+  padding: var(--yol-space-md) 0;
+  border-top: 1px solid var(--yol-border);
+  margin-top: var(--yol-space-sm);
+}
+.pagination-info {
+  font: 500 var(--yol-fs-label) var(--yol-font);
+  color: var(--yol-text-muted);
+}
+
+.btn-primary-full { background: var(--yol-primary); color: #fff; }
+.btn-primary-full:hover:not(:disabled) { background: var(--yol-primary-600); }
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid var(--yol-border);
+  color: var(--yol-text-muted);
+}
+.btn-outline:hover { border-color: var(--yol-primary); color: var(--yol-primary); }
+
+.btn-gray {
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  color: var(--yol-text-muted);
+}
+.btn-gray:hover { background: var(--yol-border); }
+
+.btn-warn   { background: var(--yol-warn);   color: #fff; }
+.btn-danger { background: var(--yol-danger); color: #fff; }
+.btn-warn:hover   { opacity: .85; }
+.btn-danger:hover { opacity: .85; }
+
+.flex1 { flex: 1; text-align: center; }
+
+/* ── Drawer de detalle ──────────────────────────── */
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100dvh;
+  width: 380px;
+  max-width: 95vw;
+  background: var(--yol-surface);
+  border-left: 1px solid var(--yol-border);
+  box-shadow: -4px 0 24px rgba(0,0,0,.1);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform .25s ease;
+}
+
+.drawer.open { transform: translateX(0); }
+
+.drawer-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: var(--yol-s-4) var(--yol-s-5);
+  border-bottom: 1px solid var(--yol-border);
+  gap: var(--yol-s-3);
+}
+
+.drawer-head h2 {
+  margin: 0;
+  font-size: var(--yol-fs-h2);
+  font-weight: 700;
+  color: var(--yol-text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.drawer-ic { color: var(--yol-primary); }
+
+.drawer-sub {
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  margin-top: 4px;
+}
+
+.btn-x {
+  background: transparent;
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--yol-text-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--yol-r);
+  transition: color var(--yol-duration-normal);
+}
+.btn-x:hover { color: var(--yol-text); }
+
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--yol-s-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-4);
+}
+
+.drawer-foot,
+.drawer-foot-top {
+  display: flex;
+  gap: var(--yol-s-2);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-top: 1px solid var(--yol-border);
+}
+
+.drawer-foot-top { border-top: 1px solid var(--yol-border); }
+.drawer-foot { border-top: none; padding-top: var(--yol-s-2); }
+
+/* Drawer content */
+.d-patient {
+  display: flex;
+  align-items: center;
+  gap: var(--yol-s-3);
+  padding-bottom: var(--yol-s-4);
+  border-bottom: 1px solid var(--yol-border);
+}
+
+.d-patient-info b { display: block; font-size: var(--yol-fs-body); font-weight: 700; color: var(--yol-text); }
+.d-patient-sub { font-size: var(--yol-fs-label); color: var(--yol-text-muted); }
+
+.d-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--yol-s-3);
+}
+
+.d-cell {
+  background: var(--yol-bg);
+  border-radius: var(--yol-r-md);
+  padding: var(--yol-s-3);
+}
+
+.d-cell-full { grid-column: span 2; }
+
+.d-label {
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-subtle);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .3px;
+  margin-bottom: 4px;
+}
+
+.d-cell b { font-size: var(--yol-fs-sm); color: var(--yol-text); }
+
+.d-section { display: flex; flex-direction: column; gap: 6px; }
+
+.d-section-head {
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .4px;
+  color: var(--yol-text-muted);
+}
+
+.d-text {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text);
+  line-height: 1.6;
+  background: var(--yol-bg);
+  border-radius: var(--yol-r-md);
+  padding: var(--yol-s-3);
+}
+
+/* ── Modal 3 pasos ──────────────────────────────── */
+.modal-3step {
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  width: 560px;
+  max-width: 95vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--yol-shadow-sm);
+}
+
+.modal-3step-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: var(--yol-s-4) var(--yol-s-5);
+  border-bottom: 1px solid var(--yol-border);
+}
+
+.modal-3step-head h3 {
+  margin: 0 0 var(--yol-s-2);
+  font-size: var(--yol-fs-h2);
+  font-weight: 700;
+  color: var(--yol-text);
+}
+
+/* Step indicator */
+.step-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.step-dot {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--yol-border);
+  background: var(--yol-surface);
+  color: var(--yol-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  transition: all var(--yol-duration-normal);
+}
+
+.step-dot.active { border-color: var(--yol-primary); color: var(--yol-primary); }
+.step-dot.done   { background: var(--yol-primary); border-color: var(--yol-primary); color: #fff; }
+
+.step-line {
+  height: 2px;
+  width: 32px;
+  background: var(--yol-border);
+  border-radius: 1px;
+}
+
+/* Step body */
+.step-body { padding: var(--yol-s-4) var(--yol-s-5); }
+
+.step-title {
+  font-size: var(--yol-fs-body);
+  font-weight: 600;
+  color: var(--yol-text);
+  margin-bottom: var(--yol-s-4);
+}
+
+/* Confirm summary */
+.confirm-summary {
+  background: var(--yol-bg);
+  border-radius: var(--yol-r-md);
+  border: 1px solid var(--yol-border);
+  overflow: hidden;
+  margin-bottom: var(--yol-s-4);
+}
+
+.confirm-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--yol-border);
+  font-size: var(--yol-fs-sm);
+}
+
+.confirm-row:last-child { border-bottom: none; }
+.confirm-row span { color: var(--yol-text-muted); }
+.confirm-row b    { color: var(--yol-text); }
+
+/* 3-step footer */
+.modal-3step-foot {
+  display: flex;
+  gap: var(--yol-s-2);
+  justify-content: flex-end;
+  padding: var(--yol-s-3) var(--yol-s-5) var(--yol-s-4);
+  border-top: 1px solid var(--yol-border);
+}
+
+/* ── Responsive DS v2 ───────────────────────────── */
+@media (max-width: 768px) {
+  .kpis { grid-template-columns: 1fr 1fr; }
+  .proxima-hero { flex-direction: column; align-items: flex-start; }
+  .cita-row { grid-template-columns: 36px 1fr auto; }
+  .cita-row .badge-fecha,
+  .cita-row .estatus-chip,
+  .cita-row .motivo-col { display: none; }
+  .drawer { width: 100vw; }
+  .citas-search-bar { flex-direction: column; align-items: stretch; }
+  .filtros-inline { flex-wrap: wrap; }
 }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
@@ -1,111 +1,110 @@
-/* ===== DOCTOR CITAS — Con variables globales y todos los elementos adaptados ===== */
 .citas-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: var(--yol-s-6);
 }
 
-/* ===== CALENDARIO SEMANAL GRID ===== */
+/* ── Calendario semanal ─────────────────────────── */
 .week-grid-card {
-  background: var(--yol-surface, #fff);
-  border: 1px solid var(--yol-border, #DDE8E3);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(27,107,69,.08);
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  box-shadow: var(--yol-shadow-xs);
   overflow: hidden;
 }
+
 .week-grid-header {
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--yol-border, #DDE8E3);
+  padding: var(--yol-s-4) var(--yol-s-5);
+  border-bottom: 1px solid var(--yol-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
+
 .week-grid-header h2 {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--yol-fs-body);
   font-weight: 600;
-  color: var(--yol-text, #1A2E25);
+  color: var(--yol-text);
 }
-.week-nav {
-  display: flex;
-  gap: 4px;
-  align-items: center;
-}
+
+.week-nav { display: flex; gap: var(--yol-s-1); align-items: center; }
+
 .btn-week {
   padding: 6px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 600;
-  border: 1px solid var(--yol-border, #DDE8E3);
-  background: var(--yol-surface, #fff);
-  color: var(--yol-text-muted, #4A6859);
+  border-radius: var(--yol-r);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  border: 1px solid var(--yol-border);
+  background: var(--yol-surface);
+  color: var(--yol-text-muted);
   cursor: pointer;
-  font-family: inherit;
-  transition: all .15s;
+  transition: background var(--yol-duration-normal), color var(--yol-duration-normal), border-color var(--yol-duration-normal);
 }
+
 .btn-week:hover {
-  background: var(--yol-bg, #F7F9F8);
-  color: var(--yol-primary, #1B6B45);
-  border-color: var(--yol-primary, #1B6B45);
+  background: var(--yol-bg);
+  color: var(--yol-primary);
+  border-color: var(--yol-primary);
 }
-.week-grid-table-wrap {
-  overflow-x: auto;
-}
+
+.week-grid-table-wrap { overflow-x: auto; }
+
 .week-grid-table {
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
-  font-size: 13px;
+  font-size: var(--yol-fs-sm);
 }
+
 .week-grid-table thead th {
   text-align: left;
   padding: 10px 12px;
-  font-size: 12px;
+  font-size: var(--yol-fs-label);
   font-weight: 600;
-  color: var(--yol-text-muted, #4A6859);
+  color: var(--yol-text-muted);
   letter-spacing: .3px;
   text-transform: uppercase;
-  background: var(--yol-bg, #F7F9F8);
-  border-bottom: 1px solid var(--yol-border, #DDE8E3);
+  background: var(--yol-bg);
+  border-bottom: 1px solid var(--yol-border);
 }
-.week-grid-table thead th.col-today {
-  color: var(--yol-primary, #1B6B45);
-}
+
+.week-grid-table thead th.col-today { color: var(--yol-primary); }
+
 .today-dot {
   display: inline-block;
   margin-left: 4px;
   font-size: 10px;
-  color: var(--yol-primary, #1B6B45);
+  color: var(--yol-primary);
   font-weight: 700;
   text-transform: lowercase;
-  letter-spacing: 0;
 }
-.col-hora {
-  width: 64px;
-}
+
+.col-hora { width: 64px; }
+
 .cell-hora {
   padding: 6px 12px;
   font-variant-numeric: tabular-nums;
-  color: var(--yol-text-subtle, #7B8F86);
-  font-size: 12px;
+  color: var(--yol-text-subtle);
+  font-size: var(--yol-fs-label);
   font-weight: 500;
-  border-bottom: 1px solid var(--yol-border, #DDE8E3);
+  border-bottom: 1px solid var(--yol-border);
   vertical-align: top;
 }
+
 .cell-slot {
   padding: 4px 6px;
   height: 52px;
   vertical-align: top;
-  border-bottom: 1px solid var(--yol-border, #DDE8E3);
-  border-left: 1px solid var(--yol-border, #DDE8E3);
+  border-bottom: 1px solid var(--yol-border);
+  border-left: 1px solid var(--yol-border);
 }
-.cell-slot.cell-today {
-  background: rgba(27,107,69,.03);
-}
+
+.cell-slot.cell-today { background: color-mix(in srgb, var(--yol-primary) 4%, transparent); }
+
 .grid-cita {
   padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: var(--yol-r);
+  font-size: var(--yol-fs-label);
   font-weight: 500;
   cursor: pointer;
   margin-bottom: 2px;
@@ -113,680 +112,473 @@
   overflow: hidden;
   text-overflow: ellipsis;
   border-left: 3px solid transparent;
-  transition: opacity .15s;
-}
-.grid-cita:hover {
-  opacity: .85;
-}
-.grid-cita.ok {
-  background: var(--yol-ok-surface, #E8F5EE);
-  color: var(--yol-ok-text, #1B6B45);
-  border-left-color: var(--yol-primary, #1B6B45);
-}
-.grid-cita.warn {
-  background: var(--yol-warn-surface, #FFF3E0);
-  color: var(--yol-warn-text, #F57C00);
-  border-left-color: #F57C00;
-}
-.grid-cita.cancel {
-  background: var(--yol-cancel-surface, #FFEBEE);
-  color: var(--yol-cancel-text, #C62828);
-  border-left-color: #C62828;
+  transition: opacity var(--yol-duration-normal);
 }
 
-@media (max-width: 768px) {
-  .week-grid-table {
-    min-width: 600px;
-  }
-}
+.grid-cita:hover { opacity: .8; }
+.grid-cita.ok     { background: var(--yol-ok-surface);     color: var(--yol-primary); border-left-color: var(--yol-primary); }
+.grid-cita.warn   { background: var(--yol-warn-surface);   color: var(--yol-warn);    border-left-color: var(--yol-warn); }
+.grid-cita.cancel { background: var(--yol-cancel-surface); color: var(--yol-danger);  border-left-color: var(--yol-danger); }
 
-/* ===== ENCABEZADO ===== */
+/* ── Encabezado de sección ──────────────────────── */
 .section-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
-  padding-bottom: 1rem;
-  border-bottom: 2px solid var(--border-light);
-  margin-bottom: 0.5rem;
-  position: relative;
+  gap: var(--yol-s-4);
+  padding-bottom: var(--yol-s-4);
+  border-bottom: 1px solid var(--yol-border);
 }
 
 .section-header h2 {
-  font-size: 1.7rem;
+  font-size: var(--yol-fs-h1);
   font-weight: 700;
-  color: var(--text-primary);
+  color: var(--yol-text);
   margin: 0;
 }
 
-.section-header h2::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 40px;
-  height: 3px;
-  background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
-  border-radius: 2px;
-}
-
+/* ── Botones de acción ──────────────────────────── */
 .btn-primary {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  color: white;
+  background: var(--yol-primary);
+  color: var(--yol-surface);
   border: none;
-  padding: 0.6rem 1.4rem;
-  border-radius: 22px;
-  font-weight: 600;
+  padding: 9px 18px;
+  border-radius: var(--yol-r-pill);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
   cursor: pointer;
-  transition: all 0.22s;
-  font-size: 0.85rem;
-  box-shadow: var(--shadow-sm);
+  transition: background var(--yol-duration-normal);
 }
 
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
+.btn-primary:hover:not(:disabled) { background: var(--yol-primary-600); }
+.btn-primary:disabled { opacity: .55; cursor: default; }
+
+.btn-secondary {
+  padding: 9px 14px;
+  background: transparent;
+  color: var(--yol-text-muted);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-pill);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+  transition: border-color var(--yol-duration-normal);
 }
 
-/* ===== BUSCADOR ===== */
-.search-bar {
-  position: relative;
-  margin: 0 0 1.2rem;
-}
+.btn-secondary:hover { border-color: var(--yol-text-muted); }
+
+/* ── Buscador ───────────────────────────────────── */
+.search-bar { position: relative; }
 
 .search-input {
   width: 100%;
-  padding: 0.9rem 3rem 0.9rem 1.3rem;
-  background: var(--bg-input);
-  border: 1.5px solid var(--border-light);
-  border-radius: 22px;
-  font-size: 0.92rem;
-  color: var(--text-primary);
-  font-family: 'Inter', sans-serif;
-  transition: all 0.22s;
-  box-shadow: var(--shadow-sm);
-}
-
-.search-input::placeholder {
-  color: var(--text-muted);
-}
-
-.search-input:focus {
+  height: 40px;
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 0 14px;
+  font: 500 var(--yol-fs-sm) var(--yol-font);
+  color: var(--yol-text);
   outline: none;
-  border-color: var(--border-focus);
-  box-shadow: var(--shadow-focus);
-  background: var(--bg-card);
+  transition: border-color var(--yol-duration-normal);
+  box-sizing: border-box;
 }
+
+.search-input::placeholder { color: var(--yol-text-subtle); }
+.search-input:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px var(--yol-primary-50); }
 
 .search-clear {
   position: absolute;
-  right: 1rem;
+  right: 10px;
   top: 50%;
   transform: translateY(-50%);
-  background: var(--border-light);
+  background: var(--yol-border);
   border: none;
   border-radius: 50%;
-  width: 28px;
-  height: 28px;
+  width: 22px;
+  height: 22px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  font-weight: bold;
-  transition: all 0.2s;
+  color: var(--yol-text-muted);
+  font-size: 11px;
+  transition: background var(--yol-duration-normal), color var(--yol-duration-normal);
 }
 
-.search-clear:hover {
-  background: var(--danger);
-  color: white;
-  transform: translateY(-50%) scale(1.05);
-}
+.search-clear:hover { background: var(--yol-danger); color: #fff; }
 
-/* ===== FILTROS (Selects, fechas, botones) ===== */
+/* ── Filtros ────────────────────────────────────── */
 .filtros-bar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.8rem;
-  margin-bottom: 1rem;
-  background: var(--bg-card);
-  padding: 1rem 1.5rem;
-  border-radius: 22px;
-  border: 1px solid var(--border-light);
-  box-shadow: var(--shadow-sm);
+  gap: var(--yol-s-2);
+  background: var(--yol-surface);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-lg);
+  border: 1px solid var(--yol-border);
+  box-shadow: var(--yol-shadow-xs);
 }
 
 .filtro-select,
 .filtro-fecha {
-  background: var(--bg-input);
-  border: 1.5px solid var(--border-light);
-  border-radius: 14px;
-  padding: 0.55rem 0.9rem;
-  font-size: 0.85rem;
-  color: var(--text-primary);
-  font-family: 'Inter', sans-serif;
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 7px 10px;
+  font: 500 var(--yol-fs-sm) var(--yol-font);
+  color: var(--yol-text);
   cursor: pointer;
-  transition: all 0.2s;
+  outline: none;
+  transition: border-color var(--yol-duration-normal);
 }
 
 .filtro-select:focus,
-.filtro-fecha:focus {
-  outline: none;
-  border-color: var(--border-focus);
-  box-shadow: var(--shadow-focus);
-}
+.filtro-fecha:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px var(--yol-primary-50); }
 
 .btn-limpiar {
   background: transparent;
-  border: 1.5px solid var(--danger);
-  color: var(--danger);
-  border-radius: 14px;
-  padding: 0.55rem 1.2rem;
-  font-size: 0.85rem;
-  font-weight: 600;
+  border: 1px solid var(--yol-danger);
+  color: var(--yol-danger);
+  border-radius: var(--yol-r-md);
+  padding: 7px 14px;
+  font: 600 var(--yol-fs-sm) var(--yol-font);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background var(--yol-duration-normal), color var(--yol-duration-normal);
 }
 
-.btn-limpiar:hover {
-  background: var(--danger);
-  color: white;
-}
+.btn-limpiar:hover { background: var(--yol-danger); color: #fff; }
 
-/* ===== LAYOUT DE CITAS ===== */
+/* ── Layout citas ───────────────────────────────── */
 .citas-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2rem;
+  gap: var(--yol-s-5);
 }
 
 .citas-column {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-radius: 26px;
-  padding: 1.5rem;
-  box-shadow: var(--shadow-sm);
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.citas-column:hover {
-  box-shadow: var(--shadow-md);
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-5);
+  box-shadow: var(--yol-shadow-xs);
 }
 
 .citas-column h3 {
-  font-size: 1.05rem;
+  font-size: var(--yol-fs-body);
   font-weight: 700;
-  color: var(--text-primary);
-  margin: 0 0 1.2rem;
-  padding-bottom: 0.8rem;
-  border-bottom: 2px solid var(--border-light);
+  color: var(--yol-text);
+  margin: 0 0 var(--yol-s-4);
+  padding-bottom: var(--yol-s-3);
+  border-bottom: 1px solid var(--yol-border);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--yol-s-2);
 }
 
-.citas-column h3::before {
-  content: "📋";
-  font-size: 1.1rem;
-}
-
-.citas-column.pendientes h3::before {
-  content: "⏳";
-}
-
-/* ===== TARJETAS DE CITAS ===== */
+/* ── Tarjetas de citas ──────────────────────────── */
 .cita-card {
-  background: var(--bg-side);
-  border-radius: 18px;
-  padding: 1.1rem 1.1rem 1.1rem 1.4rem;
-  margin-bottom: 0.9rem;
-  transition: all 0.22s;
-  border: 1px solid var(--border-light);
-  border-left: 4px solid var(--success);
+  background: var(--yol-bg);
+  border-radius: var(--yol-r-md);
+  padding: var(--yol-s-3) var(--yol-s-3) var(--yol-s-3) var(--yol-s-4);
+  margin-bottom: var(--yol-s-3);
+  border: 1px solid var(--yol-border);
+  border-left: 4px solid var(--yol-primary);
+  transition: box-shadow var(--yol-duration-normal);
 }
 
-.cita-card:hover {
-  transform: translateX(5px);
-  box-shadow: var(--shadow-md);
-  background: var(--bg-card);
-}
-
-.cita-card.cancelada {
-  border-left-color: var(--danger);
-}
-
-.cita-card.no-asistio {
-  border-left-color: var(--warning);
-}
+.cita-card:hover { box-shadow: var(--yol-shadow-sm); }
+.cita-card.cancelada   { border-left-color: var(--yol-danger); }
+.cita-card.no-asistio  { border-left-color: var(--yol-warn); }
 
 .cita-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.6rem;
+  gap: var(--yol-s-2);
+  margin-bottom: var(--yol-s-2);
 }
 
-.cita-header h4 {
-  font-size: 0.96rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin: 0;
+.cita-header h4 { font-size: var(--yol-fs-body); font-weight: 700; color: var(--yol-text); margin: 0; }
+
+.hora   { font-size: var(--yol-fs-sm); color: var(--yol-text-muted); margin: var(--yol-s-1) 0; }
+.motivo { font-size: var(--yol-fs-sm); color: var(--yol-text-muted); margin: var(--yol-s-1) 0; font-style: italic; }
+.alumno { font-size: var(--yol-fs-sm); font-weight: 600; color: var(--yol-primary); margin: var(--yol-s-1) 0; }
+
+/* estatus badge en historial */
+.estatus {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: var(--yol-r-pill);
+  font-size: var(--yol-fs-label);
+  font-weight: 600;
+  background: var(--yol-ok-surface);
+  color: var(--yol-primary);
 }
 
-.hora {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  margin: 0.2rem 0;
-}
-
-.motivo {
-  font-size: 0.86rem;
-  color: var(--text-secondary);
-  margin: 0.4rem 0 0;
-  font-style: italic;
-}
-
-.alumno {
-  font-size: 0.88rem;
-  font-weight: 700;
-  color: var(--success);
-  margin: 0.5rem 0 0;
-}
+.estatus.atendida  { background: var(--yol-ok-surface);     color: var(--yol-primary); }
+.estatus.cancelada { background: var(--yol-cancel-surface); color: var(--yol-danger); }
+.estatus.no-asistio { background: var(--yol-warn-surface);  color: var(--yol-warn); }
+.estatus.programada { background: var(--yol-primary-50);    color: var(--yol-primary-600); }
 
 .card-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.9rem;
+  gap: var(--yol-s-2);
+  margin-top: var(--yol-s-3);
   justify-content: flex-end;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--border-light);
+  padding-top: var(--yol-s-3);
+  border-top: 1px solid var(--yol-border);
 }
 
 .btn-perfil-alumno {
-  background: var(--accent-soft);
-  border: 1.5px solid var(--gradient-start);
-  color: var(--text-secondary);
-  border-radius: 12px;
-  padding: 0.4rem 1rem;
-  font-size: 0.75rem;
-  font-weight: 700;
+  background: var(--yol-primary-50);
+  border: 1px solid var(--yol-primary);
+  color: var(--yol-primary);
+  border-radius: var(--yol-r-md);
+  padding: 5px 12px;
+  font: 600 var(--yol-fs-label) var(--yol-font);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background var(--yol-duration-normal);
 }
 
-.btn-perfil-alumno:hover {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  color: white;
-  transform: translateY(-1px);
-}
+.btn-perfil-alumno:hover { background: var(--yol-primary); color: #fff; }
 
-.btn-atender,
-.btn-reprogramar,
-.btn-no-show,
-.btn-cancelar {
+.btn-atender, .btn-reprogramar, .btn-no-show, .btn-cancelar {
   border: none;
-  border-radius: 12px;
-  padding: 0.4rem 0.9rem;
-  font-size: 0.75rem;
-  font-weight: 600;
+  border-radius: var(--yol-r-md);
+  padding: 5px 12px;
+  font: 600 var(--yol-fs-label) var(--yol-font);
   cursor: pointer;
-  transition: all 0.2s;
-  color: white;
+  color: #fff;
+  transition: opacity var(--yol-duration-normal);
 }
 
-.btn-atender {
-  background: var(--success);
-}
+.btn-atender    { background: var(--yol-primary); }
+.btn-reprogramar { background: #0ea5e9; }
+.btn-no-show    { background: var(--yol-warn); }
+.btn-cancelar   { background: var(--yol-danger); }
 
-.btn-reprogramar {
-  background: var(--accent-dark);
-}
+.btn-atender:hover, .btn-reprogramar:hover,
+.btn-no-show:hover, .btn-cancelar:hover { opacity: .85; }
 
-.btn-no-show {
-  background: var(--warning);
-}
-
-.btn-cancelar {
-  background: var(--danger);
-}
-
-.btn-atender:hover,
-.btn-reprogramar:hover,
-.btn-no-show:hover,
-.btn-cancelar:hover {
-  transform: translateY(-1px);
-  filter: brightness(0.95);
-}
-
-/* ===== FORMULARIO DE NUEVA CITA ===== */
+/* ── Formulario nueva cita ──────────────────────── */
 .form-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-radius: 24px;
-  padding: 1.8rem;
-  margin-bottom: 2rem;
-  box-shadow: var(--shadow-sm);
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-5);
+  box-shadow: var(--yol-shadow-xs);
 }
 
-.form-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-}
+.form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: var(--yol-s-5); }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
+.form-group { display: flex; flex-direction: column; gap: var(--yol-s-1); }
 
 .form-group label {
-  font-weight: 700;
-  color: var(--text-secondary);
-  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--yol-text-muted);
+  font-size: var(--yol-fs-label);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: .4px;
 }
 
 .form-group input,
 .form-group textarea,
 .form-group select {
-  background: var(--bg-input);
-  border: 1.5px solid var(--border-light);
-  border-radius: 14px;
-  padding: 0.75rem 1rem;
-  color: var(--text-primary);
-  font-family: 'Inter', sans-serif;
-  font-size: 0.9rem;
-  transition: all 0.2s;
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 8px 12px;
+  font: var(--yol-fs-body) var(--yol-font);
+  color: var(--yol-text);
+  outline: none;
+  transition: border-color var(--yol-duration-normal);
 }
 
 .form-group input:focus,
 .form-group textarea:focus,
-.form-group select:focus {
-  outline: none;
-  border-color: var(--border-focus);
-  box-shadow: var(--shadow-focus);
-  background: var(--bg-card);
-}
+.form-group select:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px var(--yol-primary-50); }
 
-/* ===== CALENDARIO ===== */
+/* ── Calendario mini ────────────────────────────── */
 .calendar-card {
-  background: var(--bg-side);
-  border-radius: 20px;
-  padding: 1.2rem;
-  border: 1px solid var(--border-light);
+  background: var(--yol-bg);
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-4);
+  border: 1px solid var(--yol-border);
 }
 
 .calendar-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: var(--yol-s-3);
 }
 
-.calendar-header h4 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  text-transform: capitalize;
-}
+.calendar-header h4 { margin: 0; font-size: var(--yol-fs-body); font-weight: 700; color: var(--yol-text); text-transform: capitalize; }
 
 .calendar-nav {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
   border-radius: 50%;
-  width: 36px;
-  height: 36px;
-  font-size: 1.2rem;
+  width: 32px; height: 32px;
+  font-size: 16px;
   cursor: pointer;
-  color: var(--text-secondary);
-  transition: all 0.2s;
+  color: var(--yol-text-muted);
+  transition: background var(--yol-duration-normal), color var(--yol-duration-normal);
+  display: flex; align-items: center; justify-content: center;
 }
 
-.calendar-nav:hover:not(:disabled) {
-  background: var(--gradient-start);
-  color: white;
-  transform: scale(1.05);
-}
-
-.calendar-nav:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-}
+.calendar-nav:hover:not(:disabled) { background: var(--yol-primary); color: #fff; }
+.calendar-nav:disabled { opacity: .3; cursor: not-allowed; }
 
 .calendar-legend {
   display: flex;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  font-size: 0.7rem;
-  color: var(--text-muted);
+  gap: var(--yol-s-4);
+  margin-bottom: var(--yol-s-3);
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  align-items: center;
 }
 
 .dot {
-  width: 10px;
-  height: 10px;
+  width: 8px; height: 8px;
   border-radius: 50%;
-  display: inline-block;
-  margin-right: 4px;
-}
-
-.dot.available {
-  background: var(--yol-ia);
-}
-
-.dot.partial {
-  background: var(--yol-warn);
-}
-
-.dot.full {
-  background: var(--yol-cancel-text);
-}
-
-.calendar-weekdays {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 0.4rem;
-  margin-bottom: 0.5rem;
-  text-align: center;
-}
-
-.calendar-weekdays span {
-  font-weight: 700;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  color: var(--accent-mid);
-}
-
-.calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 0.4rem;
-}
-
-.calendar-day {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-radius: 14px;
-  padding: 0.55rem 0;
-  cursor: pointer;
-  transition: all 0.18s;
-  font-size: 0.85rem;
-  color: var(--text-primary);
-  text-align: center;
-}
-
-.calendar-day:hover:not(.unavailable) {
-  border-color: var(--border-focus);
-  background: var(--accent-soft);
-  transform: scale(1.02);
-}
-
-.calendar-day.selected {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  color: white;
-  border-color: transparent;
-}
-
-.calendar-day.today:not(.selected) {
-  background: var(--accent-soft);
-  border-color: var(--accent-mid);
-  font-weight: 700;
-}
-
-.calendar-day.unavailable {
-  opacity: 0.4;
-  cursor: not-allowed;
-  background: var(--bg-side);
-  text-decoration: line-through;
-}
-
-.selected-date-info {
-  margin-top: 0.8rem;
-  padding: 0.5rem 1rem;
-  background: var(--accent-soft);
-  border-radius: 12px;
-  color: var(--text-secondary);
-  font-size: 0.85rem;
-  text-align: center;
-}
-
-/* ===== SLOTS DE HORA ===== */
-.slots-wrapper {
-  margin-top: 1.2rem;
-}
-
-.slots-legend {
-  display: flex;
-  gap: 1rem;
-  margin-bottom: 0.8rem;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
-.leg-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
   display: inline-block;
   margin-right: 4px;
   vertical-align: middle;
 }
 
-.leg-dot.free {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
+.dot.available { background: #2563eb; }
+.dot.partial   { background: var(--yol-warn); }
+.dot.full      { background: var(--yol-danger); }
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: var(--yol-s-1);
+  margin-bottom: var(--yol-s-2);
+  text-align: center;
 }
 
-.leg-dot.selected-dot {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+.calendar-weekdays span {
+  font-weight: 700;
+  font-size: var(--yol-fs-label);
+  text-transform: uppercase;
+  color: var(--yol-text-muted);
 }
 
-.leg-dot.booked-dot {
-  background: var(--bg-side);
-  border: 1px dashed var(--border-light);
+.calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: var(--yol-s-1); }
+
+.calendar-day {
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r);
+  padding: 6px 2px;
+  cursor: pointer;
+  transition: background var(--yol-duration-normal), border-color var(--yol-duration-normal);
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text);
+  text-align: center;
 }
 
-.slots-group {
-  margin-bottom: 1rem;
+.calendar-day:hover:not(.unavailable) { border-color: var(--yol-primary); background: var(--yol-primary-50); }
+.calendar-day.selected { background: var(--yol-primary); color: #fff; border-color: transparent; }
+.calendar-day.today:not(.selected) { background: var(--yol-primary-50); border-color: var(--yol-primary); font-weight: 700; }
+.calendar-day.unavailable { opacity: .4; cursor: not-allowed; text-decoration: line-through; }
+.calendar-day.outside { opacity: .3; }
+
+.selected-date-info {
+  margin-top: var(--yol-s-2);
+  padding: var(--yol-s-2) var(--yol-s-3);
+  background: var(--yol-primary-50);
+  border-radius: var(--yol-r-md);
+  color: var(--yol-primary);
+  font-size: var(--yol-fs-sm);
+  text-align: center;
 }
+
+/* ── Slots de hora ──────────────────────────────── */
+.slots-wrapper.disabled { opacity: .5; pointer-events: none; }
+
+.slots-legend {
+  display: flex;
+  gap: var(--yol-s-4);
+  margin-bottom: var(--yol-s-2);
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  align-items: center;
+}
+
+.leg-dot { width: 12px; height: 12px; border-radius: 3px; display: inline-block; margin-right: 4px; vertical-align: middle; }
+.leg-dot.free         { background: var(--yol-surface); border: 1px solid var(--yol-border); }
+.leg-dot.selected-dot { background: var(--yol-primary); }
+.leg-dot.booked-dot   { background: var(--yol-bg); border: 1px dashed var(--yol-border); }
+
+.slots-group { margin-bottom: var(--yol-s-4); }
 
 .slots-period {
   display: block;
-  font-size: 0.7rem;
+  font-size: var(--yol-fs-label);
   font-weight: 700;
-  color: var(--accent-mid);
-  margin-bottom: 0.5rem;
+  color: var(--yol-text-muted);
   text-transform: uppercase;
+  margin-bottom: var(--yol-s-2);
 }
 
-.time-slots {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(78px, 1fr));
-  gap: 0.5rem;
-}
+.time-slots { display: grid; grid-template-columns: repeat(auto-fill, minmax(78px, 1fr)); gap: var(--yol-s-1); }
 
 .slot-button {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-radius: 12px;
-  padding: 0.5rem 0.3rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--text-secondary);
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 6px 4px;
+  font: 600 var(--yol-fs-label) var(--yol-font);
+  color: var(--yol-text-muted);
   cursor: pointer;
-  transition: all 0.18s;
+  transition: background var(--yol-duration-normal), border-color var(--yol-duration-normal), color var(--yol-duration-normal);
   text-align: center;
 }
 
-.slot-button:hover:not(.booked):not(.selected) {
-  border-color: var(--border-focus);
-  background: var(--accent-soft);
-  transform: scale(1.02);
-}
+.slot-button:hover:not(.booked):not(.selected) { border-color: var(--yol-primary); background: var(--yol-primary-50); color: var(--yol-primary); }
+.slot-button.selected { background: var(--yol-primary); color: #fff; border-color: transparent; }
+.slot-button.booked   { background: var(--yol-bg); color: var(--yol-text-subtle); text-decoration: line-through; cursor: not-allowed; opacity: .6; }
 
-.slot-button.selected {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  color: white;
-  border-color: transparent;
-}
+.helper-text { margin-top: var(--yol-s-2); font-size: var(--yol-fs-label); color: var(--yol-text-muted); }
+.helper-text.warning { color: var(--yol-warn); }
 
-.slot-button.booked {
-  background: var(--bg-side);
-  color: var(--text-muted);
-  text-decoration: line-through;
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.helper-text {
-  margin-top: 0.5rem;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
-.helper-text.warning {
-  color: var(--warning);
-}
-
-/* ===== ALERTAS ===== */
+/* ── Estados ────────────────────────────────────── */
 .alert {
   background: var(--yol-ok-surface);
-  border-left: 4px solid var(--success);
-  padding: 1rem 1.2rem;
-  border-radius: 14px;
-  color: var(--text-secondary);
-  margin: 0.5rem 0;
+  border-left: 4px solid var(--yol-primary);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  color: var(--yol-primary);
+  font-size: var(--yol-fs-sm);
 }
 
-.alert.error {
-  background: var(--yol-cancel-surface);
-  border-left-color: var(--danger);
-  color: var(--danger);
-}
+.alert.error { background: var(--yol-cancel-surface); border-left-color: var(--yol-danger); color: var(--yol-danger); }
 
 .placeholder-card {
-  background: var(--bg-side);
-  border-radius: 24px;
-  padding: 2rem;
+  background: var(--yol-bg);
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-8) var(--yol-s-5);
   text-align: center;
-  border: 1px dashed var(--border-light);
-  color: var(--text-muted);
+  border: 1px dashed var(--yol-border);
+  color: var(--yol-text-muted);
+  font-size: var(--yol-fs-sm);
 }
 
-/* ===== MODALES ===== */
+.placeholder-card h4 { font-size: var(--yol-fs-body); font-weight: 600; color: var(--yol-text); margin: 0 0 var(--yol-s-2); }
+.placeholder-card p  { margin: 0; }
+
+/* ── Modales ────────────────────────────────────── */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
+  background: rgba(0,0,0,.45);
+  backdrop-filter: blur(3px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -796,39 +588,179 @@
 .modal,
 .modal-consulta,
 .modal-perfil-alumno {
-  background: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-radius: 28px;
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
   max-width: 92%;
   width: 520px;
   max-height: 85vh;
   overflow-y: auto;
-  padding: 1.8rem;
-  box-shadow: var(--shadow-lg);
+  padding: var(--yol-s-5);
+  box-shadow: var(--yol-shadow-sm);
 }
 
-/* ===== RESPONSIVE ===== */
+.modal h3, .modal-consulta h3, .modal-perfil-alumno h3 {
+  font-size: var(--yol-fs-h2);
+  font-weight: 700;
+  color: var(--yol-text);
+  margin: 0 0 var(--yol-s-4);
+}
+
+.modal-actions {
+  display: flex;
+  gap: var(--yol-s-2);
+  justify-content: flex-end;
+  margin-top: var(--yol-s-5);
+  padding-top: var(--yol-s-4);
+  border-top: 1px solid var(--yol-border);
+}
+
+.form-msg {
+  background: var(--yol-cancel-surface);
+  border-left: 3px solid var(--yol-danger);
+  color: var(--yol-danger);
+  padding: var(--yol-s-2) var(--yol-s-3);
+  border-radius: var(--yol-r-md);
+  font-size: var(--yol-fs-sm);
+  margin-bottom: var(--yol-s-3);
+}
+
+.form-msg.success { background: var(--yol-ok-surface); border-left-color: var(--yol-primary); color: var(--yol-primary); }
+
+.consulta-cita-label {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
+  margin: 0 0 var(--yol-s-4);
+}
+
+/* ── Modal perfil alumno ────────────────────────── */
+.modal-perfil-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--yol-s-4);
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: var(--yol-text-muted);
+  padding: 4px;
+  border-radius: var(--yol-r);
+  transition: color var(--yol-duration-normal);
+}
+
+.modal-close:hover { color: var(--yol-text); }
+
+.modal-loading { color: var(--yol-text-muted); font-size: var(--yol-fs-sm); padding: var(--yol-s-4); text-align: center; }
+
+.perfil-alumno-top {
+  display: flex;
+  align-items: center;
+  gap: var(--yol-s-4);
+  margin-bottom: var(--yol-s-5);
+  padding-bottom: var(--yol-s-4);
+  border-bottom: 1px solid var(--yol-border);
+}
+
+.perfil-alumno-avatar {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 700;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.perfil-alumno-avatar img { width: 100%; height: 100%; object-fit: cover; }
+
+.perfil-alumno-info h4 { margin: 0 0 var(--yol-s-1); font-size: var(--yol-fs-body); font-weight: 700; color: var(--yol-text); }
+.perfil-alumno-info p  { margin: 2px 0; font-size: var(--yol-fs-sm); color: var(--yol-text-muted); }
+
+.perfil-alumno-medico {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-2);
+  margin-bottom: var(--yol-s-5);
+}
+
+.dato-medico {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--yol-s-4);
+  padding: var(--yol-s-2) 0;
+  border-bottom: 1px solid var(--yol-bg);
+}
+
+.dato-label { font-size: var(--yol-fs-sm); font-weight: 600; color: var(--yol-text-muted); }
+.dato-valor { font-size: var(--yol-fs-sm); color: var(--yol-text); text-align: right; }
+.dato-valor.sin-dato { color: var(--yol-text-subtle); }
+
+.perfil-alumno-historial h4 { font-size: var(--yol-fs-sm); font-weight: 700; color: var(--yol-text); margin: 0 0 var(--yol-s-3); }
+
+.historial-item-mini {
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  margin-bottom: var(--yol-s-2);
+  overflow: hidden;
+}
+
+.historial-mini-header {
+  display: flex;
+  align-items: center;
+  gap: var(--yol-s-3);
+  padding: var(--yol-s-2) var(--yol-s-3);
+  cursor: pointer;
+  background: var(--yol-bg);
+  font-size: var(--yol-fs-sm);
+}
+
+.historial-fecha   { font-weight: 600; color: var(--yol-text); white-space: nowrap; }
+.historial-motivo-mini { flex: 1; color: var(--yol-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.historial-mini-detalle {
+  padding: var(--yol-s-3);
+  background: var(--yol-surface);
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
+  border-top: 1px solid var(--yol-border);
+}
+
+.historial-mini-detalle p { margin: var(--yol-s-1) 0; }
+
+.sin-dato { color: var(--yol-text-subtle); font-size: var(--yol-fs-sm); }
+
+/* ── Dark mode ──────────────────────────────────── */
+:host-context(.dark) .week-grid-card,
+:host-context(.dark) .citas-column,
+:host-context(.dark) .form-card,
+:host-context(.dark) .filtros-bar { background: #1a2e25; border-color: #2a4030; }
+
+:host-context(.dark) .calendar-card { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .calendar-day  { background: #1a2e25; border-color: #2a4030; color: #e8f5ee; }
+
+:host-context(.dark) .cita-card { background: #0f1a15; border-color: #2a4030; }
+
+:host-context(.dark) .modal,
+:host-context(.dark) .modal-consulta,
+:host-context(.dark) .modal-perfil-alumno { background: #1a2e25; border-color: #2a4030; }
+
+:host-context(.dark) .slot-button  { background: #1a2e25; border-color: #2a4030; color: #a8c4b4; }
+:host-context(.dark) .search-input { background: #0f1a15; border-color: #2a4030; color: #e8f5ee; }
+:host-context(.dark) .filtro-select,
+:host-context(.dark) .filtro-fecha { background: #0f1a15; border-color: #2a4030; color: #e8f5ee; }
+
+/* ── Responsive ─────────────────────────────────── */
 @media (max-width: 900px) {
-  .citas-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .section-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .filtros-bar {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .calendar-grid {
-    gap: 0.2rem;
-  }
-
-  .calendar-day {
-    padding: 0.4rem 0;
-    font-size: 0.75rem;
-  }
+  .citas-layout { grid-template-columns: 1fr; }
+  .filtros-bar  { flex-direction: column; align-items: stretch; }
+  .week-grid-table { min-width: 600px; }
 }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
@@ -1,254 +1,432 @@
-<div class="citas-wrapper">
+<!-- Overlay para drawer -->
+<div class="overlay" *ngIf="drawerCitaAbierto" (click)="closeDrawer()"></div>
 
-  <!-- Mensajes -->
-  <div *ngIf="submitMessage" class="alert">{{ submitMessage }}</div>
+<!-- ===== HEADER ===== -->
+<div class="citas-header">
+  <div>
+    <div class="crumb">Servicio médico · Citas</div>
+    <h1>Gestión de citas</h1>
+  </div>
+  <button class="btn-primary" (click)="toggleCreateForm()">+ Nueva cita</button>
+</div>
 
-  <!-- ===== CALENDARIO SEMANAL ===== -->
-  <div class="week-grid-card">
-    <div class="week-grid-header">
-      <h2>{{ weekLabel }}</h2>
-      <div class="week-nav">
-        <button class="btn-week" (click)="goToThisWeek()">Hoy</button>
-        <button class="btn-week" (click)="changeWeek(-1)">‹</button>
-        <button class="btn-week" (click)="changeWeek(1)">›</button>
-      </div>
-    </div>
-    <div class="week-grid-table-wrap">
-      <table class="week-grid-table">
-        <thead>
-          <tr>
-            <th class="col-hora">Hora</th>
-            <th *ngFor="let day of weekGridDays" [class.col-today]="day.isToday">
-              {{ day.label }}
-              <span *ngIf="day.isToday" class="today-dot">hoy</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let hour of hourGridSlots">
-            <td class="cell-hora">{{ hour | number:'2.0-0' }}:00</td>
-            <td *ngFor="let day of weekGridDays" class="cell-slot" [class.cell-today]="day.isToday">
-              <div *ngFor="let cita of getCitasForSlot(day.date, hour)"
-                   class="grid-cita" [ngClass]="getGridCitaClass(cita)"
-                   (click)="cita.alumno ? openFicha.emit(cita.alumno.id) : null">
-                {{ getGridCitaName(cita) }}
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<!-- ===== KPI BAR ===== -->
+<div class="kpis" *ngIf="!isLoadingCitas && citas.length > 0">
+  <div class="kpi">
+    <div class="kpi-ic">▦</div>
+    <div>
+      <div class="kpi-lbl">Citas hoy</div>
+      <div class="kpi-v">{{ citasHoy }}</div>
     </div>
   </div>
-
-  <!-- ===== SECCIÓN EXPANDIBLE: AGENDAR + LISTA ===== -->
-  <div class="section-header">
-    <h2>Gestión de Citas</h2>
-    <button class="btn-primary" (click)="toggleCreateForm()">
-      {{ showCreateForm ? 'Cerrar formulario' : 'Agendar Nueva Cita' }}
-    </button>
+  <div class="kpi kpi-info">
+    <div class="kpi-ic">◔</div>
+    <div>
+      <div class="kpi-lbl">Próxima cita</div>
+      <div class="kpi-v">{{ proximaCitaObj ? formatTime(proximaCitaObj.hora_cita) : '—' }}</div>
+    </div>
   </div>
-
-  <!-- Formulario de creación -->
-  <div *ngIf="showCreateForm" class="form-card">
-    <form #createCitaForm="ngForm" (ngSubmit)="onCreateCita(createCitaForm)">
-      <div class="form-grid">
-        <div class="form-group">
-          <label for="numeroControl">Número de control del alumno</label>
-          <input type="text" id="numeroControl" name="numero_control" [(ngModel)]="createFormData.numero_control"
-            required placeholder="Ej. A12345678" />
-        </div>
-        <div class="form-group full-width">
-          <label>Fecha de la cita</label>
-          <div class="calendar-card">
-            <div class="calendar-header">
-              <button type="button" class="calendar-nav" (click)="changeMonth(-1)"
-                [disabled]="isCurrentMonth">‹</button>
-              <h4>{{ calendarLabel | titlecase }}</h4>
-              <button type="button" class="calendar-nav" (click)="changeMonth(1)">›</button>
-            </div>
-            <div class="calendar-legend">
-              <span><span class="dot available"></span> Disponible</span>
-              <span><span class="dot partial"></span> Parcial</span>
-              <span><span class="dot full"></span> Sin lugares</span>
-            </div>
-            <div class="calendar-weekdays">
-              <span *ngFor="let day of weekDays">{{ day }}</span>
-            </div>
-            <div class="calendar-grid">
-              <ng-container *ngFor="let week of calendarWeeks">
-                <button type="button" *ngFor="let day of week" class="calendar-day" [ngClass]="{
-                  outside: !day.isCurrentMonth,
-                  today: day.isToday,
-                  selected: isSelectedDate(day.date),
-                  unavailable: isDayUnavailable(day),
-                  'status-available': day.availability === 'available',
-                  'status-partial': day.availability === 'partial',
-                  'status-full': day.availability === 'full',
-                  'status-none': day.availability === 'none'
-                }" [ngStyle]="getDayStyle(day)" [attr.aria-pressed]="isSelectedDate(day.date)"
-                  (click)="selectCalendarDay(day)">
-                  <span class="day-number">{{ day.label }}</span>
-                  <span class="day-badge" *ngIf="day.labelText">{{ day.labelText }}</span>
-                </button>
-              </ng-container>
-            </div>
-          </div>
-          <div class="selected-date-info" *ngIf="createFormData.fecha_cita">
-            <strong>Seleccionaste:</strong> {{ formatDateDisplay(createFormData.fecha_cita) }}
-          </div>
-          <input type="hidden" id="fechaCita" name="fecha_cita" [(ngModel)]="createFormData.fecha_cita" required />
-        </div>
-        <div class="form-group full-width">
-          <label>Hora</label>
-          <div class="slots-wrapper" [class.disabled]="!createFormData.fecha_cita || !hasAvailableSlotsForSelectedDate">
-            <div class="slots-legend">
-              <span class="leg-dot free"></span> Libre
-              <span class="leg-dot selected-dot"></span> Seleccionado
-              <span class="leg-dot booked-dot"></span> Ocupado
-            </div>
-            <div class="slots-group">
-              <span class="slots-period">🌅 Mañana</span>
-              <div class="time-slots">
-                <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(0, 16)"
-                  [class.selected]="createFormData.hora_cita === normalizeTime(slot)"
-                  [class.booked]="isSlotUnavailable(slot)"
-                  [disabled]="!createFormData.fecha_cita || isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
-                  {{ formatTime(slot) }}
-                </button>
-              </div>
-            </div>
-            <div class="slots-group">
-              <span class="slots-period">🌇 Tarde</span>
-              <div class="time-slots">
-                <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(16)"
-                  [class.selected]="createFormData.hora_cita === normalizeTime(slot)"
-                  [class.booked]="isSlotUnavailable(slot)"
-                  [disabled]="!createFormData.fecha_cita || isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
-                  {{ formatTime(slot) }}
-                </button>
-              </div>
-            </div>
-          </div>
-          <small class="helper-text" *ngIf="!createFormData.fecha_cita">
-            Selecciona un día disponible para ver las horas libres.
-          </small>
-          <small class="helper-text warning" *ngIf="createFormData.fecha_cita && !hasAvailableSlotsForSelectedDate">
-            Este día ya no tiene espacios disponibles.
-          </small>
-          <input type="hidden" id="horaCita" name="hora_cita" [(ngModel)]="createFormData.hora_cita" required />
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label for="motivo">Motivo</label>
-        <textarea id="motivo" name="motivo" [(ngModel)]="createFormData.motivo" rows="3"
-          placeholder="Describe el motivo de la consulta"></textarea>
-      </div>
-
-      <button class="btn-primary" type="submit" [disabled]="isSubmitting || createCitaForm.invalid">
-        {{ isSubmitting ? 'Agendando...' : 'Guardar cita' }}
-      </button>
-    </form>
+  <div class="kpi kpi-warn">
+    <div class="kpi-ic">◷</div>
+    <div>
+      <div class="kpi-lbl">Pendientes</div>
+      <div class="kpi-v">{{ pendingCitas.length }}</div>
+    </div>
   </div>
-
-  <!-- Barra de búsqueda y filtros -->
-  <div class="search-bar">
-    <input type="text" [(ngModel)]="searchCitas" placeholder="Buscar por alumno, número de control o motivo..."
-      class="search-input">
-    <button *ngIf="searchCitas" class="search-clear" (click)="searchCitas = ''">✕</button>
+  <div class="kpi kpi-danger">
+    <div class="kpi-ic">✕</div>
+    <div>
+      <div class="kpi-lbl">Canceladas este mes</div>
+      <div class="kpi-v">{{ canceladasMes }}</div>
+    </div>
   </div>
+</div>
 
-  <div class="filtros-bar">
-    <select [(ngModel)]="filtroEstatus" class="filtro-select">
-      <option value="">Todos los estatus</option>
+<!-- ===== PRÓXIMA CITA HERO ===== -->
+<div class="proxima-hero" *ngIf="proximaCitaObj && !isLoadingCitas">
+  <div class="av av-hero">{{ getGridCitaInitials(proximaCitaObj) }}</div>
+  <div class="proxima-info">
+    <div class="proxima-label">Próxima cita</div>
+    <div class="proxima-name">{{ getGridCitaName(proximaCitaObj) }}</div>
+    <div class="proxima-meta">
+      No. {{ proximaCitaObj.alumno?.numero_control ?? '—' }} · {{ formatFechaCorta(proximaCitaObj.fecha_cita) }}
+    </div>
+  </div>
+  <div class="proxima-hora-block">
+    <div class="hora-big">{{ formatTime(proximaCitaObj.hora_cita) }}</div>
+  </div>
+  <div class="proxima-actions">
+    <button class="btn-hero-outline" *ngIf="proximaCitaObj.alumno"
+      (click)="openPerfilAlumno(proximaCitaObj.alumno.id)">Expediente</button>
+    <button class="btn-hero-white" (click)="drawerAtender(proximaCitaObj)">Iniciar consulta</button>
+  </div>
+</div>
+
+<!-- ===== SEMANA GRID (agenda) ===== -->
+<div class="week-grid-card">
+  <div class="week-grid-header">
+    <h2>{{ weekLabel }}</h2>
+    <div class="week-nav">
+      <button class="btn-week" (click)="goToThisWeek()">Hoy</button>
+      <button class="btn-week" (click)="changeWeek(-1)">‹</button>
+      <button class="btn-week" (click)="changeWeek(1)">›</button>
+    </div>
+  </div>
+  <div class="week-grid-table-wrap">
+    <table class="week-grid-table">
+      <thead>
+        <tr>
+          <th class="col-hora">Hora</th>
+          <th *ngFor="let day of weekGridDays" [class.col-today]="day.isToday">
+            {{ day.label }}<span *ngIf="day.isToday" class="today-dot">hoy</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let hour of hourGridSlots">
+          <td class="cell-hora">{{ hour | number:'2.0-0' }}:00</td>
+          <td *ngFor="let day of weekGridDays" class="cell-slot" [class.cell-today]="day.isToday">
+            <div *ngFor="let cita of getCitasForSlot(day.date, hour)"
+                 class="grid-cita" [ngClass]="getGridCitaClass(cita)"
+                 (click)="openDrawer(cita)">
+              {{ getGridCitaName(cita) }}
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- ===== BUSCADOR + FILTROS ===== -->
+<div class="citas-search-bar">
+  <span class="search-ic">⌕</span>
+  <input placeholder="Buscar por alumno, No. control o motivo…"
+         [(ngModel)]="searchCitas" />
+  <div class="filtros-inline">
+    <select [(ngModel)]="filtroEstatus" class="filtro-select-sm">
+      <option value="">Todos los estados</option>
       <option value="programada">Programada</option>
       <option value="atendida">Atendida</option>
       <option value="cancelada">Cancelada</option>
       <option value="no_asistio">No asistió</option>
     </select>
-    <input type="date" [(ngModel)]="filtroFechaDesde" class="filtro-fecha">
-    <input type="date" [(ngModel)]="filtroFechaHasta" class="filtro-fecha">
-    <button class="btn-limpiar" (click)="limpiarFiltros()"
-      *ngIf="filtroEstatus || filtroFechaDesde || filtroFechaHasta || searchCitas">
-      Limpiar filtros
-    </button>
-  </div>
-
-  <!-- Contenedor de citas -->
-  <div class="citas-container">
-    <ng-container *ngIf="!isLoadingCitas; else loadingCitas">
-      <div *ngIf="citasError" class="alert error">{{ citasError }}</div>
-
-      <div class="citas-layout" *ngIf="!citasError">
-        <!-- Columna de próximas citas -->
-        <div class="citas-column pendientes">
-          <h3>Próximas citas</h3>
-          <ng-container *ngIf="filteredPendingCitas.length > 0; else noPendientesDoctor">
-            <div *ngFor="let cita of filteredPendingCitas" class="cita-card">
-              <div class="cita-header">
-                <h4>{{ formatDateDisplay(cita.fecha_cita) }}</h4>
-                <span class="estatus programada">Programada</span>
-              </div>
-              <p class="hora">{{ formatTime(cita.hora_cita) }} hrs</p>
-              <p class="motivo" *ngIf="cita.motivo">Motivo: {{ cita.motivo }}</p>
-              <p class="alumno" *ngIf="cita.alumno">Alumno: {{ cita.alumno.nombre }} {{ cita.alumno.apellido }}</p>
-              <div class="card-actions">
-                <button class="btn-atender" (click)="onMarkAsAttended(cita)" [disabled]="isSubmitting">Atender</button>
-                <button class="btn-reprogramar" (click)="openReprogramar(cita)" [disabled]="isSubmitting">Reprogramar</button>
-                <button class="btn-no-show" (click)="onMarkAsNoShow(cita)" [disabled]="isSubmitting">No asistió</button>
-                <button class="btn-cancelar" (click)="onCancelCita(cita)" [disabled]="isSubmitting">Cancelar</button>
-                <button class="btn-perfil-alumno" *ngIf="cita.alumno" (click)="openPerfilAlumno(cita.alumno.id)">Ver perfil</button>
-              </div>
-            </div>
-          </ng-container>
-          <ng-template #noPendientesDoctor>
-            <div class="placeholder-card compact">
-              <h4>No hay citas pendientes</h4>
-              <p>Cuando agendes citas para los alumnos aparecerán aquí.</p>
-            </div>
-          </ng-template>
-        </div>
-
-
-        <!-- Columna de historial -->
-        <div class="citas-column historial">
-          <h3>Historial reciente</h3>
-          <ng-container *ngIf="filteredHandledCitas.length > 0; else noHistorialDoctor">
-            <div *ngFor="let cita of filteredHandledCitas" class="cita-card"
-              [class.cancelada]="cita.estatus === 'cancelada'" [class.no-asistio]="cita.estatus === 'no_asistio'">
-              <div class="cita-header">
-                <h4>{{ formatDateDisplay(cita.fecha_cita) }}</h4>
-                <span class="estatus" [class.atendida]="cita.estatus === 'atendida'"
-                  [class.cancelada]="cita.estatus === 'cancelada'" [class.no-asistio]="cita.estatus === 'no_asistio'">
-                  {{ cita.estatus === 'atendida' ? 'Atendida' : cita.estatus === 'no_asistio' ? 'No asistió' :
-                  'Cancelada'
-                  }}
-                </span>
-              </div>
-              <p class="hora">{{ formatTime(cita.hora_cita) }} hrs</p>
-              <p class="motivo" *ngIf="cita.motivo">Motivo: {{ cita.motivo }}</p>
-              <p class="alumno" *ngIf="cita.alumno">Alumno: {{ cita.alumno.nombre }} {{ cita.alumno.apellido }}</p>
-              <div class="card-actions" *ngIf="cita.alumno">
-                <button class="btn-perfil-alumno" (click)="openPerfilAlumno(cita.alumno.id)">Ver perfil</button>
-              </div>
-            </div>
-          </ng-container>
-          <ng-template #noHistorialDoctor>
-            <div class="placeholder-card compact">
-              <h4>Sin historial todavía</h4>
-              <p>Cuando atiendas o canceles citas aparecerán en esta sección.</p>
-            </div>
-          </ng-template>
-        </div>
-      </div>
-    </ng-container>
-    <ng-template #loadingCitas>
-      <div class="placeholder-card">Cargando lista de citas...</div>
-    </ng-template>
+    <input type="date" [(ngModel)]="filtroFechaDesde" class="filtro-fecha-sm">
+    <input type="date" [(ngModel)]="filtroFechaHasta" class="filtro-fecha-sm">
+    <button class="btn-limpiar-sm"
+      *ngIf="filtroEstatus || filtroFechaDesde || filtroFechaHasta || searchCitas"
+      (click)="limpiarFiltros()">Limpiar</button>
   </div>
 </div>
 
-<!-- Modal: Registrar consulta -->
+<!-- Loading / Error -->
+<div *ngIf="isLoadingCitas" class="placeholder">Cargando citas…</div>
+<div *ngIf="citasError" class="msg-error">{{ citasError }}</div>
+
+<!-- ===== LISTA DE CITAS ===== -->
+<div class="table-wrap" *ngIf="!isLoadingCitas && !citasError">
+
+  <!-- Pendientes -->
+  <div class="table-section-head" *ngIf="filteredPendingCitas.length > 0">
+    <span><b>{{ filteredPendingCitas.length }}</b> cita{{ filteredPendingCitas.length !== 1 ? 's' : '' }} pendiente{{ filteredPendingCitas.length !== 1 ? 's' : '' }}</span>
+  </div>
+
+  <div class="cita-row"
+       *ngFor="let c of filteredPendingCitas"
+       (click)="openDrawer(c)"
+       [class.sel]="drawerCita?.id === c.id">
+    <div class="av">{{ getGridCitaInitials(c) }}</div>
+    <div class="who">
+      <b>{{ getGridCitaName(c) }}</b>
+      <span>No. {{ c.alumno?.numero_control ?? '—' }}</span>
+    </div>
+    <span class="badge-fecha">
+      <span class="dot-verde"></span>{{ formatFechaCorta(c.fecha_cita) }} · {{ formatTime(c.hora_cita) }}
+    </span>
+    <span class="estatus-chip chip-programada">Programada</span>
+    <div class="motivo-col">{{ c.motivo || 'Sin motivo' }}</div>
+    <div class="row-actions" (click)="$event.stopPropagation()">
+      <button class="btn-sm btn-primary-full" (click)="onMarkAsAttended(c)">Atender</button>
+      <button class="btn-sm btn-outline" (click)="openDrawer(c)">Ver detalle</button>
+    </div>
+  </div>
+
+  <!-- Historial -->
+  <div class="table-section-head historial-head" *ngIf="filteredHandledCitas.length > 0">
+    <span><b>{{ filteredHandledCitas.length }}</b> cita{{ filteredHandledCitas.length !== 1 ? 's' : '' }} en historial</span>
+  </div>
+
+  <div class="cita-row"
+       *ngFor="let c of pagedHandledCitas"
+       (click)="openDrawer(c)"
+       [class.sel]="drawerCita?.id === c.id">
+    <div class="av av-muted">{{ getGridCitaInitials(c) }}</div>
+    <div class="who">
+      <b>{{ getGridCitaName(c) }}</b>
+      <span>No. {{ c.alumno?.numero_control ?? '—' }}</span>
+    </div>
+    <span class="badge-fecha badge-fecha-muted">
+      {{ formatFechaCorta(c.fecha_cita) }} · {{ formatTime(c.hora_cita) }}
+    </span>
+    <span class="estatus-chip"
+      [ngClass]="{
+        'chip-atendida':   c.estatus === 'atendida',
+        'chip-cancelada':  c.estatus === 'cancelada',
+        'chip-no-asistio': c.estatus === 'no_asistio'
+      }">
+      {{ c.estatus === 'atendida' ? 'Atendida' : c.estatus === 'cancelada' ? 'Cancelada' : 'No asistió' }}
+    </span>
+    <div class="motivo-col">{{ c.motivo || 'Sin motivo' }}</div>
+    <div class="row-actions" (click)="$event.stopPropagation()">
+      <button class="btn-sm btn-outline" (click)="openDrawer(c)">Ver detalle</button>
+    </div>
+  </div>
+
+  <!-- Paginación historial -->
+  <div class="pagination-bar" *ngIf="totalPaginasHistorial > 1">
+    <button class="btn-sm btn-outline"
+            (click)="cambiarPaginaHistorial(historialPagina - 1)"
+            [disabled]="historialPagina === 1">‹ Anterior</button>
+    <span class="pagination-info">Página {{ historialPagina }} de {{ totalPaginasHistorial }}</span>
+    <button class="btn-sm btn-outline"
+            (click)="cambiarPaginaHistorial(historialPagina + 1)"
+            [disabled]="historialPagina === totalPaginasHistorial">Siguiente ›</button>
+  </div>
+
+  <!-- Vacío -->
+  <div class="placeholder" *ngIf="filteredPendingCitas.length === 0 && filteredHandledCitas.length === 0">
+    <div class="placeholder-ic">▦</div>
+    <b>Sin citas</b>
+    <span>Usa el botón "Nueva cita" para agendar una consulta.</span>
+  </div>
+</div>
+
+<!-- ===== DRAWER: Detalle de cita ===== -->
+<aside class="drawer" [class.open]="drawerCitaAbierto">
+  <ng-container *ngIf="drawerCita">
+
+    <div class="drawer-head">
+      <div>
+        <h2><span class="drawer-ic">▦</span>Detalle de cita</h2>
+        <div class="drawer-sub">{{ formatDateDisplay(drawerCita.fecha_cita) }}</div>
+      </div>
+      <button class="btn-x" (click)="closeDrawer()">×</button>
+    </div>
+
+    <div class="drawer-body">
+      <div class="d-patient">
+        <div class="av av-md">{{ getGridCitaInitials(drawerCita) }}</div>
+        <div class="d-patient-info">
+          <b>{{ getGridCitaName(drawerCita) }}</b>
+          <span class="d-patient-sub">No. <b>{{ drawerCita.alumno?.numero_control ?? '—' }}</b></span>
+        </div>
+      </div>
+
+      <div class="d-grid">
+        <div class="d-cell">
+          <div class="d-label">Fecha</div>
+          <b>{{ formatFechaCorta(drawerCita.fecha_cita) }}</b>
+        </div>
+        <div class="d-cell">
+          <div class="d-label">Hora</div>
+          <b>{{ formatTime(drawerCita.hora_cita) }}</b>
+        </div>
+        <div class="d-cell d-cell-full">
+          <div class="d-label">Estado</div>
+          <span class="estatus-chip"
+            [ngClass]="{
+              'chip-programada': drawerCita.estatus === 'programada',
+              'chip-atendida':   drawerCita.estatus === 'atendida',
+              'chip-cancelada':  drawerCita.estatus === 'cancelada',
+              'chip-no-asistio': drawerCita.estatus === 'no_asistio'
+            }">
+            {{ drawerCita.estatus === 'programada' ? 'Programada'
+               : drawerCita.estatus === 'atendida' ? 'Atendida'
+               : drawerCita.estatus === 'cancelada' ? 'Cancelada'
+               : 'No asistió' }}
+          </span>
+        </div>
+      </div>
+
+      <div class="d-section" *ngIf="drawerCita.motivo">
+        <div class="d-section-head">Motivo</div>
+        <div class="d-text">{{ drawerCita.motivo }}</div>
+      </div>
+    </div>
+
+    <!-- Footer para citas programadas -->
+    <ng-container *ngIf="drawerCita.estatus === 'programada'">
+      <div class="drawer-foot-top" *ngIf="drawerCita.alumno">
+        <button class="btn-sm btn-outline flex1" (click)="openPerfilAlumno(drawerCita.alumno.id)">Ver expediente</button>
+        <button class="btn-sm btn-gray flex1" (click)="drawerReprogramar(drawerCita)">Reprogramar</button>
+      </div>
+      <div class="drawer-foot">
+        <button class="btn-sm btn-danger flex1" (click)="drawerCancelar(drawerCita)">Cancelar</button>
+        <button class="btn-sm btn-warn flex1" (click)="drawerNoAsistio(drawerCita)">No asistió</button>
+        <button class="btn-sm btn-primary-full flex1" (click)="drawerAtender(drawerCita)">Consulta</button>
+      </div>
+    </ng-container>
+
+    <!-- Footer para citas ya gestionadas -->
+    <div class="drawer-foot" *ngIf="drawerCita.estatus !== 'programada'">
+      <button class="btn-sm btn-gray flex1" (click)="closeDrawer()">Cerrar</button>
+      <button class="btn-sm btn-outline flex1" *ngIf="drawerCita.alumno"
+        (click)="openPerfilAlumno(drawerCita.alumno.id)">Ver expediente</button>
+    </div>
+
+  </ng-container>
+</aside>
+
+<!-- ===== MODAL: 3 pasos — Nueva cita ===== -->
+<div class="modal-overlay" *ngIf="showCreateForm" (click)="toggleCreateForm()">
+  <div class="modal-3step" (click)="$event.stopPropagation()">
+
+    <div class="modal-3step-head">
+      <div>
+        <h3>Nueva cita</h3>
+        <div class="step-indicator">
+          <span class="step-dot" [class.active]="createStep >= 1" [class.done]="createStep > 1">1</span>
+          <span class="step-line"></span>
+          <span class="step-dot" [class.active]="createStep >= 2" [class.done]="createStep > 2">2</span>
+          <span class="step-line"></span>
+          <span class="step-dot" [class.active]="createStep >= 3">3</span>
+        </div>
+      </div>
+      <button class="modal-close" (click)="toggleCreateForm()">✕</button>
+    </div>
+
+    <div *ngIf="submitMessage" class="form-msg">{{ submitMessage }}</div>
+
+    <form #createCitaForm="ngForm" (ngSubmit)="onCreateCita(createCitaForm)">
+
+      <!-- Paso 1: Alumno -->
+      <div *ngIf="createStep === 1" class="step-body">
+        <div class="step-title">¿Para quién es la cita?</div>
+        <div class="form-group">
+          <label>Número de control del alumno</label>
+          <input type="text" name="numero_control" [(ngModel)]="createFormData.numero_control"
+            placeholder="Ej. 22690495" autocomplete="off" />
+        </div>
+      </div>
+
+      <!-- Paso 2: Fecha y hora -->
+      <div *ngIf="createStep === 2" class="step-body">
+        <div class="step-title">¿Cuándo?</div>
+        <div class="calendar-card">
+          <div class="calendar-header">
+            <button type="button" class="calendar-nav" (click)="changeMonth(-1)" [disabled]="isCurrentMonth">‹</button>
+            <h4>{{ calendarLabel | titlecase }}</h4>
+            <button type="button" class="calendar-nav" (click)="changeMonth(1)">›</button>
+          </div>
+          <div class="calendar-legend">
+            <span><span class="dot available"></span> Disponible</span>
+            <span><span class="dot partial"></span> Parcial</span>
+            <span><span class="dot full"></span> Sin lugares</span>
+          </div>
+          <div class="calendar-weekdays">
+            <span *ngFor="let day of weekDays">{{ day }}</span>
+          </div>
+          <div class="calendar-grid">
+            <ng-container *ngFor="let week of calendarWeeks">
+              <button type="button" *ngFor="let day of week" class="calendar-day" [ngClass]="{
+                outside: !day.isCurrentMonth,
+                today: day.isToday,
+                selected: isSelectedDate(day.date),
+                unavailable: isDayUnavailable(day),
+                'status-available': day.availability === 'available',
+                'status-partial': day.availability === 'partial',
+                'status-full': day.availability === 'full',
+                'status-none': day.availability === 'none'
+              }" [ngStyle]="getDayStyle(day)" [attr.aria-pressed]="isSelectedDate(day.date)"
+                (click)="selectCalendarDay(day)">
+                <span class="day-number">{{ day.label }}</span>
+                <span class="day-badge" *ngIf="day.labelText">{{ day.labelText }}</span>
+              </button>
+            </ng-container>
+          </div>
+        </div>
+        <div class="selected-date-info" *ngIf="createFormData.fecha_cita">
+          <strong>Seleccionaste:</strong> {{ formatDateDisplay(createFormData.fecha_cita) }}
+        </div>
+        <div class="slots-wrapper" *ngIf="createFormData.fecha_cita"
+             [class.disabled]="!hasAvailableSlotsForSelectedDate">
+          <div class="slots-legend">
+            <span class="leg-dot free"></span> Libre
+            <span class="leg-dot selected-dot"></span> Seleccionado
+            <span class="leg-dot booked-dot"></span> Ocupado
+          </div>
+          <div class="slots-group">
+            <span class="slots-period">Mañana</span>
+            <div class="time-slots">
+              <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(0, 16)"
+                [class.selected]="createFormData.hora_cita === normalizeTime(slot)"
+                [class.booked]="isSlotUnavailable(slot)"
+                [disabled]="isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
+                {{ formatTime(slot) }}
+              </button>
+            </div>
+          </div>
+          <div class="slots-group">
+            <span class="slots-period">Tarde</span>
+            <div class="time-slots">
+              <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(16)"
+                [class.selected]="createFormData.hora_cita === normalizeTime(slot)"
+                [class.booked]="isSlotUnavailable(slot)"
+                [disabled]="isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
+                {{ formatTime(slot) }}
+              </button>
+            </div>
+          </div>
+          <small class="helper-text warning" *ngIf="!hasAvailableSlotsForSelectedDate">
+            Este día ya no tiene espacios disponibles.
+          </small>
+        </div>
+        <small class="helper-text" *ngIf="!createFormData.fecha_cita">
+          Selecciona un día disponible para ver las horas libres.
+        </small>
+      </div>
+
+      <!-- Paso 3: Confirmar + motivo -->
+      <div *ngIf="createStep === 3" class="step-body">
+        <div class="step-title">Confirmar cita</div>
+        <div class="confirm-summary">
+          <div class="confirm-row">
+            <span>Alumno</span>
+            <b>No. {{ createFormData.numero_control }}</b>
+          </div>
+          <div class="confirm-row">
+            <span>Fecha</span>
+            <b>{{ formatDateDisplay(createFormData.fecha_cita ?? '') }}</b>
+          </div>
+          <div class="confirm-row">
+            <span>Hora</span>
+            <b>{{ formatTime(createFormData.hora_cita ?? '') }}</b>
+          </div>
+        </div>
+        <div class="form-group">
+          <label>Motivo (opcional)</label>
+          <textarea name="motivo" [(ngModel)]="createFormData.motivo" rows="3"
+            placeholder="Describe el motivo de la consulta…"></textarea>
+        </div>
+      </div>
+
+      <div class="modal-3step-foot">
+        <button type="button" class="btn-secondary"
+          (click)="createStep > 1 ? stepBack() : toggleCreateForm()">
+          {{ createStep > 1 ? 'Atrás' : 'Cancelar' }}
+        </button>
+        <button type="button" class="btn-primary" *ngIf="createStep < 3" (click)="stepNext()">
+          Siguiente
+        </button>
+        <button type="submit" class="btn-primary" *ngIf="createStep === 3" [disabled]="isSubmitting">
+          {{ isSubmitting ? 'Agendando…' : 'Agendar cita' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- ===== MODAL: Registrar consulta ===== -->
 <div class="modal-overlay" *ngIf="showConsultaForm" (click)="closeConsultaForm()">
   <div class="modal modal-consulta" (click)="$event.stopPropagation()">
     <h3>Registrar consulta</h3>
@@ -275,13 +453,13 @@
     <div class="modal-actions">
       <button class="btn-secondary" (click)="closeConsultaForm()">Cancelar</button>
       <button class="btn-primary" (click)="submitConsulta()" [disabled]="isSubmittingConsulta">
-        {{ isSubmittingConsulta ? 'Guardando...' : 'Guardar y marcar atendida' }}
+        {{ isSubmittingConsulta ? 'Guardando…' : 'Guardar y marcar atendida' }}
       </button>
     </div>
   </div>
 </div>
 
-<!-- Modal: Perfil Médico Alumno -->
+<!-- ===== MODAL: Perfil médico del alumno ===== -->
 <div class="modal-overlay" *ngIf="showPerfilAlumnoModal" (click)="closePerfilAlumno()">
   <div class="modal-perfil-alumno" (click)="$event.stopPropagation()">
     <div class="modal-perfil-header">
@@ -295,8 +473,7 @@
       <div class="perfil-alumno-top">
         <div class="perfil-alumno-avatar">
           <img *ngIf="perfilAlumnoData.foto_perfil" [src]="perfilAlumnoData.foto_perfil" alt="foto" />
-          <span *ngIf="!perfilAlumnoData.foto_perfil">{{ perfilAlumnoData.nombre[0] }}{{ perfilAlumnoData.apellido[0]
-            }}</span>
+          <span *ngIf="!perfilAlumnoData.foto_perfil">{{ perfilAlumnoData.nombre[0] }}{{ perfilAlumnoData.apellido[0] }}</span>
         </div>
         <div class="perfil-alumno-info">
           <h4>{{ perfilAlumnoData.nombre }} {{ perfilAlumnoData.apellido }}</h4>
@@ -339,8 +516,7 @@
           <div *ngIf="historialAlumnoExpandido === item.id" class="historial-mini-detalle">
             <p *ngIf="item.consulta"><strong>Diagnóstico:</strong> {{ item.consulta.diagnostico }}</p>
             <p *ngIf="item.consulta"><strong>Tratamiento:</strong> {{ item.consulta.tratamiento }}</p>
-            <p *ngIf="item.receta"><strong>Receta:</strong> {{ item.receta.medicamento }} — {{ item.receta.dosis }}
-            </p>
+            <p *ngIf="item.receta"><strong>Receta:</strong> {{ item.receta.medicamento }} — {{ item.receta.dosis }}</p>
           </div>
         </div>
       </div>
@@ -348,7 +524,7 @@
   </div>
 </div>
 
-<!-- Modal: Reprogramar cita -->
+<!-- ===== MODAL: Reprogramar cita ===== -->
 <div class="modal-overlay" *ngIf="showReprogramarModal" (click)="closeReprogramar()">
   <div class="modal" (click)="$event.stopPropagation()">
     <h3>Reprogramar cita</h3>
@@ -372,7 +548,7 @@
     <div class="modal-actions">
       <button class="btn-secondary" (click)="closeReprogramar()">Cancelar</button>
       <button class="btn-primary" (click)="submitReprogramar()" [disabled]="isSubmittingReprogramar">
-        {{ isSubmittingReprogramar ? 'Reprogramando...' : 'Confirmar reprogramación' }}
+        {{ isSubmittingReprogramar ? 'Reprogramando…' : 'Confirmar reprogramación' }}
       </button>
     </div>
   </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
@@ -81,6 +81,17 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   filtroFechaDesde = '';
   filtroFechaHasta = '';
 
+  // Paginación client-side del historial
+  historialPagina = 1;
+  readonly historialPorPagina = 10;
+
+  // Drawer de detalle
+  drawerCita: Cita | null = null;
+  drawerCitaAbierto = false;
+
+  // Modal nueva cita — pasos
+  createStep: 1 | 2 | 3 = 1;
+
   // Modal reprogramar
   showReprogramarModal = false;
   reprogramarCitaId: number | null = null;
@@ -117,6 +128,37 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   get filteredPendingCitas(): Cita[] { return this.filterCitas(this.pendingCitas); }
   get filteredHandledCitas(): Cita[] { return this.filterCitas(this.handledCitas); }
 
+  get pagedHandledCitas(): Cita[] {
+    const start = (this.historialPagina - 1) * this.historialPorPagina;
+    return this.filteredHandledCitas.slice(start, start + this.historialPorPagina);
+  }
+
+  get totalPaginasHistorial(): number {
+    return Math.max(1, Math.ceil(this.filteredHandledCitas.length / this.historialPorPagina));
+  }
+
+  cambiarPaginaHistorial(p: number): void {
+    if (p < 1 || p > this.totalPaginasHistorial) return;
+    this.historialPagina = p;
+  }
+
+  get citasHoy(): number {
+    return this.citas.filter(c => c.fecha_cita === this.today).length;
+  }
+
+  get proximaCitaObj(): Cita | null {
+    return this.pendingCitas.find(c => c.fecha_cita >= this.today) ?? null;
+  }
+
+  get canceladasMes(): number {
+    const ahora = new Date();
+    return this.citas.filter(c => {
+      if (c.estatus !== 'cancelada') return false;
+      const [y, m] = c.fecha_cita.split('-').map(Number);
+      return y === ahora.getFullYear() && (m ?? 0) === ahora.getMonth() + 1;
+    }).length;
+  }
+
   private filterCitas(citas: Cita[]): Cita[] {
     let result = citas;
     const q = this.searchCitas.trim().toLowerCase();
@@ -143,6 +185,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     this.filtroFechaDesde = '';
     this.filtroFechaHasta = '';
     this.searchCitas = '';
+    this.historialPagina = 1;
   }
 
   get calendarLabel(): string {
@@ -164,6 +207,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
 
   toggleCreateForm(): void {
     this.showCreateForm = !this.showCreateForm;
+    this.createStep = 1;
     this.submitMessage = null;
     if (this.showCreateForm) {
       this.loadAvailability();
@@ -191,8 +235,9 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   }
 
   onCreateCita(form: NgForm): void {
-    if (form.invalid || !this.createFormData.numero_control?.trim()) {
-      this.submitMessage = 'Ingresa el número de control del alumno.';
+    const noCtrl = this.createFormData.numero_control?.trim();
+    if (!noCtrl || !this.createFormData.fecha_cita || !this.createFormData.hora_cita) {
+      this.submitMessage = 'Completa todos los campos requeridos.';
       return;
     }
 
@@ -206,7 +251,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
       fecha_cita: this.createFormData.fecha_cita!,
       hora_cita: normalizedTime,
       motivo: this.createFormData.motivo || undefined,
-      numero_control: this.createFormData.numero_control.trim()
+      numero_control: (this.createFormData.numero_control ?? '').trim()
     };
 
     this.isSubmitting = true;
@@ -229,7 +274,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
       )
       .subscribe(response => {
         if (response?.cita) {
-          this.submitMessage = 'Cita agendada correctamente.';
+          this.createStep = 1;
           this.loadCitas();
           this.loadAvailability();
           this.resetForm();
@@ -371,6 +416,72 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
           this.closeReprogramar();
         }
       });
+  }
+
+  // === Drawer de detalle ===
+
+  openDrawer(cita: Cita): void {
+    this.drawerCita = cita;
+    this.drawerCitaAbierto = true;
+  }
+
+  closeDrawer(): void {
+    this.drawerCita = null;
+    this.drawerCitaAbierto = false;
+  }
+
+  drawerAtender(cita: Cita): void {
+    this.closeDrawer();
+    this.onMarkAsAttended(cita);
+  }
+
+  drawerCancelar(cita: Cita): void {
+    this.closeDrawer();
+    this.onCancelCita(cita);
+  }
+
+  drawerNoAsistio(cita: Cita): void {
+    this.closeDrawer();
+    this.onMarkAsNoShow(cita);
+  }
+
+  drawerReprogramar(cita: Cita): void {
+    this.closeDrawer();
+    this.openReprogramar(cita);
+  }
+
+  stepNext(): void {
+    if (this.createStep === 1) {
+      if (!this.createFormData.numero_control?.trim()) {
+        this.submitMessage = 'Ingresa el número de control del alumno.';
+        return;
+      }
+      this.submitMessage = null;
+      this.createStep = 2;
+    } else if (this.createStep === 2) {
+      if (!this.createFormData.fecha_cita) {
+        this.submitMessage = 'Selecciona una fecha.';
+        return;
+      }
+      if (!this.createFormData.hora_cita) {
+        this.submitMessage = 'Selecciona una hora.';
+        return;
+      }
+      this.submitMessage = null;
+      this.createStep = 3;
+    }
+  }
+
+  stepBack(): void {
+    if (this.createStep > 1) this.createStep = (this.createStep - 1) as 1 | 2 | 3;
+    this.submitMessage = null;
+  }
+
+  formatFechaCorta(fecha: string): string {
+    if (!fecha) return '—';
+    const [y, m, d] = fecha.split('-').map(Number);
+    return new Intl.DateTimeFormat('es-MX', { day: 'numeric', month: 'short', year: 'numeric' })
+      .format(new Date(y, (m ?? 1) - 1, d ?? 1)).toUpperCase();
   }
 
   // === Vista semanal ===

--- a/frontend/src/app/components/doctor/components-doctor/doctor-estadisticas/doctor-estadisticas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-estadisticas/doctor-estadisticas.component.html
@@ -52,7 +52,7 @@
   </div>
 
   <div *ngIf="!estadisticas && !isLoadingEstadisticas && !estadisticasError" class="empty-state">
-    <p>📊 Presiona "Actualizar" para cargar las estadísticas.</p>
-    <button class="btn-primary" (click)="loadEstadisticas()">Cargar estadísticas</button>
+    <p>No se encontraron estadísticas disponibles.</p>
+    <button class="btn-primary" (click)="loadEstadisticas()">Reintentar</button>
   </div>
 </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-estadisticas/doctor-estadisticas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-estadisticas/doctor-estadisticas.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewChecked, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject, of } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
@@ -15,7 +15,7 @@ Chart.register(...registerables);
   styleUrls: ['./doctor-estadisticas.component.css']
 })
 
-export class DoctorEstadisticasComponent implements OnInit, AfterViewChecked, OnDestroy {
+export class DoctorEstadisticasComponent implements OnInit, OnDestroy {
   @ViewChild('barCanvas') barCanvas!: ElementRef<HTMLCanvasElement>;
   @ViewChild('doughnutCanvas') doughnutCanvas!: ElementRef<HTMLCanvasElement>;
 
@@ -32,13 +32,6 @@ export class DoctorEstadisticasComponent implements OnInit, AfterViewChecked, On
 
   ngOnInit(): void {
     this.loadEstadisticas();
-  }
-
-  ngAfterViewChecked(): void {
-    if (this.estadisticas && !this.chartsRendered && this.barCanvas && this.doughnutCanvas) {
-      this.renderCharts();
-      this.chartsRendered = true;
-    }
   }
 
   ngOnDestroy(): void {
@@ -62,7 +55,17 @@ export class DoctorEstadisticasComponent implements OnInit, AfterViewChecked, On
         }),
         finalize(() => { this.isLoadingEstadisticas = false; })
       )
-      .subscribe(data => { this.estadisticas = data; });
+      .subscribe(data => {
+        this.estadisticas = data;
+        if (data && !this.chartsRendered) {
+          setTimeout(() => {
+            if (this.barCanvas && this.doughnutCanvas) {
+              this.renderCharts();
+              this.chartsRendered = true;
+            }
+          }, 0);
+        }
+      });
   }
 
   private renderCharts(): void {

--- a/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.css
@@ -1,519 +1,308 @@
-/* ===== DOCTOR IA PRIORIDAD — Con variables globales y modo oscuro mejorado ===== */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
-
 .ia-prioridad-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: var(--yol-s-6);
 }
 
-/* ===== ENCABEZADO ===== */
+/* ── Encabezado ─────────────────────────────────── */
 .section-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
-  padding-bottom: 1rem;
-  border-bottom: 2px solid var(--border-light);
-  margin-bottom: 0.5rem;
-  position: relative;
+  gap: var(--yol-s-4);
+  padding-bottom: var(--yol-s-4);
+  border-bottom: 1px solid var(--yol-border);
 }
 
 .section-header h2 {
-  font-size: 1.7rem;
+  font-size: var(--yol-fs-h1);
   font-weight: 700;
-  color: var(--text-primary);
+  color: var(--yol-text);
   margin: 0;
 }
 
-.section-header h2::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 40px;
-  height: 3px;
-  background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
-  border-radius: 2px;
-}
-
 .btn-primary {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  color: white;
+  background: #2563eb;
+  color: #fff;
   border: none;
-  padding: 0.6rem 1.4rem;
-  border-radius: 22px;
-  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: var(--yol-r-pill);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
   cursor: pointer;
-  transition: all 0.22s;
-  font-size: 0.85rem;
-  box-shadow: var(--shadow-sm);
+  transition: background var(--yol-duration-normal);
 }
 
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-}
+.btn-primary:hover { background: #1d4ed8; }
+.btn-primary:disabled { opacity: .55; cursor: default; }
 
-/* ===== DISCLAIMER IA ===== */
+/* ── Disclaimer IA ──────────────────────────────── */
 .ia-disclaimer {
-  background: var(--accent-soft);
-  border-left: 4px solid var(--accent-mid);
-  padding: 0.9rem 1.2rem;
-  border-radius: 18px;
-  font-size: 0.86rem;
-  color: var(--text-secondary);
-  border: 1px solid var(--border-light);
-  border-left: 4px solid var(--accent-mid);
+  background: #eff6ff;
+  border-left: 4px solid #2563eb;
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  font-size: var(--yol-fs-sm);
+  color: #1e40af;
   font-weight: 500;
 }
 
-/* ===== RESUMEN DE PRIORIDADES (diseño base claro) ===== */
+/* ── KPI badges ─────────────────────────────────── */
 .prioridad-resumen {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.2rem;
-  justify-content: center;
+  gap: var(--yol-s-4);
 }
 
 .prioridad-badge {
   flex: 1;
-  min-width: 130px;
-  border-radius: 24px;
-  padding: 1.4rem 1rem;
+  min-width: 120px;
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-5) var(--yol-s-4);
   text-align: center;
-  border: 1.5px solid transparent;
-  transition: transform 0.22s, box-shadow 0.22s;
-  position: relative;
-  overflow: hidden;
-  background: var(--bg-card) padding-box, linear-gradient(135deg, var(--border-light), var(--gradient-start)) border-box;
-  box-shadow: var(--shadow-sm);
+  border: 1px solid transparent;
+  transition: transform var(--yol-duration-normal);
 }
 
-.prioridad-badge::after {
-  content: '';
-  position: absolute;
-  bottom: -24px;
-  right: -24px;
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  opacity: 0.08;
-  pointer-events: none;
-}
+.prioridad-badge:hover { transform: translateY(-3px); }
 
-/* Colores específicos para cada prioridad (modo claro) */
-.prioridad-badge.alta {
-  background: var(--yol-cancel-surface);
-  border: 1.5px solid var(--yol-cancel-text);
-}
-
-.prioridad-badge.alta::after {
-  background: var(--yol-danger);
-}
-
-.prioridad-badge.media {
-  background: var(--yol-warn-surface);
-  border: 1.5px solid var(--yol-warn);
-}
-
-.prioridad-badge.media::after {
-  background: var(--yol-warn);
-}
-
-.prioridad-badge.baja {
-  background: var(--yol-ok-surface);
-  border: 1.5px solid var(--yol-accent);
-}
-
-.prioridad-badge.baja::after {
-  background: var(--yol-primary);
-}
-
-.prioridad-badge.total {
-  background: var(--yol-primary-50);
-  border: 1.5px solid var(--yol-primary-600);
-}
-
-.prioridad-badge.total::after {
-  background: var(--yol-primary-600);
-}
-
-.prioridad-badge:hover {
-  transform: translateY(-5px);
-}
+.prioridad-badge.alta  { background: var(--yol-cancel-surface); border-color: #fecaca; }
+.prioridad-badge.media { background: var(--yol-warn-surface);   border-color: #fde68a; }
+.prioridad-badge.baja  { background: var(--yol-ok-surface);     border-color: #bbf7d0; }
+.prioridad-badge.total { background: #eff6ff;                   border-color: #bfdbfe; }
 
 .badge-num {
   display: block;
-  font-size: 2.6rem;
+  font-size: 2.4rem;
   font-weight: 800;
   line-height: 1;
 }
 
-.prioridad-badge.alta .badge-num {
-  color: var(--yol-danger);
-}
-
-.prioridad-badge.media .badge-num {
-  color: var(--yol-warn);
-}
-
-.prioridad-badge.baja .badge-num {
-  color: var(--yol-primary);
-}
-
-.prioridad-badge.total .badge-num {
-  color: var(--yol-primary-600);
-}
+.prioridad-badge.alta  .badge-num { color: var(--yol-danger); }
+.prioridad-badge.media .badge-num { color: var(--yol-warn); }
+.prioridad-badge.baja  .badge-num { color: var(--yol-primary); }
+.prioridad-badge.total .badge-num { color: #2563eb; }
 
 .badge-label {
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  font-weight: 700;
-  margin-top: 0.5rem;
   display: block;
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .6px;
+  margin-top: var(--yol-s-2);
 }
 
-.prioridad-badge.alta .badge-label {
+.prioridad-badge.alta  .badge-label { color: var(--yol-danger); }
+.prioridad-badge.media .badge-label { color: var(--yol-warn); }
+.prioridad-badge.baja  .badge-label { color: var(--yol-primary); }
+.prioridad-badge.total .badge-label { color: #2563eb; }
+
+/* ── Filtros ────────────────────────────────────── */
+.filtros-row {
+  display: flex;
+  gap: var(--yol-s-2);
+  flex-wrap: wrap;
+}
+
+.filtro-chip {
+  padding: 6px 16px;
+  border-radius: var(--yol-r-pill);
+  border: 1.5px solid var(--yol-border);
+  background: var(--yol-surface);
+  color: var(--yol-text-muted);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+  transition: border-color var(--yol-duration-normal), background var(--yol-duration-normal), color var(--yol-duration-normal);
+}
+
+.filtro-chip:hover:not(.activo) { border-color: var(--yol-text-muted); }
+
+.filtro-chip.activo              { background: #2563eb; color: #fff; border-color: transparent; }
+.filtro-alta.activo              { background: var(--yol-danger); }
+.filtro-media.activo             { background: var(--yol-warn); }
+.filtro-baja.activo              { background: var(--yol-primary); }
+
+/* ── Estados (loading / empty / error) ─────────── */
+.loading,
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--yol-s-3);
+  padding: var(--yol-s-8) var(--yol-s-6);
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-lg);
+  border: 1px dashed var(--yol-border);
+  color: var(--yol-text-muted);
+  font-size: var(--yol-fs-sm);
+  text-align: center;
+  flex-direction: column;
+  box-shadow: var(--yol-shadow-xs);
+}
+
+.alert-error {
+  background: var(--yol-cancel-surface);
+  border: 1px solid #fecaca;
+  border-left: 4px solid var(--yol-danger);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
   color: var(--yol-danger);
+  font-size: var(--yol-fs-sm);
 }
 
-.prioridad-badge.media .badge-label {
-  color: var(--yol-warn);
-}
-
-.prioridad-badge.baja .badge-label {
-  color: var(--yol-primary);
-}
-
-.prioridad-badge.total .badge-label {
-  color: var(--yol-primary-600);
-}
-
-/* ===== LISTA DE CITAS POR PRIORIDAD ===== */
+/* ── Cita card ──────────────────────────────────── */
 .citas-prioridad-lista {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--yol-s-3);
 }
 
 .cita-prioridad-card {
-  background: var(--bg-card) padding-box,
-    linear-gradient(135deg, var(--border-light), var(--gradient-start)) border-box;
-  border: 1.5px solid transparent;
-  border-radius: 22px;
-  padding: 1.3rem 1.3rem 1.3rem 1.6rem;
-  box-shadow: var(--shadow-sm);
-  transition: all 0.22s;
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-4) var(--yol-s-4) var(--yol-s-4) var(--yol-s-5);
+  box-shadow: var(--yol-shadow-xs);
   position: relative;
   overflow: hidden;
+  transition: box-shadow var(--yol-duration-normal);
 }
 
+.cita-prioridad-card:hover { box-shadow: var(--yol-shadow-sm); }
+
+/* borde izquierdo de color por prioridad */
 .cita-prioridad-card::before {
   content: '';
   position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 6px;
-  border-radius: 22px 0 0 22px;
+  left: 0; top: 0; bottom: 0;
+  width: 5px;
+  border-radius: var(--yol-r-lg) 0 0 var(--yol-r-lg);
 }
 
-.cita-prioridad-card.prioridad-alta::before {
-  background: var(--yol-cancel-text);
-}
+.cita-prioridad-card.prioridad-alta::before  { background: var(--yol-danger); }
+.cita-prioridad-card.prioridad-media::before { background: var(--yol-warn); }
+.cita-prioridad-card.prioridad-baja::before  { background: var(--yol-primary); }
 
-.cita-prioridad-card.prioridad-media::before {
-  background: var(--yol-warn);
-}
-
-.cita-prioridad-card.prioridad-baja::before {
-  background: var(--yol-primary);
-}
-
-.cita-prioridad-card:hover {
-  transform: translateX(5px);
-  box-shadow: var(--shadow-md);
-}
-
+/* Header clickable (expand toggle) */
 .cita-prioridad-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.prioridad-tag {
-  padding: 0.28rem 0.9rem;
-  border-radius: 20px;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-}
-
-.tag-alta {
-  background: var(--yol-cancel-surface);
-  color: var(--yol-danger);
-  border: 1px solid var(--yol-cancel-text);
-}
-
-.tag-media {
-  background: var(--yol-warn-surface);
-  color: var(--yol-warn);
-  border: 1px solid var(--yol-warn);
-}
-
-.tag-baja {
-  background: var(--yol-ok-surface);
-  color: var(--yol-primary);
-  border: 1px solid var(--yol-accent);
-}
-
-.prioridad-score {
-  font-size: 0.72rem;
-  background: var(--accent-soft);
-  padding: 0.25rem 0.7rem;
-  border-radius: 20px;
-  color: var(--text-secondary);
-  font-weight: 700;
-  border: 1px solid var(--border-light);
-}
-
-.cita-prioridad-body p {
-  margin: 0.45rem 0;
-  font-size: 0.88rem;
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.cita-prioridad-body strong {
-  color: var(--text-primary);
-  font-weight: 700;
-}
-
-.justificacion {
-  background: var(--accent-soft);
-  padding: 0.7rem 0.9rem;
-  border-radius: 14px;
-  font-style: italic;
-  margin-top: 0.75rem !important;
-  border-left: 3px solid var(--accent-mid);
-  border: 1px solid var(--border-light);
-  border-left: 3px solid var(--accent-mid);
-  color: var(--text-secondary);
-  font-size: 0.84rem;
-}
-
-/* ===== ESTADOS ===== */
-.empty-state,
-.loading {
-  text-align: center;
-  padding: 3rem;
-  background: var(--bg-side);
-  border-radius: 24px;
-  border: 1.5px dashed var(--border-light);
-  color: var(--text-muted);
-  font-size: 0.95rem;
-}
-
-.loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.7rem;
-}
-
-.loading::before {
-  content: '⏳';
-  font-size: 1.3rem;
-  animation: pulse-load 1.2s infinite;
-}
-
-@keyframes pulse-load {
-
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  50% {
-    opacity: 0.5;
-    transform: scale(0.9);
-  }
-}
-
-.alert-error {
-  background: var(--yol-cancel-surface);
-  border: 1px solid var(--yol-cancel-text);
-  border-left: 4px solid var(--yol-danger);
-  padding: 1rem 1.2rem;
-  border-radius: 14px;
-  color: var(--yol-danger);
-  font-size: 0.88rem;
-}
-
-/* ===== AJUSTES DE MODO OSCURO PARA BADGES DE PRIORIDAD ===== */
-body.dark-mode .prioridad-badge.alta {
-  background: var(--yol-cancel-surface);
-}
-
-body.dark-mode .prioridad-badge.media {
-  background: var(--yol-warn-surface);
-}
-
-body.dark-mode .prioridad-badge.baja {
-  background: var(--yol-ok-surface);
-}
-
-body.dark-mode .prioridad-badge.total {
-  background: var(--yol-primary-50);
-}
-
-/* Ajuste de los números y etiquetas para que resalten */
-body.dark-mode .prioridad-badge.alta .badge-num,
-body.dark-mode .prioridad-badge.alta .badge-label {
-  color: var(--yol-cancel-text);
-}
-
-body.dark-mode .prioridad-badge.media .badge-num,
-body.dark-mode .prioridad-badge.media .badge-label {
-  color: var(--yol-warn);
-}
-
-body.dark-mode .prioridad-badge.baja .badge-num,
-body.dark-mode .prioridad-badge.baja .badge-label {
-  color: var(--yol-ok-text);
-}
-
-body.dark-mode .prioridad-badge.total .badge-num,
-body.dark-mode .prioridad-badge.total .badge-label {
-  color: var(--yol-ia);
-}
-
-/* ===== FILTROS ===== */
-.filtros-row {
-  display: flex;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-}
-
-.filtro-chip {
-  padding: 0.4rem 1rem;
-  border-radius: 20px;
-  border: 1.5px solid var(--border-light);
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  font-size: 0.82rem;
-  font-weight: 600;
+  gap: var(--yol-s-2);
   cursor: pointer;
-  transition: all 0.2s;
-}
-
-.filtro-chip:hover {
-  border-color: var(--accent-mid);
-}
-
-.filtro-chip.activo {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  color: white;
-  border-color: transparent;
-}
-
-.filtro-alta.activo {
-  background: var(--yol-cancel-text);
-}
-
-.filtro-media.activo {
-  background: var(--yol-warn);
-}
-
-.filtro-baja.activo {
-  background: var(--yol-primary);
-}
-
-/* ===== EXPAND TOGGLE ===== */
-.cita-prioridad-header {
-  cursor: pointer;
+  margin-bottom: var(--yol-s-3);
 }
 
 .header-right {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: var(--yol-s-2);
+}
+
+.prioridad-tag {
+  padding: 3px 10px;
+  border-radius: var(--yol-r-pill);
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .4px;
+}
+
+.tag-alta  { background: var(--yol-cancel-surface); color: var(--yol-danger);  border: 1px solid #fecaca; }
+.tag-media { background: var(--yol-warn-surface);   color: var(--yol-warn);    border: 1px solid #fde68a; }
+.tag-baja  { background: var(--yol-ok-surface);     color: var(--yol-primary); border: 1px solid #bbf7d0; }
+
+.prioridad-score {
+  font-size: var(--yol-fs-label);
+  background: #eff6ff;
+  color: #2563eb;
+  padding: 3px 10px;
+  border-radius: var(--yol-r-pill);
+  font-weight: 700;
+  border: 1px solid #bfdbfe;
 }
 
 .expand-icon {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  transition: transform 0.2s;
+  font-size: 10px;
+  color: var(--yol-text-muted);
+  transition: transform var(--yol-duration-normal);
   display: inline-block;
 }
 
-.expand-icon.expanded {
-  transform: rotate(180deg);
-}
+.expand-icon.expanded { transform: rotate(180deg); }
 
-/* ===== DETALLES EXPANDIBLES ===== */
-.cita-detalles {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--border-light);
-  animation: slideDown 0.2s ease-out;
-}
-
-@keyframes slideDown {
-  from { opacity: 0; max-height: 0; }
-  to { opacity: 1; max-height: 500px; }
-}
-
-.detalle-justificacion {
-  background: var(--accent-soft);
-  padding: 0.8rem 1rem;
-  border-radius: 12px;
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  border-left: 3px solid var(--accent-mid);
-  margin-bottom: 0.6rem;
-}
-
-.detalle-justificacion p {
-  margin: 0.4rem 0 0;
-}
-
-.detalle-factores {
-  font-size: 0.84rem;
-  color: var(--text-secondary);
-}
-
-.detalle-factores ul {
-  margin: 0.3rem 0 0;
-  padding-left: 1.2rem;
-}
-
-.detalle-factores li {
-  margin-bottom: 0.25rem;
+/* Body de la cita */
+.cita-prioridad-body p {
+  margin: var(--yol-s-1) 0;
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
   line-height: 1.5;
 }
 
-/* ===== RESPONSIVE ===== */
+.cita-prioridad-body strong { color: var(--yol-text); font-weight: 600; }
+
+.justificacion {
+  background: #eff6ff;
+  padding: var(--yol-s-3) var(--yol-s-3);
+  border-radius: var(--yol-r-md);
+  font-style: italic;
+  margin-top: var(--yol-s-3) !important;
+  border-left: 3px solid #2563eb;
+  color: #1e40af;
+  font-size: var(--yol-fs-sm);
+}
+
+/* Detalles expandibles */
+.cita-detalles {
+  margin-top: var(--yol-s-3);
+  padding-top: var(--yol-s-3);
+  border-top: 1px solid var(--yol-border);
+  animation: slideDown .2s ease-out;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.detalle-justificacion {
+  background: #eff6ff;
+  padding: var(--yol-s-3);
+  border-radius: var(--yol-r-md);
+  font-size: var(--yol-fs-sm);
+  color: #1e40af;
+  border-left: 3px solid #2563eb;
+  margin-bottom: var(--yol-s-2);
+}
+
+.detalle-justificacion p { margin: var(--yol-s-1) 0 0; }
+
+.detalle-factores {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
+}
+
+.detalle-factores ul { margin: var(--yol-s-1) 0 0; padding-left: 18px; }
+.detalle-factores li { margin-bottom: var(--yol-s-1); line-height: 1.5; }
+
+/* ── Dark mode ──────────────────────────────────── */
+:host-context(.dark) .cita-prioridad-card { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .prioridad-badge.alta  { background: #2d1a1a; border-color: #7f1d1d; }
+:host-context(.dark) .prioridad-badge.media { background: #2d2310; border-color: #92400e; }
+:host-context(.dark) .prioridad-badge.baja  { background: #0f2d1a; border-color: #166534; }
+:host-context(.dark) .prioridad-badge.total { background: #1a1d2e; border-color: #1e3a8a; }
+:host-context(.dark) .ia-disclaimer         { background: #1a1d2e; color: #93c5fd; border-color: #2563eb; }
+:host-context(.dark) .justificacion,
+:host-context(.dark) .detalle-justificacion { background: #1a1d2e; color: #93c5fd; }
+:host-context(.dark) .prioridad-score       { background: #1a1d2e; color: #93c5fd; border-color: #1e3a8a; }
+:host-context(.dark) .loading,
+:host-context(.dark) .empty-state           { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .cita-detalles         { border-top-color: #2a4030; }
+
+/* ── Responsive ─────────────────────────────────── */
 @media (max-width: 768px) {
-  .prioridad-resumen {
-    gap: 0.75rem;
-  }
-
-  .prioridad-badge {
-    min-width: 110px;
-    padding: 1.1rem 0.6rem;
-  }
-
-  .cita-prioridad-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+  .prioridad-resumen { gap: var(--yol-s-3); }
+  .prioridad-badge   { min-width: 100px; padding: var(--yol-s-4) var(--yol-s-3); }
+  .cita-prioridad-header { flex-direction: column; align-items: flex-start; }
 }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.html
@@ -85,7 +85,7 @@
     </div>
   </div>
 
-  <div *ngIf="!prioridadResumen && !isLoadingPrioridad && !prioridadError" class="empty-state">
+  <div *ngIf="!prioridadResumen && !isLoadingPrioridad && !hasError" class="empty-state">
     <p>Presiona "Actualizar" para clasificar las citas pendientes.</p>
     <button class="btn-primary" (click)="loadPrioridad()">Clasificar ahora</button>
   </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.component.html
@@ -41,10 +41,10 @@
          *ngFor="let r of recetas"
          [class.sel]="recetaSel?.id === r.id"
          (click)="abrirVista(r)">
-      <div class="av">{{ iniciales(r.alumno?.nombre, r.alumno?.apellido) }}</div>
+      <div class="av">{{ iniciales(resolveAlumno(r)?.nombre, resolveAlumno(r)?.apellido) }}</div>
       <div class="who">
-        <b>{{ r.alumno?.nombre }} {{ r.alumno?.apellido }}</b>
-        <span>No. {{ r.alumno?.numero_control ?? '—' }}</span>
+        <b>{{ resolveAlumno(r)?.nombre }} {{ resolveAlumno(r)?.apellido }}</b>
+        <span>No. {{ resolveAlumno(r)?.numero_control ?? '—' }}</span>
       </div>
       <span class="badge-fecha">
         <span class="dot"></span>Emitida {{ formatFecha(r.fecha_emision) }}
@@ -98,11 +98,11 @@
 
     <div class="drawer-body">
       <div class="d-patient">
-        <div class="av">{{ iniciales(recetaSel.alumno?.nombre, recetaSel.alumno?.apellido) }}</div>
+        <div class="av">{{ iniciales(resolveAlumno(recetaSel)?.nombre, resolveAlumno(recetaSel)?.apellido) }}</div>
         <div class="d-patient-info">
-          <b>{{ recetaSel.alumno?.nombre }} {{ recetaSel.alumno?.apellido }}</b>
+          <b>{{ resolveAlumno(recetaSel)?.nombre }} {{ resolveAlumno(recetaSel)?.apellido }}</b>
           <span class="d-patient-sub">
-            Matrícula <b>{{ recetaSel.alumno?.numero_control ?? '—' }}</b>
+            Matrícula <b>{{ resolveAlumno(recetaSel)?.numero_control ?? '—' }}</b>
           </span>
         </div>
       </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.component.ts
@@ -143,6 +143,11 @@ export class DoctorRecetasComponent implements OnInit, OnDestroy {
     });
   }
 
+  // Devuelve alumno directo o anidado en cita como fallback
+  resolveAlumno(r: RecetaItem) {
+    return r.alumno ?? r.cita?.alumno ?? null;
+  }
+
   iniciales(nombre?: string, apellido?: string): string {
     return ((nombre?.[0] ?? '') + (apellido?.[0] ?? '')).toUpperCase() || '?';
   }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.service.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.service.ts
@@ -11,7 +11,7 @@ export interface RecetaItem {
   fecha_emision: string;
   medicamentos: string;
   indicaciones?: string | null;
-  cita?: { id: number; fecha_cita: string; hora_cita: string } | null;
+  cita?: { id: number; fecha_cita: string; hora_cita: string; alumno?: { id: number; nombre: string; apellido: string; numero_control?: string } | null } | null;
   alumno?: { id: number; nombre: string; apellido: string; numero_control?: string } | null;
 }
 
@@ -31,7 +31,7 @@ export interface RecetaPayload {
 
 @Injectable({ providedIn: 'root' })
 export class DoctorRecetasService {
-  private readonly base = `${API_BASE_URL}/doctor/recetas`;
+  private readonly base = `${API_BASE_URL}/recetas`;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/app/components/login/login/login.component.css
+++ b/frontend/src/app/components/login/login/login.component.css
@@ -16,7 +16,7 @@
 
 /* ===== PANEL IZQUIERDO (oscuro) ===== */
 .welcome-panel {
-  background: var(--yol-text);
+  background: #1A2E25;
   position: relative;
   display: flex;
   align-items: center;

--- a/frontend/src/app/components/shared/agendar-cita/agendar-cita.component.css
+++ b/frontend/src/app/components/shared/agendar-cita/agendar-cita.component.css
@@ -3,7 +3,7 @@
   position: fixed;
   top: 20px;
   right: 20px;
-  background: var(--primary);
+  background: var(--yol-primary);
   color: #fff;
   padding: 12px 20px;
   border-radius: 8px;
@@ -22,7 +22,7 @@
 }
 
 .ac-buscar-head h2 { margin: 0 0 6px; font-size: 20px; font-weight: 700; }
-.ac-buscar-sub { margin: 0 0 20px; font-size: 14px; color: var(--text-muted); }
+.ac-buscar-sub { margin: 0 0 20px; font-size: 14px; color: var(--yol-text-muted); }
 
 .ac-buscar-form {
   display: flex;
@@ -31,21 +31,21 @@
 
 .ac-input {
   flex: 1;
-  border: 1px solid var(--border);
+  border: 1px solid var(--yol-border);
   border-radius: 8px;
   padding: 10px 14px;
   font-size: 14px;
-  color: var(--text);
-  background: #fff;
+  color: var(--yol-text);
+  background: var(--yol-surface);
   outline: none;
   font-family: inherit;
 }
 
-.ac-input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(26, 92, 58, .1); }
+.ac-input:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px rgba(26, 92, 58, .1); }
 
 .ac-results {
   margin-top: 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--yol-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -56,19 +56,19 @@
   flex-direction: column;
   align-items: flex-start;
   padding: 12px 16px;
-  background: #fff;
+  background: var(--yol-surface);
   border: none;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--yol-border);
   cursor: pointer;
   text-align: left;
   font-family: inherit;
 }
 
 .ac-result-item:last-child { border-bottom: none; }
-.ac-result-item:hover { background: var(--soft); }
+.ac-result-item:hover { background: var(--yol-bg); }
 
-.ac-result-name { font-size: 14px; font-weight: 600; color: var(--text); }
-.ac-result-meta { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+.ac-result-name { font-size: 14px; font-weight: 600; color: var(--yol-text); }
+.ac-result-meta { font-size: 12px; color: var(--yol-text-muted); margin-top: 2px; }
 
 /* ── Layout principal ───────────────────────────────────── */
 .ac-layout {
@@ -84,29 +84,29 @@
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  background: var(--primary-50);
-  border: 1px solid var(--primary);
+  background: var(--yol-primary-50);
+  border: 1px solid var(--yol-primary);
   border-radius: 8px;
   font-size: 13.5px;
 }
 
-.ac-alumno-label { color: var(--text-muted); }
-.ac-alumno-nc { color: var(--primary); font-variant-numeric: tabular-nums; }
+.ac-alumno-label { color: var(--yol-text-muted); }
+.ac-alumno-nc { color: var(--yol-primary); font-variant-numeric: tabular-nums; }
 
 .ac-chip-change {
   margin-left: auto;
   font-size: 12px;
   font-weight: 600;
-  color: var(--primary);
+  color: var(--yol-primary);
   background: none;
-  border: 1px solid var(--primary);
+  border: 1px solid var(--yol-primary);
   border-radius: 6px;
   padding: 4px 10px;
   cursor: pointer;
   font-family: inherit;
 }
 
-.ac-chip-change:hover { background: var(--primary); color: #fff; }
+.ac-chip-change:hover { background: var(--yol-primary); color: #fff; }
 
 /* ── Columna calendario ─────────────────────────────────── */
 .ac-cal-col {
@@ -121,8 +121,8 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
-  background: var(--soft);
-  border: 1px solid var(--border);
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
   border-radius: 10px;
   padding: 10px 14px;
 }
@@ -133,19 +133,19 @@
   width: 32px;
   height: 32px;
   border-radius: 8px;
-  background: #fff;
-  border: 1px solid var(--border);
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   font-family: inherit;
 }
 
-.ac-nav-btn:hover { border-color: var(--primary); color: var(--primary); }
+.ac-nav-btn:hover { border-color: var(--yol-primary); color: var(--yol-primary); }
 
 .ac-dow {
   display: grid;
@@ -158,7 +158,7 @@
   text-align: center;
   font-size: 11px;
   font-weight: 700;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
   letter-spacing: .5px;
   text-transform: uppercase;
   padding: 6px 0;
@@ -175,8 +175,8 @@
 .ac-day {
   height: 56px;
   border-radius: 8px;
-  border: 1px solid var(--border);
-  background: #fff;
+  border: 1px solid var(--yol-border);
+  background: var(--yol-surface);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -195,29 +195,29 @@
 .ac-day-d { font-size: 9.5px; font-weight: 600; margin-top: 3px; letter-spacing: .2px; }
 
 /* Estado: buena disponibilidad */
-.ac-day.good { border-color: var(--primary); }
+.ac-day.good { border-color: var(--yol-primary); }
 .ac-day.good .ac-day-n,
-.ac-day.good .ac-day-d { color: var(--primary); }
+.ac-day.good .ac-day-d { color: var(--yol-primary); }
 
 /* Estado: poca disponibilidad */
-.ac-day.mid { border-color: var(--warn); }
+.ac-day.mid { border-color: var(--yol-warn); }
 .ac-day.mid .ac-day-n,
-.ac-day.mid .ac-day-d { color: var(--warn); }
+.ac-day.mid .ac-day-d { color: var(--yol-warn); }
 
 /* Estado: sin disponibilidad */
-.ac-day.none { background: var(--danger-50); border-color: #fecaca; }
+.ac-day.none { background: var(--yol-cancel-surface); border-color: #fecaca; }
 .ac-day.none .ac-day-n,
-.ac-day.none .ac-day-d { color: var(--danger); }
+.ac-day.none .ac-day-d { color: var(--yol-danger); }
 
 /* Estado: pasado */
-.ac-day.past { background: var(--soft); border-color: var(--border); }
+.ac-day.past { background: var(--yol-bg); border-color: var(--yol-border); }
 .ac-day.past .ac-day-n,
-.ac-day.past .ac-day-d { color: var(--text-subtle); }
+.ac-day.past .ac-day-d { color: var(--yol-text-muted); }
 
 /* Seleccionado */
-.ac-day.selected { background: var(--primary-50); border: 2px solid var(--primary); }
+.ac-day.selected { background: var(--yol-primary-50); border: 2px solid var(--yol-primary); }
 .ac-day.selected .ac-day-n,
-.ac-day.selected .ac-day-d { color: var(--primary); font-weight: 700; }
+.ac-day.selected .ac-day-d { color: var(--yol-primary); font-weight: 700; }
 
 /* Hoy */
 .ac-day.today::after {
@@ -227,13 +227,13 @@
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--primary);
+  background: var(--yol-primary);
 }
 
 .ac-grid-loading {
   padding: 24px;
   text-align: center;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
   font-size: 13.5px;
 }
 
@@ -244,11 +244,11 @@
   gap: 14px;
   margin-top: 18px;
   padding: 14px;
-  background: var(--soft);
-  border: 1px solid var(--border);
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
   border-radius: 10px;
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
 }
 
 .ac-legend-item { display: flex; align-items: center; gap: 7px; }
@@ -260,17 +260,17 @@
   flex-shrink: 0;
 }
 
-.ac-dot.good { background: var(--primary); }
-.ac-dot.mid  { background: var(--warn); }
-.ac-dot.none { background: var(--danger); }
-.ac-dot.past { background: var(--text-subtle); }
+.ac-dot.good { background: var(--yol-primary); }
+.ac-dot.mid  { background: var(--yol-warn); }
+.ac-dot.none { background: var(--yol-danger); }
+.ac-dot.past { background: var(--yol-text-muted); }
 
 /* ── Columna slots ──────────────────────────────────────── */
 .ac-slot-col { flex: 1; min-width: 0; }
 
 .ac-slot-head h2 { margin: 0 0 4px; font-size: 18px; font-weight: 600; }
-.ac-slot-fecha { color: var(--primary); font-size: 14px; font-weight: 600; margin-bottom: 6px; }
-.ac-slot-note  { font-size: 13px; color: var(--text-muted); margin: 0 0 18px; }
+.ac-slot-fecha { color: var(--yol-primary); font-size: 14px; font-weight: 600; margin-bottom: 6px; }
+.ac-slot-note  { font-size: 13px; color: var(--yol-text-muted); margin: 0 0 18px; }
 
 .ac-slot-placeholder {
   display: flex;
@@ -279,7 +279,7 @@
   justify-content: center;
   padding: 48px 24px;
   text-align: center;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
   font-size: 14px;
 }
 
@@ -289,7 +289,7 @@
 .ac-no-slots {
   padding: 24px;
   text-align: center;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
   font-size: 13.5px;
 }
 
@@ -300,10 +300,10 @@
 }
 
 .ac-slot {
-  border: 1px solid var(--border);
+  border: 1px solid var(--yol-border);
   border-radius: 8px;
   padding: 12px;
-  background: #fff;
+  background: var(--yol-surface);
   text-align: left;
   display: flex;
   flex-direction: column;
@@ -312,12 +312,12 @@
   font-family: inherit;
 }
 
-.ac-slot:hover { border-color: var(--primary); background: var(--primary-50); }
+.ac-slot:hover { border-color: var(--yol-primary); background: var(--yol-primary-50); }
 
 .ac-slot b    { font-size: 18px; font-weight: 600; letter-spacing: -.3px; font-variant-numeric: tabular-nums; }
-.ac-slot span { font-size: 12px; color: var(--text-muted); margin-top: 2px; font-variant-numeric: tabular-nums; }
+.ac-slot span { font-size: 12px; color: var(--yol-text-muted); margin-top: 2px; font-variant-numeric: tabular-nums; }
 
-.ac-slot.selected { background: var(--primary); border-color: var(--primary); }
+.ac-slot.selected { background: var(--yol-primary); border-color: var(--yol-primary); }
 .ac-slot.selected b,
 .ac-slot.selected span { color: #fff; }
 
@@ -327,11 +327,11 @@
   align-items: flex-start;
   gap: 8px;
   padding: 12px 14px;
-  background: var(--soft);
-  border: 1px solid var(--border);
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
   border-radius: 8px;
   font-size: 12.5px;
-  color: var(--text-muted);
+  color: var(--yol-text-muted);
   max-width: 460px;
 }
 
@@ -350,7 +350,7 @@
 .ac-modal {
   width: 440px;
   max-width: 100%;
-  background: #fff;
+  background: var(--yol-surface);
   border-radius: 14px;
   box-shadow: 0 30px 80px rgba(0, 0, 0, .25);
   padding: 24px;
@@ -364,26 +364,26 @@
 .ac-modal h3 { margin: 0 0 14px; font-size: 18px; font-weight: 700; }
 
 .ac-resume {
-  background: var(--primary-50);
-  border: 1px solid var(--primary);
+  background: var(--yol-primary-50);
+  border: 1px solid var(--yol-primary);
   border-radius: 8px;
   padding: 12px 14px;
   margin-bottom: 14px;
   display: flex;
   align-items: center;
   gap: 11px;
-  color: var(--primary);
+  color: var(--yol-primary);
   font-weight: 600;
   font-size: 14px;
 }
 
-.ac-resume-alumno { background: var(--soft); border-color: var(--border); color: var(--text); }
+.ac-resume-alumno { background: var(--yol-bg); border-color: var(--yol-border); color: var(--yol-text); }
 
 .ac-resume-icon {
   width: 30px;
   height: 30px;
   border-radius: 7px;
-  background: var(--primary);
+  background: var(--yol-primary);
   color: #fff;
   display: flex;
   align-items: center;
@@ -392,7 +392,7 @@
   flex-shrink: 0;
 }
 
-.ac-resume-alumno .ac-resume-icon { background: var(--border-strong); color: var(--text); }
+.ac-resume-alumno .ac-resume-icon { background: #cdd9d3; color: var(--yol-text); }
 
 .ac-resume small {
   display: block;
@@ -407,19 +407,19 @@
   font-size: 13px;
   font-weight: 600;
   margin-bottom: 6px;
-  color: var(--text);
+  color: var(--yol-text);
 }
 
-.ac-req { color: var(--danger); margin-left: 2px; }
+.ac-req { color: var(--yol-danger); margin-left: 2px; }
 
 .ac-textarea {
   width: 100%;
-  border: 1px solid var(--border);
+  border: 1px solid var(--yol-border);
   border-radius: 8px;
   padding: 10px 12px;
   font-size: 13.5px;
-  color: var(--text);
-  background: #fff;
+  color: var(--yol-text);
+  background: var(--yol-surface);
   outline: none;
   resize: vertical;
   min-height: 72px;
@@ -427,9 +427,9 @@
   font-family: inherit;
 }
 
-.ac-textarea:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(26, 92, 58, .12); }
+.ac-textarea:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px rgba(26, 92, 58, .12); }
 
-.ac-error { font-size: 12px; color: var(--danger); margin-top: 6px; }
+.ac-error { font-size: 12px; color: var(--yol-danger); margin-top: 6px; }
 
 .ac-modal-foot {
   display: flex;
@@ -444,7 +444,7 @@
   border-radius: 8px;
   font-size: 13.5px;
   font-weight: 600;
-  background: var(--primary);
+  background: var(--yol-primary);
   color: #fff;
   border: 1px solid transparent;
   cursor: pointer;
@@ -453,7 +453,7 @@
   min-width: 120px;
 }
 
-.ac-btn-primary:hover:not(:disabled) { background: var(--primary-600); }
+.ac-btn-primary:hover:not(:disabled) { background: var(--yol-primary-600); }
 .ac-btn-primary:disabled { opacity: .6; cursor: not-allowed; }
 
 .ac-btn-cancel {
@@ -461,15 +461,15 @@
   border-radius: 8px;
   font-size: 13.5px;
   font-weight: 600;
-  background: #fff;
-  color: var(--text-muted);
-  border: 1px solid var(--border-strong);
+  background: var(--yol-surface);
+  color: var(--yol-text-muted);
+  border: 1px solid #cdd9d3;
   cursor: pointer;
   font-family: inherit;
   transition: background .15s;
 }
 
-.ac-btn-cancel:hover { background: var(--soft); }
+.ac-btn-cancel:hover { background: var(--yol-bg); }
 
 /* ── Responsive ─────────────────────────────────────────── */
 @media (max-width: 900px) {
@@ -485,3 +485,23 @@
   .ac-day-n { font-size: 13px; }
   .ac-day-d { display: none; }
 }
+
+/* ── Dark mode ──────────────────────────────────── */
+:host-context(.dark) .ac-input,
+:host-context(.dark) .ac-textarea    { background: #1a2e25; border-color: #2a4030; color: #e8f5ee; }
+:host-context(.dark) .ac-result-item { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .ac-result-item:hover { background: #0f2d1a; }
+:host-context(.dark) .ac-results     { border-color: #2a4030; }
+:host-context(.dark) .ac-month-nav   { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .ac-nav-btn     { background: #1a2e25; border-color: #2a4030; color: #86efac; }
+:host-context(.dark) .ac-day         { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .ac-day.past    { background: #0f1a15; }
+:host-context(.dark) .ac-legend      { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .ac-slot        { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .ac-slot:hover  { background: #0f2d1a; }
+:host-context(.dark) .ac-help        { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .ac-modal       { background: #1a2e25; }
+:host-context(.dark) .ac-btn-cancel  { background: #1a2e25; border-color: #2a4030; color: var(--yol-text-muted); }
+:host-context(.dark) .ac-btn-cancel:hover { background: #0f1a15; }
+:host-context(.dark) .ac-alumno-chip { background: #0f2d1a; border-color: #166534; }
+:host-context(.dark) .ac-resume-alumno { background: #1a2e25; border-color: #2a4030; }

--- a/frontend/src/app/components/student/mis-citas/mis-citas.component.css
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.component.css
@@ -297,8 +297,6 @@
 
 .mc-btn-cancel:hover { background: var(--yol-cancel-surface); }
 
-.mc-actions-cell { text-align: right; }
-
 /* Empty */
 .mc-empty {
   padding: 64px var(--yol-s-7);
@@ -371,6 +369,33 @@
   justify-content: flex-end;
   margin-top: 20px;
 }
+
+/* Dark mode */
+:host-context(.dark) .mc-header,
+:host-context(.dark) .mc-cita-card,
+:host-context(.dark) .mc-modal { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .mc-title { color: #e8f5ee; }
+:host-context(.dark) .mc-sub,
+:host-context(.dark) .mc-cita-meta,
+:host-context(.dark) .mc-cita-doctor { color: #a8c4b4; }
+:host-context(.dark) .mc-crumb,
+:host-context(.dark) .mc-date-info span,
+:host-context(.dark) .mc-meta-sep,
+:host-context(.dark) .mc-diagnostico,
+:host-context(.dark) .mc-motivo-cancel { color: #7b9e8c; }
+:host-context(.dark) .mc-date-info b { color: #e8f5ee; }
+:host-context(.dark) .mc-tab-count { background: #0f1a15; }
+:host-context(.dark) .mc-empty {
+  background: #1a2e25;
+  border-color: #2a4030;
+}
+:host-context(.dark) .mc-empty h3 { color: #e8f5ee; }
+:host-context(.dark) .mc-empty p { color: #a8c4b4; }
+:host-context(.dark) .mc-cita-sep { border-top-color: #2a4030; }
+:host-context(.dark) .mc-modal h3 { color: #e8f5ee; }
+:host-context(.dark) .mc-modal p { color: #a8c4b4; }
+:host-context(.dark) .mc-btn-ghost { color: #a8c4b4; }
+:host-context(.dark) .mc-btn-ghost:hover { background: #0f1a15; }
 
 /* Responsive */
 @media (max-width: 768px) {

--- a/frontend/src/app/components/student/mis-citas/mis-citas.component.css
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.component.css
@@ -28,7 +28,8 @@
   padding: var(--yol-s-7) var(--yol-s-7) 0;
 }
 
-.mc-head-row { margin-bottom: 18px; }
+.mc-head-row { margin-bottom: 18px; display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
+.mc-head-actions { flex-shrink: 0; padding-top: 4px; }
 
 .mc-crumb {
   font-size: var(--yol-fs-cap);

--- a/frontend/src/app/components/student/mis-citas/mis-citas.component.css
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.component.css
@@ -111,46 +111,27 @@
 .mc-error { color: var(--yol-cancel-text); }
 .mc-error p { margin: 0 0 var(--yol-s-4); }
 
-/* Card / Table */
-.mc-card {
+/* Cards */
+.mc-citas-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-3);
+}
+
+.mc-cita-card {
   background: var(--yol-surface);
   border: 1px solid var(--yol-border);
   border-radius: var(--yol-r-lg);
-  overflow: hidden;
+  padding: var(--yol-s-5) var(--yol-s-6);
   box-shadow: var(--yol-shadow-xs);
 }
 
-.mc-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--yol-fs-sm);
+.mc-cita-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--yol-s-3);
 }
-
-.mc-table th {
-  text-align: left;
-  padding: 12px 22px;
-  font-size: var(--yol-fs-label);
-  font-weight: 600;
-  color: var(--yol-text-muted);
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  background: var(--yol-bg);
-  border-bottom: 1px solid var(--yol-border);
-}
-
-.mc-table td {
-  padding: 14px 22px;
-  border-bottom: 1px solid var(--yol-border);
-  vertical-align: middle;
-}
-
-.mc-table tr:last-child td { border-bottom: none; }
-.mc-table tr:hover td { background: var(--yol-bg); }
-
-.col-fecha { width: 26%; }
-.col-hora { width: 10%; }
-.col-estatus { width: 14%; }
-.col-acciones { width: 12%; text-align: right; }
 
 /* Date cell */
 .mc-date-cell {
@@ -204,31 +185,50 @@
   color: var(--yol-text-subtle);
 }
 
-.mc-hora {
+.mc-cita-hora {
+  font-size: 20px;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  color: var(--yol-text);
+  color: var(--yol-primary);
+  margin-bottom: var(--yol-s-2);
 }
 
-/* Motivo */
-.mc-motivo b {
-  display: block;
-  color: var(--yol-text);
-  font-weight: 500;
-  font-size: var(--yol-fs-sm);
-  margin-bottom: 2px;
-}
-
-.mc-motivo span {
-  display: block;
-  font-size: var(--yol-fs-cap);
+.mc-cita-hora.past {
   color: var(--yol-text-subtle);
 }
 
+.mc-cita-meta {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
+  margin-bottom: var(--yol-s-1);
+}
+
+.mc-meta-sep { color: var(--yol-text-subtle); }
+
+.mc-cita-doctor { color: var(--yol-text-subtle); }
+
 .mc-diagnostico {
-  margin-top: 3px;
-  color: var(--yol-text-muted) !important;
-  font-style: italic;
+  font-size: var(--yol-fs-cap);
+  color: var(--yol-text-subtle);
+  margin-top: var(--yol-s-1);
+}
+
+.mc-motivo-cancel {
+  font-size: var(--yol-fs-cap);
+  color: var(--yol-text-subtle);
+  margin-top: var(--yol-s-1);
+}
+
+.mc-cita-sep {
+  border: none;
+  border-top: 1px solid var(--yol-border);
+  margin: var(--yol-s-4) 0 var(--yol-s-3);
+}
+
+.mc-cita-footer {
+  display: flex;
+  justify-content: flex-end;
+  min-height: 28px;
 }
 
 /* Badges */
@@ -376,7 +376,7 @@
 @media (max-width: 768px) {
   .mc-header { padding: 20px var(--yol-s-4) 0; }
   .mc-content { padding: var(--yol-s-4); }
-  .mc-table th, .mc-table td { padding: 10px 12px; }
+  .mc-cita-card { padding: var(--yol-s-4); }
   .mc-date-info { display: none; }
   .mc-modal { margin: 0 var(--yol-s-4); }
 }

--- a/frontend/src/app/components/student/mis-citas/mis-citas.component.html
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.component.html
@@ -5,11 +5,21 @@
   <!-- Header -->
   <div class="mc-header">
     <div class="mc-head-row">
-      <div class="mc-crumb">Servicio médico · Citas</div>
-      <h1 class="mc-title">Mis citas</h1>
-      <p class="mc-sub">Consulta tus citas agendadas y tu historial de consultas pasadas.</p>
+      <div>
+        <div class="mc-crumb">Servicio médico · Citas</div>
+        <h1 class="mc-title">{{ showAgendar ? 'Nueva cita' : 'Mis citas' }}</h1>
+        <p class="mc-sub" *ngIf="!showAgendar">Consulta tus citas agendadas y tu historial de consultas pasadas.</p>
+      </div>
+      <div class="mc-head-actions">
+        <button *ngIf="!showAgendar" class="mc-btn mc-btn-primary" (click)="showAgendar = true">
+          <span>＋</span> Nueva cita
+        </button>
+        <button *ngIf="showAgendar" class="mc-btn mc-btn-ghost" (click)="showAgendar = false">
+          ← Volver
+        </button>
+      </div>
     </div>
-    <div class="mc-tabs">
+    <div class="mc-tabs" *ngIf="!showAgendar">
       <button *ngFor="let tab of tabs"
         [class.active]="activeTab === tab.id"
         (click)="activeTab = tab.id">
@@ -17,6 +27,11 @@
         <span class="mc-tab-count" [class.active]="activeTab === tab.id">{{ getCount(tab.id) }}</span>
       </button>
     </div>
+  </div>
+
+  <!-- Agendar cita -->
+  <div class="mc-content" *ngIf="showAgendar">
+    <app-agendar-cita modo="alumno" (citaAgendada)="onCitaAgendada()"></app-agendar-cita>
   </div>
 
   <!-- Content -->

--- a/frontend/src/app/components/student/mis-citas/mis-citas.component.html
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.component.html
@@ -56,59 +56,48 @@
         : 'No se encontraron citas en esta categoría.' }}</p>
     </div>
 
-    <!-- Tabla -->
-    <div class="mc-card" *ngIf="!isLoading && !error && citasActivas.length > 0">
-      <table class="mc-table">
-        <thead>
-          <tr>
-            <th class="col-fecha">Fecha</th>
-            <th class="col-hora">Hora</th>
-            <th>Motivo</th>
-            <th class="col-estatus">Estatus</th>
-            <th class="col-acciones"></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let cita of citasActivas">
-            <td>
-              <div class="mc-date-cell" [class.past]="activeTab !== 'proximas'">
-                <div class="mc-date-block">
-                  <b>{{ getDia(cita.fecha_cita) }}</b>
-                  <span>{{ getMes(cita.fecha_cita) }}</span>
-                </div>
-                <div class="mc-date-info">
-                  <b>{{ getDiaSemana(cita.fecha_cita) }}</b>
-                  <span>{{ getAnio(cita.fecha_cita) }}</span>
-                </div>
-              </div>
-            </td>
-            <td class="mc-hora">{{ formatTime(cita.hora_cita) }}</td>
-            <td>
-              <div class="mc-motivo">
-                <b>{{ cita.motivo || 'Sin motivo' }}</b>
-                <span>{{ doctorNombre(cita) }}</span>
-                <span class="mc-diagnostico"
-                  *ngIf="activeTab === 'pasadas' && cita.diagnostico">
-                  Diagnóstico: {{ cita.diagnostico }}
-                </span>
-              </div>
-            </td>
-            <td>
-              <span class="mc-badge" [ngClass]="estatusClass(cita.estatus)">
-                <span class="mc-badge-dot"></span>
-                {{ estatusLabel(cita.estatus) }}
-              </span>
-            </td>
-            <td class="mc-actions-cell">
-              <button *ngIf="activeTab === 'proximas'"
-                class="mc-btn-cancel"
-                (click)="abrirModalCancelar(cita)">
-                Cancelar
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <!-- Cards -->
+    <div class="mc-citas-list" *ngIf="!isLoading && !error && citasActivas.length > 0">
+      <div class="mc-cita-card" *ngFor="let cita of citasActivas">
+        <div class="mc-cita-top">
+          <div class="mc-date-cell" [class.past]="activeTab !== 'proximas'">
+            <div class="mc-date-block">
+              <b>{{ getDia(cita.fecha_cita) }}</b>
+              <span>{{ getMes(cita.fecha_cita) }}</span>
+            </div>
+            <div class="mc-date-info">
+              <b>{{ getDiaSemana(cita.fecha_cita) }}</b>
+              <span>{{ getAnio(cita.fecha_cita) }}</span>
+            </div>
+          </div>
+          <span class="mc-badge" [ngClass]="estatusClass(cita.estatus)">
+            <span class="mc-badge-dot"></span>
+            {{ estatusLabel(cita.estatus) }}
+          </span>
+        </div>
+        <div class="mc-cita-hora" [class.past]="activeTab !== 'proximas'">
+          {{ formatTime(cita.hora_cita) }}
+        </div>
+        <div class="mc-cita-meta">
+          {{ cita.motivo || 'Sin motivo' }}
+          <span class="mc-meta-sep"> · </span>
+          <span class="mc-cita-doctor">{{ doctorNombre(cita) }}</span>
+        </div>
+        <div class="mc-diagnostico" *ngIf="activeTab === 'pasadas' && cita.diagnostico">
+          Diagnóstico: {{ cita.diagnostico }}
+        </div>
+        <div class="mc-motivo-cancel" *ngIf="activeTab === 'canceladas' && cita.motivo_cancelacion">
+          {{ cita.motivo_cancelacion }}
+        </div>
+        <hr class="mc-cita-sep">
+        <div class="mc-cita-footer">
+          <button *ngIf="activeTab === 'proximas'"
+            class="mc-btn-cancel"
+            (click)="abrirModalCancelar(cita)">
+            Cancelar cita
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/components/student/mis-citas/mis-citas.component.ts
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.component.ts
@@ -3,13 +3,14 @@ import { CommonModule } from '@angular/common';
 import { Subject, of } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
 import { MisCitasService, CitaMisCitas } from './mis-citas.service';
+import { AgendarCitaComponent } from '../../shared/agendar-cita/agendar-cita.component';
 
 type TabId = 'proximas' | 'pasadas' | 'canceladas';
 
 @Component({
   selector: 'app-mis-citas',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, AgendarCitaComponent],
   templateUrl: './mis-citas.component.html',
   styleUrls: ['./mis-citas.component.css'],
 })
@@ -28,6 +29,8 @@ export class MisCitasComponent implements OnInit, OnDestroy {
   error: string | null = null;
   mensaje: string | null = null;
 
+  showAgendar = false;
+
   citaCancelando: CitaMisCitas | null = null;
   isCancelling = false;
 
@@ -38,6 +41,12 @@ export class MisCitasComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void { this.loadCitas(); }
   ngOnDestroy(): void { this.destroy$.next(); this.destroy$.complete(); }
+
+  onCitaAgendada(): void {
+    this.showAgendar = false;
+    this.loadCitas();
+    this.mostrarMensaje('Cita agendada correctamente.');
+  }
 
   loadCitas(): void {
     this.isLoading = true;

--- a/frontend/src/app/components/student/mis-citas/mis-citas.service.ts
+++ b/frontend/src/app/components/student/mis-citas/mis-citas.service.ts
@@ -5,6 +5,7 @@ import { Cita, CitaService } from '../../../services/cita.service';
 
 export interface CitaMisCitas extends Cita {
   diagnostico?: string | null;
+  motivo_cancelacion?: string | null;
 }
 
 export interface CitasFiltradas {

--- a/frontend/src/app/components/student/perfil/student-perfil.component.css
+++ b/frontend/src/app/components/student/perfil/student-perfil.component.css
@@ -336,7 +336,7 @@
 }
 .sp-btn:disabled { opacity: 0.55; cursor: default; }
 
-.sp-btn-primary { background: var(--yol-primary); color: #fff; }
+.sp-btn-primary { background: var(--yol-primary); color: var(--yol-surface); }
 .sp-btn-primary:hover:not(:disabled) { background: var(--yol-primary-600); }
 
 .sp-btn-secondary {
@@ -441,5 +441,4 @@
   .sp-grid3 { grid-template-columns: 1fr; gap: 14px; padding: 16px; }
   .sp-full { grid-column: 1; }
   .sp-card-head { padding: 14px 16px; }
-  .sp-actions-bar { flex-direction: row-reverse; }
 }

--- a/frontend/src/app/components/student/perfil/student-perfil.component.css
+++ b/frontend/src/app/components/student/perfil/student-perfil.component.css
@@ -12,23 +12,13 @@
 .sp-head {
   background: var(--yol-surface);
   border-bottom: 1px solid var(--yol-border);
-  padding: 28px 36px 0;
-}
-
-.sp-crumb {
-  font-size: var(--yol-fs-label);
-  color: var(--yol-text-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  font-weight: 500;
-  margin-bottom: 14px;
+  padding: 28px 36px;
 }
 
 .sp-pcard {
   display: flex;
   align-items: center;
   gap: 24px;
-  padding-bottom: 24px;
 }
 
 /* Avatar */
@@ -42,8 +32,8 @@
 }
 
 .sp-circle {
-  width: 92px;
-  height: 92px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
   background: var(--yol-primary-50);
   color: var(--yol-primary);
@@ -51,7 +41,7 @@
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 32px;
+  font-size: 24px;
   letter-spacing: -1px;
   border: 3px solid var(--yol-surface);
   box-shadow: 0 0 0 1px var(--yol-border);
@@ -74,7 +64,7 @@
   border: 1px solid var(--yol-primary);
   font-size: 11px;
   font-weight: 600;
-  padding: 5px 9px;
+  padding: 4px 8px;
   border-radius: var(--yol-r-pill);
   box-shadow: var(--yol-shadow-xs);
   cursor: pointer;
@@ -104,27 +94,8 @@
   font-size: var(--yol-fs-sm);
   color: var(--yol-text-muted);
   font-variant-numeric: tabular-nums;
-  margin-bottom: 10px;
   font-weight: 500;
 }
-.sp-ctrl b { color: var(--yol-text); font-weight: 600; }
-
-.sp-meta {
-  display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
-  font-size: var(--yol-fs-sm);
-  color: var(--yol-text-muted);
-}
-.sp-meta div { display: flex; flex-direction: column; gap: 2px; }
-.sp-meta span {
-  font-size: 10.5px;
-  font-weight: 600;
-  color: var(--yol-text-subtle);
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-}
-.sp-meta b { color: var(--yol-text); font-weight: 600; font-size: 13.5px; }
 
 /* Badge activo */
 .sp-badge-ok {
@@ -149,6 +120,9 @@
 .sp-content {
   padding: 24px 36px 60px;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 /* Skeleton */
@@ -160,7 +134,7 @@
 }
 .sk-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 18px 24px;
   margin-top: 18px;
 }
@@ -174,10 +148,36 @@
 .sk-full { grid-column: 1 / -1; height: 80px; }
 @keyframes skPulse {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  50%       { opacity: 0.5; }
 }
 
-/* ── Card ── */
+/* ── Editbar (fondo de card en modo edición) ── */
+.sp-editbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 22px;
+  background: var(--yol-bg);
+  border-top: 1px solid var(--yol-border);
+}
+.sp-editbar-btns { display: flex; gap: 10px; }
+.sp-saved {
+  font-size: var(--yol-fs-cap);
+  color: var(--yol-text-subtle);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sp-saved b { color: var(--yol-text-muted); font-weight: 600; }
+
+/* Hint bajo el título de card */
+.sp-hint {
+  font-size: 12px;
+  color: var(--yol-text-subtle);
+  margin-top: 2px;
+}
+
+/* ── Cards ── */
 .sp-card {
   background: var(--yol-surface);
   border: 1px solid var(--yol-border);
@@ -192,21 +192,18 @@
   align-items: center;
   padding: 16px 22px;
   border-bottom: 1px solid var(--yol-border);
+  gap: 12px;
 }
-.sp-card-head-left h2 {
+.sp-card-head > div { flex: 1; min-width: 0; }
+.sp-card-head h2 {
   margin: 0;
   font-size: 15.5px;
   font-weight: 600;
   letter-spacing: -0.1px;
   color: var(--yol-text);
 }
-.sp-hint {
-  font-size: var(--yol-fs-cap);
-  color: var(--yol-text-subtle);
-  margin: 2px 0 0;
-}
 
-/* Grid campos */
+/* Grid 2 columnas */
 .sp-grid2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -214,6 +211,14 @@
   padding: 22px;
 }
 .sp-full { grid-column: 1 / -1; }
+
+/* Grid 3 columnas */
+.sp-grid3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 18px 24px;
+  padding: 22px;
+}
 
 .sp-field {
   display: flex;
@@ -273,30 +278,46 @@
 }
 .sp-field textarea { min-height: 84px; resize: vertical; line-height: 1.55; }
 
+/* Input con unidad */
+.sp-input-unit {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r);
+  overflow: hidden;
+  background: var(--yol-surface);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.sp-input-unit:focus-within {
+  border-color: var(--yol-primary);
+  box-shadow: 0 0 0 3px rgba(27, 107, 69, 0.1);
+}
+.sp-input-unit input {
+  flex: 1;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 10px 12px;
+}
+.sp-input-unit input:focus { border: none; box-shadow: none; }
+.sp-unit {
+  padding: 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--yol-text-subtle);
+  background: var(--yol-bg);
+  border-left: 1px solid var(--yol-border);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
 .sp-below {
   font-size: 11.5px;
   color: var(--yol-text-subtle);
   margin-top: 2px;
 }
-
-/* Barra de acciones */
-.sp-editbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 14px 22px;
-  background: var(--yol-bg);
-  border-top: 1px solid var(--yol-border);
-}
-.sp-saved {
-  font-size: var(--yol-fs-cap);
-  color: var(--yol-text-subtle);
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-.sp-saved b { color: var(--yol-text-muted); font-weight: 600; }
-.sp-editbar-btns { display: flex; gap: 10px; }
 
 /* Botones */
 .sp-btn {
@@ -382,11 +403,8 @@
 :host-context(.dark) .sp-wrap { background: #0f1a15; }
 :host-context(.dark) .sp-head,
 :host-context(.dark) .sp-card { background: #1a2e25; border-color: #2a4030; }
-:host-context(.dark) .sp-crumb,
-:host-context(.dark) .sp-meta span { color: #7b9e8c; }
 :host-context(.dark) .sp-name { color: #e8f5ee; }
 :host-context(.dark) .sp-ctrl { color: #a8c4b4; }
-:host-context(.dark) .sp-meta b { color: #e8f5ee; }
 :host-context(.dark) .sp-ro {
   background: #0f1a15;
   border-color: #2a4030;
@@ -399,24 +417,29 @@
   border-color: #2a4030;
   color: #e8f5ee;
 }
-:host-context(.dark) .sp-editbar { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .sp-input-unit {
+  background: #0f1a15;
+  border-color: #2a4030;
+}
+:host-context(.dark) .sp-unit { background: #0f1a15; border-color: #2a4030; color: #7b9e8c; }
 :host-context(.dark) .sp-card-head { border-color: #2a4030; }
-:host-context(.dark) .sp-card-head-left h2 { color: #e8f5ee; }
+:host-context(.dark) .sp-card-head h2 { color: #e8f5ee; }
 :host-context(.dark) .sp-skeleton { background: #1a2e25; border-color: #2a4030; }
 :host-context(.dark) .sk-line { background: #0f1a15; }
 :host-context(.dark) .sp-btn-gray { background: #1a2e25; color: #a8c4b4; border-color: #2a4030; }
 :host-context(.dark) .sp-btn-gray:hover:not(:disabled) { background: #0f1a15; }
 :host-context(.dark) .sp-change-btn { background: #1a2e25; }
+:host-context(.dark) .sp-editbar { background: #0f1a15; border-color: #2a4030; }
 
 /* Responsive */
 @media (max-width: 768px) {
-  .sp-head { padding: 20px 20px 0; }
-  .sp-content { padding: 16px 20px 40px; }
-  .sp-pcard { flex-direction: column; align-items: flex-start; gap: 16px; }
+  .sp-head { padding: 20px 20px; }
+  .sp-content { padding: 16px 20px 40px; gap: 12px; }
+  .sp-pcard { flex-direction: column; align-items: flex-start; gap: 14px; }
   .sp-name { font-size: 20px; }
-  .sp-meta { gap: 14px; }
-  .sp-grid2 { grid-template-columns: 1fr; gap: 14px; padding: 16px; }
+  .sp-grid2,
+  .sp-grid3 { grid-template-columns: 1fr; gap: 14px; padding: 16px; }
   .sp-full { grid-column: 1; }
-  .sp-card-head { flex-direction: column; align-items: flex-start; gap: 12px; }
-  .sp-editbar { flex-direction: column; align-items: flex-end; gap: 12px; }
+  .sp-card-head { padding: 14px 16px; }
+  .sp-actions-bar { flex-direction: row-reverse; }
 }

--- a/frontend/src/app/components/student/perfil/student-perfil.component.html
+++ b/frontend/src/app/components/student/perfil/student-perfil.component.html
@@ -2,7 +2,6 @@
 
   <!-- Encabezado de perfil -->
   <div class="sp-head">
-    <div class="sp-crumb">Mi perfil</div>
     <div class="sp-pcard">
 
       <!-- Avatar -->
@@ -25,23 +24,12 @@
           {{ perfil?.nombre }} {{ perfil?.apellido }}
           <span class="sp-badge-ok"><span class="sp-pulse"></span>Activo</span>
         </h1>
-        <div class="sp-ctrl">No. de control · <b>{{ perfil?.numero_control }}</b></div>
-        <div class="sp-meta">
-          <div *ngIf="perfil?.carrera">
-            <span>Carrera</span><b>{{ perfil?.carrera }}</b>
-          </div>
-          <div *ngIf="perfil?.semestre">
-            <span>Semestre</span><b>{{ perfil?.semestre }}°</b>
-          </div>
-          <div>
-            <span>Correo</span><b>{{ perfil?.email }}</b>
-          </div>
-          <div *ngIf="perfil?.updated_at">
-            <span>Última actualización</span>
-            <b>{{ perfil?.updated_at | date:'dd MMM yyyy' }}</b>
-          </div>
+        <div class="sp-ctrl">
+          {{ perfil?.numero_control }}
+          <ng-container *ngIf="perfil?.carrera"> · {{ perfil?.carrera }}</ng-container>
         </div>
       </div>
+
     </div>
   </div>
 
@@ -55,138 +43,124 @@
         <div class="sk-line"></div>
         <div class="sk-line"></div>
         <div class="sk-line"></div>
-        <div class="sk-line"></div>
         <div class="sk-line sk-full"></div>
         <div class="sk-line sk-full"></div>
       </div>
     </div>
 
-    <!-- Card info médica -->
-    <div *ngIf="!cargando && perfil" class="sp-card">
+    <ng-container *ngIf="!cargando && perfil">
 
-      <!-- Encabezado card -->
-      <div class="sp-card-head">
-        <div class="sp-card-head-left">
-          <h2>{{ editando ? 'Editar información médica' : 'Información médica' }}</h2>
-          <p class="sp-hint">
-            {{ editando
-              ? 'Los cambios serán visibles para el personal médico autorizado.'
-              : 'Tus datos los puede consultar el doctor durante la consulta. Mantenlos actualizados.' }}
-          </p>
-        </div>
-        <button *ngIf="!editando" class="sp-btn sp-btn-sm sp-btn-secondary" (click)="iniciarEdicion()">
-          ✎ Editar
-        </button>
-        <span *ngIf="editando" class="sp-badge-ok"><span class="sp-pulse"></span>Modo edición</span>
-      </div>
-
-      <!-- Modo lectura -->
-      <div *ngIf="!editando" class="sp-grid2">
-        <div class="sp-field">
-          <label>Tipo de sangre</label>
-          <div class="sp-ro" [class.sp-ro-empty]="!perfil.tipo_sangre">
-            {{ perfil.tipo_sangre || 'No especificado' }}
+      <!-- Card: Datos físicos -->
+      <div class="sp-card">
+        <div class="sp-card-head">
+          <div>
+            <h2>Datos físicos</h2>
+            <div *ngIf="editando" class="sp-hint">Los cambios serán visibles para el personal médico autorizado.</div>
           </div>
+          <button *ngIf="!editando" class="sp-btn sp-btn-secondary sp-btn-sm" (click)="iniciarEdicion()">✎ Editar</button>
+          <span *ngIf="editando" class="sp-badge-ok"><span class="sp-pulse"></span>Modo edición</span>
         </div>
-        <div class="sp-field">
-          <label>Peso</label>
-          <div class="sp-ro" [class.sp-ro-empty]="!perfil.peso">
-            {{ perfil.peso ? perfil.peso + ' kg' : 'No registrado' }}
+        <div class="sp-grid3">
+          <div class="sp-field">
+            <label>Tipo de sangre</label>
+            <div *ngIf="!editando" class="sp-ro" [class.sp-ro-empty]="!perfil.tipo_sangre">
+              {{ perfil.tipo_sangre || 'No especificado' }}
+            </div>
+            <select *ngIf="editando" [(ngModel)]="form.tipo_sangre">
+              <option value="">No especificado</option>
+              <option *ngFor="let t of TIPOS_SANGRE" [value]="t">{{ t }}</option>
+            </select>
           </div>
-        </div>
-        <div class="sp-field">
-          <label>Estatura</label>
-          <div class="sp-ro" [class.sp-ro-empty]="!perfil.estatura">
-            {{ perfil.estatura ? perfil.estatura + ' cm' : 'No registrada' }}
+          <div class="sp-field">
+            <label>Peso</label>
+            <div *ngIf="!editando" class="sp-ro" [class.sp-ro-empty]="!perfil.peso">
+              {{ perfil.peso ? perfil.peso + ' kg' : 'No registrado' }}
+            </div>
+            <div *ngIf="editando" class="sp-input-unit">
+              <input type="number" inputmode="decimal" min="0" max="300" step="0.1"
+                [(ngModel)]="form.peso" placeholder="Ej: 68" />
+              <span class="sp-unit">kg</span>
+            </div>
           </div>
-        </div>
-        <div class="sp-field">
-          <label>Contacto de emergencia</label>
-          <div class="sp-ro"
-            [class.sp-ro-empty]="!perfil.contacto_emergencia_nombre && !perfil.contacto_emergencia_telefono">
-            <ng-container *ngIf="perfil.contacto_emergencia_nombre || perfil.contacto_emergencia_telefono">
-              {{ perfil.contacto_emergencia_nombre }}
-              <ng-container *ngIf="perfil.contacto_emergencia_nombre && perfil.contacto_emergencia_telefono"> — </ng-container>
-              {{ perfil.contacto_emergencia_telefono }}
-            </ng-container>
-            <ng-container *ngIf="!perfil.contacto_emergencia_nombre && !perfil.contacto_emergencia_telefono">
-              No registrado
-            </ng-container>
-          </div>
-        </div>
-        <div class="sp-field sp-full">
-          <label>Alergias conocidas</label>
-          <div class="sp-ro sp-ro-medical" [class.sp-ro-empty]="!perfil.alergias">
-            {{ perfil.alergias || 'Ninguna registrada' }}
-          </div>
-        </div>
-        <div class="sp-field sp-full">
-          <label>Enfermedades crónicas / antecedentes</label>
-          <div class="sp-ro sp-ro-medical" [class.sp-ro-empty]="!perfil.enfermedades_cronicas">
-            {{ perfil.enfermedades_cronicas || 'Ninguna registrada' }}
+          <div class="sp-field">
+            <label>Estatura</label>
+            <div *ngIf="!editando" class="sp-ro" [class.sp-ro-empty]="!perfil.estatura">
+              {{ perfil.estatura ? perfil.estatura + ' cm' : 'No registrada' }}
+            </div>
+            <div *ngIf="editando" class="sp-input-unit">
+              <input type="number" inputmode="numeric" min="0" max="250"
+                [(ngModel)]="form.estatura" placeholder="Ej: 175" />
+              <span class="sp-unit">cm</span>
+            </div>
           </div>
         </div>
       </div>
 
-      <!-- Modo edición -->
-      <div *ngIf="editando" class="sp-grid2">
-        <div class="sp-field">
-          <label>Tipo de sangre <span class="sp-req">*</span></label>
-          <select [(ngModel)]="form.tipo_sangre">
-            <option value="">No especificado</option>
-            <option *ngFor="let t of TIPOS_SANGRE" [value]="t">{{ t }}</option>
-          </select>
+      <!-- Card: Información médica -->
+      <div class="sp-card">
+        <div class="sp-card-head">
+          <h2>Información médica</h2>
         </div>
-        <div class="sp-field">
-          <label>Peso (kg)</label>
-          <input type="number" inputmode="decimal" min="0" max="300" step="0.1"
-            [(ngModel)]="form.peso" placeholder="Ej: 68" />
-        </div>
-        <div class="sp-field">
-          <label>Estatura (cm)</label>
-          <input type="number" inputmode="numeric" min="0" max="250"
-            [(ngModel)]="form.estatura" placeholder="Ej: 175" />
-        </div>
-        <div class="sp-field">
-          <label>Nombre del contacto de emergencia</label>
-          <input type="text" [(ngModel)]="form.contacto_emergencia_nombre"
-            placeholder="Nombre completo" />
-        </div>
-        <div class="sp-field">
-          <label>Teléfono de emergencia</label>
-          <input type="tel" [(ngModel)]="form.contacto_emergencia_telefono"
-            placeholder="10 dígitos" />
-        </div>
-        <div class="sp-field sp-full">
-          <label>Alergias conocidas</label>
-          <textarea [(ngModel)]="form.alergias" rows="3"
-            placeholder="Ej: Penicilina, Polen&#10;Separa cada alergia con un salto de línea."></textarea>
-          <span class="sp-below">Separa cada alergia con un salto de línea. Indica gravedad si aplica.</span>
-        </div>
-        <div class="sp-field sp-full">
-          <label>Enfermedades crónicas / antecedentes</label>
-          <textarea [(ngModel)]="form.enfermedades_cronicas" rows="3"
-            placeholder="Ej: Asma leve, Diabetes tipo 2 (familiar)"></textarea>
+        <div class="sp-grid2">
+          <div class="sp-field sp-full">
+            <label>Alergias conocidas</label>
+            <div *ngIf="!editando" class="sp-ro sp-ro-medical" [class.sp-ro-empty]="!perfil.alergias">
+              {{ perfil.alergias || 'Ninguna registrada' }}
+            </div>
+            <textarea *ngIf="editando" [(ngModel)]="form.alergias" rows="3"
+              placeholder="Ej: Penicilina, Polen&#10;Separa cada alergia con un salto de línea."></textarea>
+            <span *ngIf="editando" class="sp-below">Separa cada alergia con un salto de línea. Indica gravedad si aplica.</span>
+          </div>
+          <div class="sp-field sp-full">
+            <label>Enfermedades crónicas / antecedentes</label>
+            <div *ngIf="!editando" class="sp-ro sp-ro-medical" [class.sp-ro-empty]="!perfil.enfermedades_cronicas">
+              {{ perfil.enfermedades_cronicas || 'Ninguna registrada' }}
+            </div>
+            <textarea *ngIf="editando" [(ngModel)]="form.enfermedades_cronicas" rows="3"
+              placeholder="Ej: Asma leve, Diabetes tipo 2 (familiar)"></textarea>
+          </div>
         </div>
       </div>
 
-      <!-- Barra de acciones en modo edición -->
-      <div *ngIf="editando" class="sp-editbar">
-        <div class="sp-saved" *ngIf="perfil.updated_at">
-          Última actualización:
-          <b>{{ perfil.updated_at | date:'dd MMM yyyy, HH:mm' }}</b>
+      <!-- Card: Contacto de emergencia -->
+      <div class="sp-card">
+        <div class="sp-card-head">
+          <h2>Contacto de emergencia</h2>
         </div>
-        <div class="sp-saved" *ngIf="!perfil.updated_at"></div>
-        <div class="sp-editbar-btns">
-          <button class="sp-btn sp-btn-gray" (click)="cancelarEdicion()" [disabled]="guardando">
-            Cancelar
-          </button>
-          <button class="sp-btn sp-btn-primary" (click)="guardar()" [disabled]="guardando">
-            {{ guardando ? 'Guardando...' : 'Guardar cambios' }}
-          </button>
+        <div class="sp-grid2">
+          <div class="sp-field">
+            <label>Nombre</label>
+            <div *ngIf="!editando" class="sp-ro" [class.sp-ro-empty]="!perfil.contacto_emergencia_nombre">
+              {{ perfil.contacto_emergencia_nombre || 'No registrado' }}
+            </div>
+            <input *ngIf="editando" type="text" [(ngModel)]="form.contacto_emergencia_nombre"
+              placeholder="Nombre completo" />
+          </div>
+          <div class="sp-field">
+            <label>Teléfono</label>
+            <div *ngIf="!editando" class="sp-ro" [class.sp-ro-empty]="!perfil.contacto_emergencia_telefono">
+              {{ perfil.contacto_emergencia_telefono || 'No registrado' }}
+            </div>
+            <input *ngIf="editando" type="tel" [(ngModel)]="form.contacto_emergencia_telefono"
+              placeholder="10 dígitos" />
+          </div>
         </div>
+
+        <div *ngIf="editando" class="sp-editbar">
+          <div class="sp-saved" *ngIf="perfil.updated_at">
+            Última actualización: <b>{{ perfil.updated_at | date:'dd MMM yyyy' }}</b>
+          </div>
+          <div class="sp-editbar-btns">
+            <button class="sp-btn sp-btn-gray" (click)="cancelarEdicion()" [disabled]="guardando">Cancelar</button>
+            <button class="sp-btn sp-btn-primary" (click)="guardar()" [disabled]="guardando">
+              {{ guardando ? 'Guardando...' : 'Guardar cambios' }}
+            </button>
+          </div>
+        </div>
+
       </div>
-    </div>
+
+    </ng-container>
 
     <!-- Estado vacío si falla la carga -->
     <div *ngIf="!cargando && !perfil" class="sp-error-state">

--- a/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.css
+++ b/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.css
@@ -22,7 +22,7 @@
 }
 
 .pe-title {
-  margin: 0 0 4px;
+  margin: 0;
   font-size: 22px;
   font-weight: 700;
   color: var(--yol-text, #1a2e25);
@@ -42,34 +42,21 @@
   font-weight: 600;
 }
 
-/* Grid dos columnas */
-.pe-grid {
-  display: grid;
-  grid-template-columns: 60% 40%;
-  flex: 1;
-  min-height: 0;
+.pe-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
 }
 
-/* Columna chat */
-.pe-col-chat {
+/* Chat full width */
+.pe-chat-wrap {
   display: flex;
   flex-direction: column;
-  border-right: 1px solid var(--yol-border, #e2e8e5);
-  background: var(--yol-surface, #fff);
+  flex: 1;
   min-height: 0;
-}
-
-.pe-chat-meta {
-  padding: 12px 24px;
-  border-bottom: 1px solid var(--yol-border, #e2e8e5);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 12px;
-}
-
-.pe-session {
-  color: var(--yol-text-subtle, #7b8f86);
+  background: var(--yol-surface, #fff);
 }
 
 .pe-live {
@@ -93,7 +80,7 @@
 .pe-msgs {
   flex: 1;
   overflow-y: auto;
-  padding: 24px 24px 8px;
+  padding: 24px 32px 8px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -102,32 +89,24 @@
 .pe-msg {
   display: flex;
   gap: 10px;
-  max-width: 78%;
+  max-width: 72%;
 }
 
 .pe-msg.ai { align-self: flex-start; }
-.pe-msg.me { align-self: flex-end; flex-direction: row-reverse; }
+.pe-msg.me { align-self: flex-end; }
 
 .pe-msg-av {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 12px;
   font-weight: 700;
-}
-
-.pe-msg.ai .pe-msg-av {
   background: #2563EB;
   color: #fff;
-}
-
-.pe-msg.me .pe-msg-av {
-  background: var(--yol-primary-50, #e8f1ec);
-  color: var(--yol-primary, #1a5c3a);
 }
 
 .pe-msg-body {
@@ -147,7 +126,8 @@
 }
 
 .pe-msg.ai .pe-bubble {
-  background: #f3f4f6;
+  background: #fff;
+  border: 1px solid var(--yol-border, #e2e8e5);
   border-top-left-radius: 4px;
 }
 
@@ -219,7 +199,7 @@
 /* Composer */
 .pe-composer {
   border-top: 1px solid var(--yol-border, #e2e8e5);
-  padding: 14px 24px 18px;
+  padding: 14px 32px 18px;
   background: var(--yol-surface, #fff);
   flex-shrink: 0;
 }
@@ -299,54 +279,31 @@
   font-weight: 600;
 }
 
-/* Columna resultados */
-.pe-col-res {
-  padding: 20px 24px;
-  overflow-y: auto;
-  background: var(--yol-bg, #f7f9f8);
+/* Result card inline */
+.pe-result-body {
+  max-width: 460px;
 }
 
-/* Paneles */
-.pe-panel {
+.pe-result-card {
   background: var(--yol-surface, #fff);
   border: 1px solid var(--yol-border, #e2e8e5);
+  border-left: 3px solid var(--yol-primary, #1a5c3a);
   border-radius: 12px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(26, 92, 58, 0.04);
-  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(26, 92, 58, 0.06);
 }
 
-.pe-panel-head {
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--yol-border, #e2e8e5);
-}
-
-.pe-panel-head h3 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--yol-text, #1a2e25);
-}
-
-.pe-panel-icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 6px;
-  background: var(--yol-primary-50, #e8f1ec);
-  color: var(--yol-primary, #1a5c3a);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.pe-result-title {
+  padding: 12px 16px 10px;
   font-size: 13px;
   font-weight: 700;
+  color: var(--yol-text, #1a2e25);
+  border-bottom: 1px solid var(--yol-border, #e2e8e5);
 }
 
 /* Diagnosticos */
 .pe-dx {
-  padding: 16px 18px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--yol-border, #e2e8e5);
 }
 
@@ -360,7 +317,7 @@
 }
 
 .pe-dx-name {
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--yol-text, #1a2e25);
   display: flex;
@@ -384,18 +341,18 @@
 .pe-dx-code {
   color: var(--yol-text-subtle, #7b8f86);
   font-weight: 500;
-  font-size: 11.5px;
+  font-size: 11px;
 }
 
 .pe-dx-pct {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
   color: var(--yol-primary, #1a5c3a);
   font-variant-numeric: tabular-nums;
 }
 
 .pe-bar {
-  height: 8px;
+  height: 7px;
   border-radius: 999px;
   background: var(--yol-bg, #f7f9f8);
   overflow: hidden;
@@ -408,7 +365,6 @@
   transition: width 0.5s ease;
 }
 
-/* Colores progresivos para posiciones 2 y 3 */
 .pe-dx-2 .pe-dx-pct { color: #3d8c64; }
 .pe-dx-2 .pe-bar-fill { background: #3d8c64; }
 .pe-dx-3 .pe-dx-pct { color: #6ba88a; }
@@ -417,38 +373,38 @@
 .pe-dx-meta {
   font-size: 11.5px;
   color: var(--yol-text-subtle, #7b8f86);
-  margin-top: 8px;
+  margin-top: 6px;
   line-height: 1.4;
 }
 
 /* Warning callout */
 .pe-callout {
-  margin: 14px 18px 16px;
-  padding: 12px 14px;
+  margin: 12px 16px 14px;
+  padding: 10px 12px;
   background: #fef3e0;
   border: 1px solid #fde0a0;
-  border-radius: 9px;
+  border-radius: 8px;
   display: flex;
   gap: 10px;
   align-items: flex-start;
 }
 
 .pe-callout-icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
   background: #f59e0b;
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .pe-callout-txt {
-  font-size: 12.5px;
+  font-size: 12px;
   line-height: 1.45;
   color: #7a4d05;
 }
@@ -458,116 +414,38 @@
   font-weight: 700;
   color: #5e3a02;
   margin-bottom: 2px;
-  font-size: 13px;
+  font-size: 12.5px;
 }
 
-/* CTA panel */
-.pe-panel-cta {
-  padding: 14px 18px;
+/* CTA */
+.pe-result-cta {
+  padding: 12px 16px;
   background: var(--yol-bg, #f7f9f8);
   border-top: 1px solid var(--yol-border, #e2e8e5);
 }
 
 .pe-btn-agendar {
   width: 100%;
-  padding: 10px 16px;
+  padding: 9px 16px;
   border-radius: 8px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   font-family: inherit;
-  border: 1px solid var(--yol-primary, #1a5c3a);
-  background: var(--yol-surface, #fff);
-  color: var(--yol-primary, #1a5c3a);
+  border: none;
+  background: var(--yol-primary, #1a5c3a);
+  color: #fff;
   transition: background 0.15s;
 }
 
 .pe-btn-agendar:hover {
-  background: var(--yol-primary-50, #e8f1ec);
-}
-
-/* Sintomas chips */
-.pe-syms {
-  padding: 14px 18px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.pe-chip {
-  padding: 4px 10px;
-  border: 1px solid var(--yol-border, #e2e8e5);
-  background: var(--yol-primary-50, #e8f1ec);
-  border-radius: 999px;
-  font-size: 11.5px;
-  color: var(--yol-primary, #1a5c3a);
-  font-weight: 500;
-}
-
-/* Tips / Recomendaciones */
-.pe-tips ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.pe-tips li {
-  display: flex;
-  gap: 10px;
-  align-items: flex-start;
-  padding: 11px 18px;
-  border-bottom: 1px solid var(--yol-border, #e2e8e5);
-  font-size: 12.5px;
-  line-height: 1.5;
-  color: var(--yol-text-muted, #4a6859);
-}
-
-.pe-tips li:last-child { border-bottom: none; }
-
-.pe-tip-num {
-  width: 20px;
-  height: 20px;
-  border-radius: 5px;
-  background: var(--yol-primary-50, #e8f1ec);
-  color: var(--yol-primary, #1a5c3a);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  font-weight: 700;
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-/* Estado vacío */
-.pe-empty {
-  text-align: center;
-  padding: 60px 32px;
-  color: var(--yol-text-subtle, #7b8f86);
-}
-
-.pe-empty-icon {
-  font-size: 40px;
-  margin-bottom: 12px;
-  opacity: 0.3;
-}
-
-.pe-empty h3 {
-  margin: 0 0 8px;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--yol-text-muted, #4a6859);
-}
-
-.pe-empty p {
-  margin: 0;
-  font-size: 13px;
-  line-height: 1.5;
+  background: var(--yol-primary-600, #144a2e);
 }
 
 /* Dark mode */
-:host-context(.dark) .pe-msg.ai .pe-bubble { background: #2a2a2a; }
+:host-context(.dark) .pe-msg.ai .pe-bubble { background: #1e2a23; border-color: #2d4a38; }
 :host-context(.dark) .pe-msg.me .pe-bubble { background: #1a3a28; }
+:host-context(.dark) .pe-result-card { background: #1e2a23; border-color: #2d4a38; border-left-color: #4ade80; }
 :host-context(.dark) .pe-callout { background: #332b1a; border-color: #5a4a20; }
 :host-context(.dark) .pe-callout-txt { color: #d4a94e; }
 :host-context(.dark) .pe-callout-txt b { color: #e8c06a; }
@@ -575,14 +453,9 @@
 
 /* Responsive */
 @media (max-width: 768px) {
-  .pe-grid {
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr auto;
-  }
-
-  .pe-col-chat { border-right: none; border-bottom: 1px solid var(--yol-border, #e2e8e5); }
-  .pe-col-res { max-height: 40vh; }
   .pe-header { padding: 16px 16px 12px; }
   .pe-msgs { padding: 16px; }
   .pe-composer { padding: 12px 16px; }
+  .pe-msg { max-width: 90%; }
+  .pe-result-body { max-width: 100%; }
 }

--- a/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.html
+++ b/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.html
@@ -2,152 +2,113 @@
   <!-- Header -->
   <div class="pe-header">
     <div class="pe-crumb">PRE-EVALUACION IA</div>
-    <h2 class="pe-title">Pre-evaluacion con IA</h2>
+    <div class="pe-header-row">
+      <h2 class="pe-title">Pre-evaluacion con IA</h2>
+      <span class="pe-live"><span class="pe-dot"></span>IA en linea</span>
+    </div>
     <p class="pe-sub">Describe tus sintomas con tus propias palabras. Esto <b>NO reemplaza una consulta medica</b> — solo orienta y prepara tu cita con el doctor.</p>
   </div>
 
-  <div class="pe-grid">
-    <!-- Columna chat -->
-    <div class="pe-col-chat">
-      <div class="pe-chat-meta">
-        <span class="pe-session">Sesion activa</span>
-        <span class="pe-live"><span class="pe-dot"></span>IA en linea</span>
-      </div>
-
-      <div class="pe-msgs" #scrollContainer>
-        @for (msg of mensajes; track $index) {
-          <div class="pe-msg" [class.ai]="msg.tipo === 'ai'" [class.me]="msg.tipo === 'user'">
-            <div class="pe-msg-av">{{ msg.tipo === 'ai' ? 'IA' : '?' }}</div>
-            <div class="pe-msg-body">
-              <div class="pe-bubble">{{ msg.contenido }}</div>
-              <div class="pe-ts">{{ msg.hora }}</div>
-            </div>
-          </div>
-        }
-
-        <!-- Typing indicator -->
-        @if (enviando) {
-          <div class="pe-msg ai">
+  <div class="pe-chat-wrap">
+    <div class="pe-msgs" #scrollContainer>
+      @for (msg of mensajes; track $index) {
+        <div class="pe-msg" [class.ai]="msg.tipo === 'ai'" [class.me]="msg.tipo === 'user'">
+          @if (msg.tipo === 'ai') {
             <div class="pe-msg-av">IA</div>
-            <div class="pe-msg-body">
-              <div class="pe-bubble">
-                <div class="pe-typing">
-                  <span></span><span></span><span></span>
-                </div>
-              </div>
-            </div>
-          </div>
-        }
-
-        <!-- Error -->
-        @if (error) {
-          <div class="pe-error">
-            <span>{{ error }}</span>
-            <button class="pe-error-btn" (click)="reintentar()">Reintentar</button>
-          </div>
-        }
-      </div>
-
-      <!-- Input -->
-      <div class="pe-composer">
-        <div class="pe-input-row">
-          <textarea
-            #inputRef
-            [(ngModel)]="textoInput"
-            (keydown)="onKeydown($event)"
-            (input)="autoResize()"
-            placeholder="Escribe otro sintoma o duda..."
-            rows="1"
-            [disabled]="enviando">
-          </textarea>
-          <button class="pe-send" (click)="enviar()" [disabled]="enviando || !textoInput.trim()" title="Enviar">
-            &#8593;
-          </button>
-        </div>
-        <div class="pe-input-hint">
-          <span>Presiona <kbd>Enter</kbd> para enviar · <kbd>Shift</kbd>+<kbd>Enter</kbd> nueva linea</span>
-          <span>Tus respuestas son confidenciales</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Columna resultados -->
-    <div class="pe-col-res">
-      @if (mostrarResultado) {
-        <!-- Diagnosticos -->
-        <div class="pe-panel">
-          <div class="pe-panel-head">
-            <h3><span class="pe-panel-icon">&#9672;</span>Posibles diagnosticos</h3>
-          </div>
-
-          @for (dx of diagnosticos; track dx.nombre; let i = $index) {
-            <div class="pe-dx" [class]="'pe-dx-' + (i + 1)">
-              <div class="pe-dx-row">
-                <div class="pe-dx-name">
-                  <span class="pe-dx-rank">{{ i + 1 }}</span>
-                  {{ dx.nombre }}
-                  @if (dx.codigo) {
-                    <span class="pe-dx-code">{{ dx.codigo }}</span>
-                  }
-                </div>
-                <div class="pe-dx-pct">{{ dx.porcentaje }}%</div>
-              </div>
-              <div class="pe-bar"><div class="pe-bar-fill" [style.width.%]="dx.porcentaje"></div></div>
-              @if (dx.descripcion) {
-                <div class="pe-dx-meta">{{ dx.descripcion }}</div>
-              }
-            </div>
           }
-
-          <!-- Warning -->
-          <div class="pe-callout">
-            <div class="pe-callout-icon">!</div>
-            <div class="pe-callout-txt">
-              <b>Solo orientativo</b>
-              El doctor confirmara el diagnostico. No tomes medicamentos sin prescripcion.
-            </div>
+          <div class="pe-msg-body">
+            <div class="pe-bubble">{{ msg.contenido }}</div>
+            <div class="pe-ts">{{ msg.hora }}</div>
           </div>
-
-          <div class="pe-panel-cta">
-            <button class="pe-btn-agendar" (click)="agendarCita()">Agendar cita</button>
-          </div>
-        </div>
-
-        <!-- Sintomas detectados -->
-        @if (sintomasDetectados.length) {
-          <div class="pe-panel">
-            <div class="pe-panel-head">
-              <h3><span class="pe-panel-icon">&#9906;</span>Sintomas detectados</h3>
-            </div>
-            <div class="pe-syms">
-              @for (s of sintomasDetectados; track s) {
-                <span class="pe-chip">{{ s }}</span>
-              }
-            </div>
-          </div>
-        }
-
-        <!-- Recomendaciones -->
-        @if (recomendaciones.length) {
-          <div class="pe-panel pe-tips">
-            <div class="pe-panel-head">
-              <h3><span class="pe-panel-icon">&#9829;</span>Recomendaciones</h3>
-            </div>
-            <ul>
-              @for (r of recomendaciones; track r; let i = $index) {
-                <li><span class="pe-tip-num">{{ i + 1 }}</span><span>{{ r }}</span></li>
-              }
-            </ul>
-          </div>
-        }
-      } @else {
-        <!-- Estado vacío -->
-        <div class="pe-empty">
-          <div class="pe-empty-icon">&#9672;</div>
-          <h3>Resultados</h3>
-          <p>Los posibles diagnosticos apareceran aqui cuando la IA tenga suficiente informacion.</p>
         </div>
       }
+
+      <!-- Typing indicator -->
+      @if (enviando) {
+        <div class="pe-msg ai">
+          <div class="pe-msg-av">IA</div>
+          <div class="pe-msg-body">
+            <div class="pe-bubble">
+              <div class="pe-typing">
+                <span></span><span></span><span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+
+      <!-- Resultado inline en el chat -->
+      @if (mostrarResultado) {
+        <div class="pe-msg ai">
+          <div class="pe-msg-av">IA</div>
+          <div class="pe-msg-body pe-result-body">
+            <div class="pe-result-card">
+              <div class="pe-result-title">&#9672; Posibles diagnosticos</div>
+
+              @for (dx of diagnosticos; track dx.nombre; let i = $index) {
+                <div class="pe-dx" [class]="'pe-dx-' + (i + 1)">
+                  <div class="pe-dx-row">
+                    <div class="pe-dx-name">
+                      <span class="pe-dx-rank">{{ i + 1 }}</span>
+                      {{ dx.nombre }}
+                      @if (dx.codigo) {
+                        <span class="pe-dx-code">{{ dx.codigo }}</span>
+                      }
+                    </div>
+                    <div class="pe-dx-pct">{{ dx.porcentaje }}%</div>
+                  </div>
+                  <div class="pe-bar"><div class="pe-bar-fill" [style.width.%]="dx.porcentaje"></div></div>
+                  @if (dx.descripcion) {
+                    <div class="pe-dx-meta">{{ dx.descripcion }}</div>
+                  }
+                </div>
+              }
+
+              <div class="pe-callout">
+                <div class="pe-callout-icon">!</div>
+                <div class="pe-callout-txt">
+                  <b>Solo orientativo</b>
+                  El doctor confirmara el diagnostico. No tomes medicamentos sin prescripcion.
+                </div>
+              </div>
+
+              <div class="pe-result-cta">
+                <button class="pe-btn-agendar" (click)="agendarCita()">&#8853; Agendar cita</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+
+      <!-- Error -->
+      @if (error) {
+        <div class="pe-error">
+          <span>{{ error }}</span>
+          <button class="pe-error-btn" (click)="reintentar()">Reintentar</button>
+        </div>
+      }
+    </div>
+
+    <!-- Input -->
+    <div class="pe-composer">
+      <div class="pe-input-row">
+        <textarea
+          #inputRef
+          [(ngModel)]="textoInput"
+          (keydown)="onKeydown($event)"
+          (input)="autoResize()"
+          placeholder="Escribe otro sintoma o duda..."
+          rows="1"
+          [disabled]="enviando">
+        </textarea>
+        <button class="pe-send" (click)="enviar()" [disabled]="enviando || !textoInput.trim()" title="Enviar">
+          &#8593;
+        </button>
+      </div>
+      <div class="pe-input-hint">
+        <span>Presiona <kbd>Enter</kbd> para enviar · <kbd>Shift</kbd>+<kbd>Enter</kbd> nueva linea</span>
+        <span>Tus respuestas son confidenciales</span>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-historial/sd-historial.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-historial/sd-historial.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { CommonModule, DatePipe } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
 import { of } from 'rxjs';
@@ -8,7 +8,7 @@ import { ConsultaHistorial, PerfilMedicoService } from '../../../../../services/
 @Component({
   selector: 'app-sd-historial',
   standalone: true,
-  imports: [CommonModule, DatePipe],
+  imports: [CommonModule],
   templateUrl: './sd-historial.component.html',
   styles: [`
     .historial-info { display: flex; align-items: center; gap: 0.75rem; flex: 1; min-width: 0; }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-historial/sd-historial.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-historial/sd-historial.component.ts
@@ -10,6 +10,12 @@ import { ConsultaHistorial, PerfilMedicoService } from '../../../../../services/
   standalone: true,
   imports: [CommonModule, DatePipe],
   templateUrl: './sd-historial.component.html',
+  styles: [`
+    .historial-info { display: flex; align-items: center; gap: 0.75rem; flex: 1; min-width: 0; }
+    .historial-fecha { font-weight: 700; color: var(--yol-primary, #2563eb); white-space: nowrap; }
+    .historial-motivo { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .historial-doctor { color: var(--yol-text-subtle, #6b7280); white-space: nowrap; font-size: 0.875rem; }
+  `],
 })
 export class SdHistorialComponent implements OnInit, OnDestroy {
   historial: ConsultaHistorial[] = [];

--- a/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.css
@@ -304,3 +304,22 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Dark mode ──────────────────────────────────── */
+:host-context(.dark) .kpi-card              { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .kpi-card.highlighted  { border-color: #166534; }
+:host-context(.dark) .kpi-icon              { background: #0f2d1a; color: #86efac; }
+:host-context(.dark) .kpi-value             { color: #e8f5ee; }
+:host-context(.dark) .kpi-label             { color: #5a7a6a; }
+:host-context(.dark) .section-card          { background: #1a2e25; border-color: #2a4030; }
+:host-context(.dark) .section-title         { color: #e8f5ee; }
+:host-context(.dark) .citas-table th        { background: #0f1a15; color: #5a7a6a; border-color: #2a4030; }
+:host-context(.dark) .citas-table td        { border-color: #2a4030; color: #e8f5ee; }
+:host-context(.dark) .citas-table tr:hover td { background: #0f2d1a; }
+:host-context(.dark) .date-day              { background: #0f2d1a; color: #86efac; }
+:host-context(.dark) .empty-row td,
+:host-context(.dark) .no-data-msg           { color: #5a7a6a; }
+:host-context(.dark) .receta-item           { border-color: #2a4030; }
+:host-context(.dark) .receta-med            { color: #e8f5ee; }
+:host-context(.dark) .receta-date,
+:host-context(.dark) .receta-doctor         { color: #5a7a6a; }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.css
@@ -7,24 +7,24 @@
 }
 
 .kpi {
-  background: #fff;
-  border: 1px solid #e2e8e5;
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
   border-radius: 10px;
   padding: 20px 22px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  box-shadow: 0 2px 8px rgba(26,92,58,.04);
+  box-shadow: var(--yol-shadow-xs);
 }
 
 .kpi.accent {
-  border-left: 3px solid #1a5c3a;
+  border-left: 3px solid var(--yol-primary);
 }
 
 .kpi-lbl {
   font-size: 11px;
   font-weight: 600;
-  color: #4a6859;
+  color: var(--yol-text-muted);
   letter-spacing: .5px;
   text-transform: uppercase;
   display: flex;
@@ -36,8 +36,8 @@
   width: 24px;
   height: 24px;
   border-radius: 6px;
-  background: #e8f1ec;
-  color: #1a5c3a;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -49,23 +49,23 @@
   font-weight: 700;
   line-height: 1;
   letter-spacing: -.8px;
-  color: #1a2e25;
+  color: var(--yol-text);
 }
 
 .kpi-v small {
   font-size: 14px;
-  color: #4a6859;
+  color: var(--yol-text-muted);
   font-weight: 500;
   margin-left: 6px;
 }
 
 .kpi-sub {
   font-size: 12.5px;
-  color: #7b8f86;
+  color: var(--yol-text-subtle);
 }
 
 .kpi-sub b {
-  color: #4a6859;
+  color: var(--yol-text-muted);
   font-weight: 600;
 }
 
@@ -86,12 +86,12 @@
   font-size: 17px;
   font-weight: 600;
   letter-spacing: -.2px;
-  color: #1a2e25;
+  color: var(--yol-text);
 }
 
 .inicio-link {
   font-size: 12.5px;
-  color: #1a5c3a;
+  color: var(--yol-primary);
   font-weight: 600;
   cursor: pointer;
 }
@@ -102,11 +102,11 @@
 
 /* Card + tabla */
 .inicio-card {
-  background: #fff;
-  border: 1px solid #e2e8e5;
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
   border-radius: 10px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(26,92,58,.04);
+  box-shadow: var(--yol-shadow-xs);
 }
 
 .inicio-table {
@@ -120,18 +120,18 @@
   padding: 13px 22px;
   font-size: 11px;
   font-weight: 600;
-  color: #4a6859;
+  color: var(--yol-text-muted);
   letter-spacing: .5px;
   text-transform: uppercase;
-  background: #f7f9f8;
-  border-bottom: 1px solid #e2e8e5;
+  background: var(--yol-bg);
+  border-bottom: 1px solid var(--yol-border);
 }
 
 .inicio-table td {
   padding: 14px 22px;
-  border-bottom: 1px solid #e2e8e5;
+  border-bottom: 1px solid var(--yol-border);
   vertical-align: middle;
-  color: #1a2e25;
+  color: var(--yol-text);
 }
 
 .inicio-table tr:last-child td {
@@ -139,7 +139,7 @@
 }
 
 .inicio-table tr:hover td {
-  background: #f7f9f8;
+  background: var(--yol-bg);
 }
 
 /* Celda de fecha */
@@ -153,10 +153,10 @@
   flex-shrink: 0;
   width: 42px;
   text-align: center;
-  background: #e8f1ec;
+  background: var(--yol-primary-50);
   border-radius: 7px;
   padding: 6px 0;
-  color: #1a5c3a;
+  color: var(--yol-primary);
 }
 
 .date-block b {
@@ -177,13 +177,13 @@
 
 .date-dow {
   font-size: 11.5px;
-  color: #7b8f86;
+  color: var(--yol-text-subtle);
   text-transform: capitalize;
 }
 
 .date-dow b {
   display: block;
-  color: #1a2e25;
+  color: var(--yol-text);
   font-size: 13px;
   font-weight: 500;
   text-transform: capitalize;
@@ -193,7 +193,7 @@
 .hora-cell {
   font-variant-numeric: tabular-nums;
   font-weight: 600;
-  color: #1a2e25;
+  color: var(--yol-text);
 }
 
 /* Badge */
@@ -208,13 +208,13 @@
 }
 
 .badge.ok {
-  background: #e8f1ec;
-  color: #1a5c3a;
+  background: var(--yol-ok-surface);
+  color: var(--yol-ok-text);
 }
 
 .badge.warn {
-  background: #fef3e0;
-  color: #f59e0b;
+  background: var(--yol-warn-surface);
+  color: var(--yol-warn);
 }
 
 .badge-dot {
@@ -234,8 +234,8 @@
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: #e8f1ec;
-  color: #1a5c3a;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -247,13 +247,13 @@
   margin: 0 0 6px;
   font-size: 16px;
   font-weight: 600;
-  color: #1a2e25;
+  color: var(--yol-text);
 }
 
 .empty p {
   margin: 0 0 18px;
   font-size: 13.5px;
-  color: #4a6859;
+  color: var(--yol-text-muted);
   max-width: 360px;
   margin-left: auto;
   margin-right: auto;
@@ -261,7 +261,7 @@
 }
 
 .btn-agendar {
-  background: #1a5c3a;
+  background: var(--yol-primary);
   color: #fff;
   border: none;
   border-radius: 7px;
@@ -276,7 +276,7 @@
 }
 
 .btn-agendar:hover {
-  background: #144a2e;
+  background: var(--yol-primary-600);
 }
 
 /* Skeleton loader */
@@ -290,7 +290,7 @@
 }
 
 .sk-line {
-  background: #e2e8e5;
+  background: var(--yol-border);
   border-radius: 4px;
   height: 14px;
   margin-bottom: 8px;
@@ -304,22 +304,3 @@
     grid-template-columns: 1fr;
   }
 }
-
-/* ── Dark mode ──────────────────────────────────── */
-:host-context(.dark) .kpi-card              { background: #1a2e25; border-color: #2a4030; }
-:host-context(.dark) .kpi-card.highlighted  { border-color: #166534; }
-:host-context(.dark) .kpi-icon              { background: #0f2d1a; color: #86efac; }
-:host-context(.dark) .kpi-value             { color: #e8f5ee; }
-:host-context(.dark) .kpi-label             { color: #5a7a6a; }
-:host-context(.dark) .section-card          { background: #1a2e25; border-color: #2a4030; }
-:host-context(.dark) .section-title         { color: #e8f5ee; }
-:host-context(.dark) .citas-table th        { background: #0f1a15; color: #5a7a6a; border-color: #2a4030; }
-:host-context(.dark) .citas-table td        { border-color: #2a4030; color: #e8f5ee; }
-:host-context(.dark) .citas-table tr:hover td { background: #0f2d1a; }
-:host-context(.dark) .date-day              { background: #0f2d1a; color: #86efac; }
-:host-context(.dark) .empty-row td,
-:host-context(.dark) .no-data-msg           { color: #5a7a6a; }
-:host-context(.dark) .receta-item           { border-color: #2a4030; }
-:host-context(.dark) .receta-med            { color: #e8f5ee; }
-:host-context(.dark) .receta-date,
-:host-context(.dark) .receta-doctor         { color: #5a7a6a; }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.css
@@ -1,0 +1,306 @@
+/* KPI grid */
+.inicio-kpis {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.kpi {
+  background: #fff;
+  border: 1px solid #e2e8e5;
+  border-radius: 10px;
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 2px 8px rgba(26,92,58,.04);
+}
+
+.kpi.accent {
+  border-left: 3px solid #1a5c3a;
+}
+
+.kpi-lbl {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4a6859;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.kpi-ic {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: #e8f1ec;
+  color: #1a5c3a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+}
+
+.kpi-v {
+  font-size: 34px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -.8px;
+  color: #1a2e25;
+}
+
+.kpi-v small {
+  font-size: 14px;
+  color: #4a6859;
+  font-weight: 500;
+  margin-left: 6px;
+}
+
+.kpi-sub {
+  font-size: 12.5px;
+  color: #7b8f86;
+}
+
+.kpi-sub b {
+  color: #4a6859;
+  font-weight: 600;
+}
+
+/* Section */
+.inicio-section {
+  margin-bottom: 28px;
+}
+
+.inicio-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 14px;
+}
+
+.inicio-section-head h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -.2px;
+  color: #1a2e25;
+}
+
+.inicio-link {
+  font-size: 12.5px;
+  color: #1a5c3a;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.inicio-link:hover {
+  text-decoration: underline;
+}
+
+/* Card + tabla */
+.inicio-card {
+  background: #fff;
+  border: 1px solid #e2e8e5;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(26,92,58,.04);
+}
+
+.inicio-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+.inicio-table th {
+  text-align: left;
+  padding: 13px 22px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #4a6859;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  background: #f7f9f8;
+  border-bottom: 1px solid #e2e8e5;
+}
+
+.inicio-table td {
+  padding: 14px 22px;
+  border-bottom: 1px solid #e2e8e5;
+  vertical-align: middle;
+  color: #1a2e25;
+}
+
+.inicio-table tr:last-child td {
+  border-bottom: none;
+}
+
+.inicio-table tr:hover td {
+  background: #f7f9f8;
+}
+
+/* Celda de fecha */
+.date-cell {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.date-block {
+  flex-shrink: 0;
+  width: 42px;
+  text-align: center;
+  background: #e8f1ec;
+  border-radius: 7px;
+  padding: 6px 0;
+  color: #1a5c3a;
+}
+
+.date-block b {
+  display: block;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.date-block span {
+  display: block;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+.date-dow {
+  font-size: 11.5px;
+  color: #7b8f86;
+  text-transform: capitalize;
+}
+
+.date-dow b {
+  display: block;
+  color: #1a2e25;
+  font-size: 13px;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+/* Hora */
+.hora-cell {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: #1a2e25;
+}
+
+/* Badge */
+.badge {
+  display: inline-flex;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  align-items: center;
+  gap: 5px;
+}
+
+.badge.ok {
+  background: #e8f1ec;
+  color: #1a5c3a;
+}
+
+.badge.warn {
+  background: #fef3e0;
+  color: #f59e0b;
+}
+
+.badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* Empty state */
+.empty {
+  padding: 48px 32px;
+  text-align: center;
+}
+
+.empty-ic {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #e8f1ec;
+  color: #1a5c3a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  margin: 0 auto 14px;
+}
+
+.empty h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a2e25;
+}
+
+.empty p {
+  margin: 0 0 18px;
+  font-size: 13.5px;
+  color: #4a6859;
+  max-width: 360px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.5;
+}
+
+.btn-agendar {
+  background: #1a5c3a;
+  color: #fff;
+  border: none;
+  border-radius: 7px;
+  padding: 10px 18px;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.btn-agendar:hover {
+  background: #144a2e;
+}
+
+/* Skeleton loader */
+.skeleton {
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: .4; }
+}
+
+.sk-line {
+  background: #e2e8e5;
+  border-radius: 4px;
+  height: 14px;
+  margin-bottom: 8px;
+}
+
+.sk-sm { width: 60%; }
+.sk-lg { width: 40%; height: 28px; }
+
+@media (max-width: 768px) {
+  .inicio-kpis {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.html
@@ -1,35 +1,110 @@
-<section class="content-section">
-  <div class="welcome-card">
-    <h2>Bienvenido al Sistema del Consultorio</h2>
-
-    <div class="quick-stats">
-      <div class="stat-card">
-        <h3>Próxima Cita</h3>
-        <ng-container *ngIf="nextCitaInfo; else noProximaCita">
-          <p class="stat-value">{{ nextCitaInfo.fecha }}</p>
-          <p class="stat-detail">{{ nextCitaInfo.hora }} hrs</p>
-          <p class="stat-detail" *ngIf="nextCitaInfo.motivo">Motivo: {{ nextCitaInfo.motivo }}</p>
-        </ng-container>
-        <ng-template #noProximaCita>
-          <p class="stat-value">No tienes citas programadas</p>
-        </ng-template>
+<!-- KPIs skeleton -->
+@if (isLoading) {
+  <div class="inicio-kpis">
+    @for (i of [1,2,3]; track i) {
+      <div class="kpi skeleton">
+        <div class="sk-line sk-sm"></div>
+        <div class="sk-line sk-lg"></div>
+        <div class="sk-line sk-sm"></div>
       </div>
+    }
+  </div>
+}
 
-      <div class="stat-card">
-        <h3>Citas Programadas</h3>
-        <p class="stat-value">{{ totalCitasProgramadas }} {{ totalCitasProgramadas === 1 ? 'cita' : 'citas' }}</p>
-      </div>
+<!-- KPIs cargados -->
+@if (!isLoading) {
+  <div class="inicio-kpis">
+    <div class="kpi accent">
+      <div class="kpi-lbl"><span class="kpi-ic">⊞</span>Próximas citas</div>
+      <div class="kpi-v">{{ citasProximas.length }}<small>agendadas</small></div>
+      @if (citasProximas.length > 0) {
+        <div class="kpi-sub">
+          Próxima: <b>{{ citasProximas[0].dow }} {{ citasProximas[0].dia }} {{ citasProximas[0].mes }}, {{ citasProximas[0].hora }}</b>
+        </div>
+      } @else {
+        <div class="kpi-sub">Sin citas agendadas</div>
+      }
+    </div>
 
-      <div class="stat-card" [class.stat-card-alert]="citasPendientesSinEvaluacion > 0">
-        <h3>Pre-evaluación IA</h3>
-        <ng-container *ngIf="citasPendientesSinEvaluacion > 0; else evalAlDia">
-          <p class="stat-value">{{ citasPendientesSinEvaluacion }} pendiente{{ citasPendientesSinEvaluacion > 1 ? 's' : '' }}</p>
-          <button class="btn-ia-inicio" (click)="navegarACitas.emit()">Completar ahora →</button>
-        </ng-container>
-        <ng-template #evalAlDia>
-          <p class="stat-value">✓ Al día</p>
-        </ng-template>
+    <div class="kpi">
+      <div class="kpi-lbl"><span class="kpi-ic">⚲</span>Última visita</div>
+      @if (ultimaVisita) {
+        <div class="kpi-v">{{ ultimaVisita.fecha }}</div>
+        <div class="kpi-sub">{{ ultimaVisita.motivo }} · <b>Atendida</b></div>
+      } @else {
+        <div class="kpi-v">—</div>
+        <div class="kpi-sub">Sin visitas previas</div>
+      }
+    </div>
+
+    <div class="kpi">
+      <div class="kpi-lbl"><span class="kpi-ic">℞</span>Recetas</div>
+      <div class="kpi-v">{{ recetasActivas }}<small>total</small></div>
+      <div class="kpi-sub">
+        <span (click)="navegarARecetas.emit()" class="inicio-link">Ver mis recetas →</span>
       </div>
     </div>
   </div>
-</section>
+}
+
+<!-- Próximas citas -->
+<div class="inicio-section">
+  <div class="inicio-section-head">
+    <h2>Próximas citas</h2>
+    @if (citasProximas.length > 0) {
+      <a class="inicio-link" (click)="navegarACitas.emit()">Ver todas →</a>
+    }
+  </div>
+
+  <div class="inicio-card">
+    @if (!isLoading && citasProximas.length === 0) {
+      <div class="empty">
+        <div class="empty-ic">⊞</div>
+        <h3>No tienes citas agendadas</h3>
+        <p>Cuando agendes una consulta en el servicio médico aparecerá aquí con su fecha, hora y motivo.</p>
+        <button class="btn-agendar" (click)="navegarAAgendar.emit()">
+          <span>＋</span> Agendar cita
+        </button>
+      </div>
+    }
+
+    @if (citasProximas.length > 0) {
+      <table class="inicio-table">
+        <thead>
+          <tr>
+            <th style="width:28%">Fecha</th>
+            <th style="width:12%">Hora</th>
+            <th>Motivo</th>
+            <th style="width:14%">Estatus</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (c of citasProximas; track c.id) {
+            <tr>
+              <td>
+                <div class="date-cell">
+                  <div class="date-block">
+                    <b>{{ c.dia }}</b>
+                    <span>{{ c.mes }}</span>
+                  </div>
+                  <div class="date-dow">
+                    <b>{{ c.dow }}</b>
+                    2026
+                  </div>
+                </div>
+              </td>
+              <td class="hora-cell">{{ c.hora }}</td>
+              <td>{{ c.motivo }}</td>
+              <td>
+                <span class="badge" [class.ok]="c.estatus === 'programada'" [class.warn]="c.estatus !== 'programada'">
+                  <span class="badge-dot"></span>
+                  {{ c.estatus === 'programada' ? 'Confirmada' : 'Pendiente' }}
+                </span>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    }
+  </div>
+</div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-inicio/sd-inicio.component.ts
@@ -1,33 +1,57 @@
 import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
-import { catchError, finalize, takeUntil } from 'rxjs/operators';
-import { of } from 'rxjs';
+import { Subject, forkJoin, of } from 'rxjs';
+import { catchError, takeUntil } from 'rxjs/operators';
 import { Cita, CitaService } from '../../../../../services/cita.service';
-import { PreEvaluacionIAService, PreEvaluacion } from '../../../../../services/pre-evaluacion-ia.service';
+import { Receta, RecetaService } from '../../../../../services/receta.service';
+
+interface CitaResumen {
+  id: number;
+  dia: number;
+  mes: string;
+  dow: string;
+  hora: string;
+  motivo: string;
+  estatus: string;
+}
 
 @Component({
   selector: 'app-sd-inicio',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './sd-inicio.component.html',
+  styleUrls: ['./sd-inicio.component.css'],
 })
 export class SdInicioComponent implements OnInit, OnDestroy {
   @Output() navegarACitas = new EventEmitter<void>();
+  @Output() navegarAAgendar = new EventEmitter<void>();
+  @Output() navegarARecetas = new EventEmitter<void>();
 
-  nextCitaInfo: { fecha: string; hora: string; motivo?: string } | null = null;
-  totalCitasProgramadas = 0;
-  citasPendientesSinEvaluacion = 0;
+  citasProximas: CitaResumen[] = [];
+  ultimaVisita: { fecha: string; motivo: string } | null = null;
+  recetasActivas = 0;
+  isLoading = true;
 
   private destroy$ = new Subject<void>();
 
+  private readonly MESES = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+  private readonly DIAS  = ['domingo','lunes','martes','miércoles','jueves','viernes','sábado'];
+
   constructor(
     private citaService: CitaService,
-    private preEvaluacionService: PreEvaluacionIAService,
+    private recetaService: RecetaService,
   ) {}
 
   ngOnInit(): void {
-    this.cargarResumen();
+    forkJoin({
+      citas:   this.citaService.getCitas().pipe(catchError(() => of([] as Cita[]))),
+      recetas: this.recetaService.getRecetas().pipe(catchError(() => of([] as Receta[]))),
+    })
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(({ citas, recetas }) => {
+      this.procesarCitas(citas);
+      this.recetasActivas = recetas.length;
+      this.isLoading = false;
+    });
   }
 
   ngOnDestroy(): void {
@@ -35,30 +59,40 @@ export class SdInicioComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  private cargarResumen(): void {
-    this.citaService.getCitas()
-      .pipe(takeUntil(this.destroy$), catchError(() => of([])))
-      .subscribe((citas: Cita[]) => {
-        const programadas = citas.filter(c => c.estatus === 'programada');
-        this.totalCitasProgramadas = programadas.length;
+  private procesarCitas(citas: Cita[]): void {
+    const hoy = new Date();
+    hoy.setHours(0, 0, 0, 0);
 
-        const proxima = programadas.sort((a, b) =>
-          new Date(a.fecha_cita).getTime() - new Date(b.fecha_cita).getTime()
-        )[0];
+    const proximas = citas
+      .filter(c => c.estatus === 'programada' && new Date(c.fecha_cita) >= hoy)
+      .sort((a, b) => new Date(a.fecha_cita).getTime() - new Date(b.fecha_cita).getTime());
 
-        if (proxima) {
-          this.nextCitaInfo = {
-            fecha: new Intl.DateTimeFormat('es-MX', { dateStyle: 'long' }).format(new Date(proxima.fecha_cita)),
-            hora: proxima.hora_cita,
-            motivo: proxima.motivo ?? undefined,
-          };
-        }
-      });
+    this.citasProximas = proximas.slice(0, 5).map(c => this.mapearCita(c));
 
-    this.preEvaluacionService.getPreEvaluaciones()
-      .pipe(takeUntil(this.destroy$), catchError(() => of([])))
-      .subscribe((res: any) => { const evals: PreEvaluacion[] = res?.pre_evaluaciones ?? [];
-        this.citasPendientesSinEvaluacion = evals.filter(e => !e.estatus_validacion).length;
-      });
+    const pasadas = citas
+      .filter(c => c.estatus === 'atendida')
+      .sort((a, b) => new Date(b.fecha_cita).getTime() - new Date(a.fecha_cita).getTime());
+
+    if (pasadas.length) {
+      const p = pasadas[0];
+      const d = new Date(p.fecha_cita);
+      this.ultimaVisita = {
+        fecha: `${d.getDate()} ${this.MESES[d.getMonth()]} ${d.getFullYear()}`,
+        motivo: p.motivo ?? 'Consulta general',
+      };
+    }
+  }
+
+  private mapearCita(c: Cita): CitaResumen {
+    const d = new Date(c.fecha_cita);
+    return {
+      id:     c.id,
+      dia:    d.getDate(),
+      mes:    this.MESES[d.getMonth()].toUpperCase(),
+      dow:    this.DIAS[d.getDay()],
+      hora:   c.hora_cita,
+      motivo: c.motivo ?? 'Consulta general',
+      estatus: c.estatus,
+    };
   }
 }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.css
@@ -293,3 +293,199 @@
 @media (max-width: 900px) {
   .sp-grid { grid-template-columns: 1fr; }
 }
+
+/* ── Campos bloqueados ──────────────────────────── */
+.sp-row-locked {
+  opacity: .75;
+  cursor: default;
+}
+
+.sp-lock-icon {
+  display: flex;
+  align-items: center;
+  color: var(--yol-text-muted);
+}
+
+.sp-lock-icon svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.sp-locked-field {
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  margin-bottom: var(--yol-s-2);
+}
+
+.sp-locked-label {
+  font-size: var(--yol-fs-label);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .4px;
+  color: var(--yol-text-muted);
+  margin-bottom: 4px;
+}
+
+.sp-locked-value {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text);
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.sp-locked-value.muted { color: var(--yol-text-muted); font-style: italic; }
+
+/* ── Notices ────────────────────────────────────── */
+.sp-notice {
+  display: flex;
+  gap: var(--yol-s-2);
+  align-items: flex-start;
+  font-size: var(--yol-fs-sm);
+  line-height: 1.5;
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  margin-bottom: var(--yol-s-3);
+  border: 1px solid transparent;
+}
+
+.sp-notice svg { width: 16px; height: 16px; flex-shrink: 0; margin-top: 1px; }
+
+.sp-notice-info {
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
+  border-color: var(--yol-border);
+}
+
+.sp-notice-warn {
+  background: var(--yol-warn-surface);
+  color: var(--yol-warn);
+  border-color: #fde68a;
+}
+
+/* ── Password strength ──────────────────────────── */
+.sp-strength-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--yol-s-2);
+  margin-top: var(--yol-s-2);
+}
+
+.sp-strength-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--yol-border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.sp-strength-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width .3s ease, background .3s ease;
+}
+
+.sp-strength-fill.weak   { background: var(--yol-danger); }
+.sp-strength-fill.fair   { background: var(--yol-warn); }
+.sp-strength-fill.good   { background: #22c55e; }
+.sp-strength-fill.strong { background: var(--yol-primary); }
+
+.sp-strength-label {
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  min-width: 48px;
+}
+.sp-strength-label.weak   { color: var(--yol-danger); }
+.sp-strength-label.fair   { color: var(--yol-warn); }
+.sp-strength-label.good   { color: #22c55e; }
+.sp-strength-label.strong { color: var(--yol-primary); }
+
+.sp-strength-hints {
+  list-style: none;
+  padding: 0;
+  margin: var(--yol-s-2) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+}
+
+.sp-strength-hints li {
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  padding-left: 14px;
+  position: relative;
+}
+
+.sp-strength-hints li::before {
+  content: '○';
+  position: absolute;
+  left: 0;
+  font-size: 9px;
+  top: 2px;
+  color: var(--yol-text-muted);
+}
+
+.sp-strength-hints li.ok { color: var(--yol-primary); font-weight: 600; }
+.sp-strength-hints li.ok::before { content: '●'; color: var(--yol-primary); }
+
+/* ── Toggles (notificaciones) ───────────────────── */
+.sp-toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--yol-s-3) 0;
+  border-bottom: 1px solid var(--yol-border);
+  gap: var(--yol-s-4);
+}
+
+.sp-toggle-row:last-of-type { border-bottom: none; }
+
+.sp-toggle-label {
+  font-size: var(--yol-fs-sm);
+  font-weight: 600;
+  color: var(--yol-text);
+}
+
+.sp-toggle-desc {
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  margin-top: 2px;
+}
+
+.sp-toggle {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 12px;
+  border: none;
+  background: var(--yol-border);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--yol-duration-normal);
+}
+
+.sp-toggle.on { background: var(--yol-primary); }
+
+.sp-toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform var(--yol-duration-normal);
+  box-shadow: 0 1px 3px rgba(0,0,0,.2);
+}
+
+.sp-toggle.on .sp-toggle-thumb { transform: translateX(20px); }
+
+/* ── Dark mode additions ────────────────────────── */
+:host-context(.dark) .sp-locked-field { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .sp-notice-info  { background: #0f2d1a; border-color: #166534; color: #86efac; }
+:host-context(.dark) .sp-notice-warn  { background: #2d2310; border-color: #92400e; color: #fcd34d; }
+:host-context(.dark) .sp-strength-bar { background: #2a4030; }
+:host-context(.dark) .sp-toggle       { background: #2a4030; }
+:host-context(.dark) .sp-toggle-row   { border-color: #2a4030; }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.css
@@ -1,0 +1,295 @@
+/* Layout dos columnas */
+.sp-grid {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 20px;
+  max-width: 1080px;
+  align-items: start;
+}
+
+.sp-card {
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-lg);
+  box-shadow: var(--yol-shadow-xs);
+  overflow: hidden;
+}
+
+/* Loading */
+.sp-loading {
+  padding: var(--yol-s-8);
+  text-align: center;
+  color: var(--yol-text-muted);
+  font-size: var(--yol-fs-sm);
+}
+
+/* ── Identity card ─────────────────────────────── */
+.sp-id-body {
+  padding: var(--yol-s-6) var(--yol-s-5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--yol-s-2);
+  text-align: center;
+}
+
+.sp-avatar-wrap { position: relative; margin-bottom: var(--yol-s-1); }
+
+.sp-avatar {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: .5px;
+  overflow: hidden;
+}
+
+.sp-avatar img { width: 100%; height: 100%; object-fit: cover; }
+
+.sp-foto-label {
+  display: inline-block;
+  margin-top: var(--yol-s-2);
+  font-size: var(--yol-fs-label);
+  font-weight: 600;
+  color: var(--yol-primary);
+  cursor: pointer;
+}
+
+.sp-foto-label:hover { text-decoration: underline; }
+.sp-foto-label input { display: none; }
+
+.sp-foto-msg {
+  display: block;
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  margin-top: 2px;
+}
+
+.sp-name {
+  margin: var(--yol-s-2) 0 0;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.2px;
+  color: var(--yol-text);
+}
+
+.sp-ctrl {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.sp-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--yol-primary-50);
+  color: var(--yol-primary);
+  font-size: var(--yol-fs-label);
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: var(--yol-r-pill);
+  margin-top: var(--yol-s-2);
+}
+
+.sp-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--yol-primary);
+}
+
+.sp-id-actions {
+  padding: 0 var(--yol-s-4) var(--yol-s-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-2);
+}
+
+.sp-btn-out {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--yol-border);
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-md);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  color: var(--yol-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  transition: border-color var(--yol-duration-normal), color var(--yol-duration-normal);
+}
+
+.sp-btn-out:hover { border-color: var(--yol-primary); color: var(--yol-primary); }
+.sp-btn-out svg { width: 14px; height: 14px; stroke-width: 1.8; }
+
+.sp-btn-out.danger { color: var(--yol-danger); border-color: #fee2e2; }
+.sp-btn-out.danger:hover { border-color: var(--yol-danger); background: var(--yol-cancel-surface); }
+
+/* ── Tabs card ─────────────────────────────────── */
+.sp-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--yol-border);
+  padding: 0 var(--yol-s-5);
+}
+
+.sp-tab {
+  padding: 14px 4px;
+  margin-right: 22px;
+  font-size: var(--yol-fs-sm);
+  font-weight: 500;
+  color: var(--yol-text-muted);
+  cursor: pointer;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  background: none;
+  font-family: var(--yol-font);
+  transition: color var(--yol-duration-normal);
+}
+
+.sp-tab.active { color: var(--yol-primary); border-bottom-color: var(--yol-primary); font-weight: 600; }
+.sp-tab:hover:not(.active) { color: var(--yol-text); }
+
+/* Sections dentro del tab */
+.sp-section { padding: var(--yol-s-1) var(--yol-s-5) var(--yol-s-5); }
+.sp-section + .sp-section { border-top: 1px solid var(--yol-bg); }
+
+.sp-section-title {
+  margin: var(--yol-s-4) 0 var(--yol-s-3);
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  color: var(--yol-text-subtle);
+  letter-spacing: .5px;
+  text-transform: uppercase;
+}
+
+/* Rows de solo lectura */
+.sp-row {
+  display: grid;
+  grid-template-columns: 160px 1fr auto;
+  gap: var(--yol-s-4);
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--yol-bg);
+}
+
+.sp-row:last-child { border-bottom: none; }
+.sp-lab { font-size: var(--yol-fs-sm); color: var(--yol-text-muted); font-weight: 500; }
+.sp-val { font-size: var(--yol-fs-body); color: var(--yol-text); font-weight: 500; }
+.sp-val.muted { color: var(--yol-text-subtle); font-weight: 400; }
+
+.sp-edit {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-primary);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.sp-edit:hover { text-decoration: underline; }
+
+/* Forms de edición inline */
+.sp-msg {
+  padding: var(--yol-s-2) var(--yol-s-3);
+  border-radius: var(--yol-r);
+  font-size: var(--yol-fs-sm);
+  margin-bottom: var(--yol-s-3);
+}
+
+.sp-msg.ok { background: var(--yol-ok-surface); color: var(--yol-ok-text); }
+.sp-msg.err { background: var(--yol-cancel-surface); color: var(--yol-danger); }
+
+.sp-form-group { margin-bottom: var(--yol-s-3); }
+.sp-form-group label { display: block; font-size: var(--yol-fs-sm); font-weight: 600; color: var(--yol-text-muted); margin-bottom: var(--yol-s-1); }
+
+.sp-input,
+.sp-select,
+.sp-textarea {
+  width: 100%;
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 8px 12px;
+  font: var(--yol-fs-body) var(--yol-font);
+  color: var(--yol-text);
+  background: var(--yol-surface);
+  outline: none;
+  transition: border-color var(--yol-duration-normal);
+}
+
+.sp-input:focus,
+.sp-select:focus,
+.sp-textarea:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px var(--yol-primary-50); }
+
+.sp-textarea { resize: vertical; min-height: 72px; }
+
+.sp-form-actions {
+  display: flex;
+  gap: var(--yol-s-2);
+  margin-top: var(--yol-s-4);
+}
+
+.sp-btn-primary {
+  padding: 9px 18px;
+  background: var(--yol-primary);
+  color: var(--yol-surface);
+  border: none;
+  border-radius: var(--yol-r-md);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+}
+
+.sp-btn-primary:hover:not(:disabled) { background: var(--yol-primary-600); }
+.sp-btn-primary:disabled { opacity: .55; cursor: default; }
+
+.sp-btn-ghost {
+  padding: 9px 14px;
+  background: transparent;
+  color: var(--yol-text-muted);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+}
+
+.sp-btn-ghost:hover { border-color: var(--yol-text-muted); }
+
+/* Sesiones */
+.sp-sesiones-list { list-style: none; padding: 0; margin: var(--yol-s-3) 0 0; display: flex; flex-direction: column; gap: var(--yol-s-2); }
+.sp-sesion-item { display: flex; align-items: center; justify-content: space-between; padding: var(--yol-s-2) var(--yol-s-3); background: var(--yol-bg); border-radius: var(--yol-r-md); }
+.sp-sesion-name { font-size: var(--yol-fs-sm); font-weight: 600; color: var(--yol-text); }
+.sp-sesion-actual { font-size: var(--yol-fs-label); background: var(--yol-primary-50); color: var(--yol-primary); padding: 2px 7px; border-radius: var(--yol-r-pill); margin-left: var(--yol-s-1); font-weight: 600; }
+.sp-sesion-meta { font-size: var(--yol-fs-label); color: var(--yol-text-muted); margin-top: 2px; }
+.sp-btn-danger-sm { font-size: var(--yol-fs-label); font-weight: 600; color: var(--yol-danger); background: transparent; border: none; cursor: pointer; padding: 2px 6px; }
+.sp-btn-danger-sm:hover { text-decoration: underline; }
+
+/* Dark mode */
+:host-context(.dark) .sp-card { background: #1a2e25; }
+:host-context(.dark) .sp-name { color: #e8f5ee; }
+:host-context(.dark) .sp-ctrl { color: #a8c4b4; }
+:host-context(.dark) .sp-btn-out { background: #1a2e25; border-color: #2a4030; color: #e8f5ee; }
+:host-context(.dark) .sp-btn-out:hover { border-color: var(--yol-primary); color: #86efac; }
+:host-context(.dark) .sp-tabs { border-bottom-color: #2a4030; }
+:host-context(.dark) .sp-tab { color: #7b9e8c; }
+:host-context(.dark) .sp-tab.active { color: #86efac; border-bottom-color: #86efac; }
+:host-context(.dark) .sp-section + .sp-section { border-top-color: #2a4030; }
+:host-context(.dark) .sp-row { border-bottom-color: #2a4030; }
+:host-context(.dark) .sp-lab { color: #7b9e8c; }
+:host-context(.dark) .sp-val { color: #e8f5ee; }
+:host-context(.dark) .sp-input,
+:host-context(.dark) .sp-select,
+:host-context(.dark) .sp-textarea { background: #0f1a15; border-color: #2a4030; color: #e8f5ee; }
+:host-context(.dark) .sp-sesion-item { background: #0f1a15; }
+
+@media (max-width: 900px) {
+  .sp-grid { grid-template-columns: 1fr; }
+}

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.html
@@ -32,7 +32,7 @@
           <div class="perfil-item"><span class="perfil-label">N° Control</span><span>{{ perfilMedico.numero_control }}</span></div>
           <div class="perfil-item"><span class="perfil-label">Email</span><span>{{ perfilMedico.email }}</span></div>
           <div class="perfil-item"><span class="perfil-label">Teléfono</span><span>{{ perfilMedico.telefono || '—' }}</span></div>
-          <div class="perfil-item"><span class="perfil-label">Fecha nacimiento</span><span>{{ perfilMedico.fecha_nacimiento || '—' }}</span></div>
+          <div class="perfil-item"><span class="perfil-label">Fecha nacimiento</span><span>{{ perfilMedico.fecha_nacimiento ? (perfilMedico.fecha_nacimiento | date:'dd/MM/yyyy') : '—' }}</span></div>
         </ng-container>
         <ng-container *ngIf="editandoPersonal">
           <div class="form-group"><label>Nombre</label><input type="text" [(ngModel)]="personalForm.nombre" class="form-input" /></div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.html
@@ -5,7 +5,6 @@
   <!-- ── Columna izquierda: identity card ── -->
   <div class="sp-card">
     <div class="sp-id-body">
-      <!-- Avatar / foto -->
       <div class="sp-avatar">
         <img *ngIf="fotoPreview || perfilMedico.foto_perfil"
              [src]="fotoPreview || perfilMedico.foto_perfil"
@@ -43,53 +42,67 @@
   <!-- ── Columna derecha: tabs ── -->
   <div class="sp-card">
     <div class="sp-tabs">
-      <button class="sp-tab" [class.active]="activeTab === 'personal'" (click)="activeTab = 'personal'">Información personal</button>
-      <button class="sp-tab" [class.active]="activeTab === 'medico'"   (click)="activeTab = 'medico'">Información médica</button>
-      <button class="sp-tab" [class.active]="activeTab === 'seguridad'" (click)="activeTab = 'seguridad'">Seguridad</button>
+      <button class="sp-tab" [class.active]="activeTab === 'personal'"       (click)="activeTab = 'personal'">Personal</button>
+      <button class="sp-tab" [class.active]="activeTab === 'medico'"         (click)="activeTab = 'medico'">Médico</button>
+      <button class="sp-tab" [class.active]="activeTab === 'seguridad'"      (click)="activeTab = 'seguridad'">Seguridad</button>
+      <button class="sp-tab" [class.active]="activeTab === 'notificaciones'" (click)="activeTab = 'notificaciones'">Notificaciones</button>
     </div>
 
     <!-- TAB: personal -->
     <div *ngIf="activeTab === 'personal'">
       <div class="sp-section">
         <div class="sp-section-title">Datos personales</div>
+
+        <!-- Aviso campos bloqueados -->
+        <div class="sp-notice sp-notice-info">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          Los datos de identidad (nombre, número de control, fecha de nacimiento) solo pueden modificarse a través de la Oficina Escolar.
+        </div>
+
         <div *ngIf="personalMsg" class="sp-msg" [class.ok]="!personalMsg.includes('Error')" [class.err]="personalMsg.includes('Error')">{{ personalMsg }}</div>
 
+        <!-- Campos bloqueados -->
+        <div class="sp-row sp-row-locked">
+          <span class="sp-lab">Nombre completo</span>
+          <span class="sp-val">{{ perfilMedico.nombre }} {{ perfilMedico.apellido }}</span>
+          <span class="sp-lock-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+          </span>
+        </div>
+        <div class="sp-row sp-row-locked">
+          <span class="sp-lab">N° de control</span>
+          <span class="sp-val">{{ perfilMedico.numero_control }}</span>
+          <span class="sp-lock-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+          </span>
+        </div>
+        <div class="sp-row sp-row-locked">
+          <span class="sp-lab">Fecha de nacimiento</span>
+          <span class="sp-val" [class.muted]="!perfilMedico.fecha_nacimiento">
+            {{ perfilMedico.fecha_nacimiento ? (perfilMedico.fecha_nacimiento | date:'dd/MM/yyyy') : 'Sin registrar' }}
+          </span>
+          <span class="sp-lock-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+          </span>
+        </div>
+
+        <!-- Campos editables -->
         <ng-container *ngIf="!editandoPersonal">
-          <div class="sp-row">
-            <span class="sp-lab">Nombre completo</span>
-            <span class="sp-val">{{ perfilMedico.nombre }} {{ perfilMedico.apellido }}</span>
-            <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
-          </div>
-          <div class="sp-row">
-            <span class="sp-lab">N° de control</span>
-            <span class="sp-val">{{ perfilMedico.numero_control }}</span>
-            <span></span>
-          </div>
           <div class="sp-row">
             <span class="sp-lab">Email</span>
             <span class="sp-val">{{ perfilMedico.email }}</span>
-            <span></span>
+            <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
           </div>
           <div class="sp-row">
             <span class="sp-lab">Teléfono</span>
             <span class="sp-val" [class.muted]="!perfilMedico.telefono">{{ perfilMedico.telefono || 'Sin registrar' }}</span>
             <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
           </div>
-          <div class="sp-row">
-            <span class="sp-lab">Fecha de nacimiento</span>
-            <span class="sp-val" [class.muted]="!perfilMedico.fecha_nacimiento">
-              {{ perfilMedico.fecha_nacimiento ? (perfilMedico.fecha_nacimiento | date:'dd/MM/yyyy') : 'Sin registrar' }}
-            </span>
-            <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
-          </div>
         </ng-container>
 
         <ng-container *ngIf="editandoPersonal">
-          <div class="sp-form-group"><label>Nombre</label><input class="sp-input" type="text" [(ngModel)]="personalForm.nombre" /></div>
-          <div class="sp-form-group"><label>Apellido</label><input class="sp-input" type="text" [(ngModel)]="personalForm.apellido" /></div>
           <div class="sp-form-group"><label>Email</label><input class="sp-input" type="email" [(ngModel)]="personalForm.email" /></div>
           <div class="sp-form-group"><label>Teléfono</label><input class="sp-input" type="text" [(ngModel)]="personalForm.telefono" placeholder="Opcional" /></div>
-          <div class="sp-form-group"><label>Fecha de nacimiento</label><input class="sp-input" type="date" [(ngModel)]="personalForm.fecha_nacimiento" /></div>
           <div class="sp-form-actions">
             <button class="sp-btn-primary" (click)="submitDatosPersonales()" [disabled]="isSubmittingPersonal">
               {{ isSubmittingPersonal ? 'Guardando...' : 'Guardar cambios' }}
@@ -103,9 +116,8 @@
     <!-- TAB: médico -->
     <div *ngIf="activeTab === 'medico'">
       <div class="sp-section">
-        <div class="sp-section-title">Información médica</div>
+        <div class="sp-section-title">Tipo de sangre</div>
         <div *ngIf="perfilMsg" class="sp-msg" [class.ok]="!perfilMsg.includes('Error')" [class.err]="perfilMsg.includes('Error')">{{ perfilMsg }}</div>
-
         <div class="sp-form-group">
           <label>Tipo de sangre</label>
           <select class="sp-select" [(ngModel)]="perfilForm.tipo_sangre">
@@ -113,30 +125,56 @@
             <option *ngFor="let t of ['A+','A-','B+','B-','AB+','AB-','O+','O-']" [value]="t">{{ t }}</option>
           </select>
         </div>
-        <div class="sp-form-group">
-          <label>Alergias</label>
-          <textarea class="sp-textarea" [(ngModel)]="perfilForm.alergias" placeholder="Ej: Penicilina, polen..."></textarea>
-        </div>
-        <div class="sp-form-group">
-          <label>Enfermedades crónicas</label>
-          <textarea class="sp-textarea" [(ngModel)]="perfilForm.enfermedades_cronicas" placeholder="Ej: Diabetes, hipertensión..."></textarea>
-        </div>
         <div class="sp-form-actions">
           <button class="sp-btn-primary" (click)="submitPerfil()" [disabled]="isSubmittingPerfil">
-            {{ isSubmittingPerfil ? 'Guardando...' : 'Guardar cambios' }}
+            {{ isSubmittingPerfil ? 'Guardando...' : 'Guardar' }}
           </button>
+        </div>
+      </div>
+
+      <div class="sp-section">
+        <div class="sp-section-title">Información clínica</div>
+        <div class="sp-notice sp-notice-warn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+          Estos campos solo pueden ser modificados por el personal médico.
+        </div>
+        <div class="sp-locked-field">
+          <div class="sp-locked-label">Alergias conocidas</div>
+          <div class="sp-locked-value" [class.muted]="!perfilMedico.alergias">
+            {{ perfilMedico.alergias || 'Sin registrar' }}
+          </div>
+        </div>
+        <div class="sp-locked-field">
+          <div class="sp-locked-label">Enfermedades crónicas</div>
+          <div class="sp-locked-value" [class.muted]="!perfilMedico.enfermedades_cronicas">
+            {{ perfilMedico.enfermedades_cronicas || 'Sin registrar' }}
+          </div>
         </div>
       </div>
     </div>
 
     <!-- TAB: seguridad -->
     <div *ngIf="activeTab === 'seguridad'">
-      <!-- Cambiar contraseña -->
       <div class="sp-section">
         <div class="sp-section-title">Cambiar contraseña</div>
         <div *ngIf="passwordMsg" class="sp-msg" [class.ok]="passwordMsg.includes('correctamente')" [class.err]="!passwordMsg.includes('correctamente')">{{ passwordMsg }}</div>
         <div class="sp-form-group"><label>Contraseña actual</label><input class="sp-input" type="password" [(ngModel)]="passwordForm.password_actual" placeholder="Tu contraseña actual" /></div>
-        <div class="sp-form-group"><label>Nueva contraseña</label><input class="sp-input" type="password" [(ngModel)]="passwordForm.password_nuevo" placeholder="Mínimo 8 caracteres" /></div>
+        <div class="sp-form-group">
+          <label>Nueva contraseña</label>
+          <input class="sp-input" type="password" [(ngModel)]="passwordForm.password_nuevo" placeholder="Mínimo 8 caracteres" />
+          <div class="sp-strength-wrap" *ngIf="passwordForm.password_nuevo">
+            <div class="sp-strength-bar">
+              <div class="sp-strength-fill" [ngClass]="strengthClass" [style.width.%]="strengthPercent"></div>
+            </div>
+            <span class="sp-strength-label" [ngClass]="strengthClass">{{ strengthLabel }}</span>
+          </div>
+          <ul class="sp-strength-hints" *ngIf="passwordForm.password_nuevo">
+            <li [class.ok]="passwordForm.password_nuevo.length >= 8">Mínimo 8 caracteres</li>
+            <li [class.ok]="hasUppercase">Mayúscula (A–Z)</li>
+            <li [class.ok]="hasNumber">Número (0–9)</li>
+            <li [class.ok]="hasSymbol">Símbolo (!@#...)</li>
+          </ul>
+        </div>
         <div class="sp-form-group"><label>Confirmar contraseña</label><input class="sp-input" type="password" [(ngModel)]="passwordForm.password_nuevo_confirmation" /></div>
         <div class="sp-form-actions">
           <button class="sp-btn-primary" (click)="submitCambiarPassword()"
@@ -146,7 +184,6 @@
         </div>
       </div>
 
-      <!-- Sesiones activas -->
       <div class="sp-section">
         <div class="sp-section-title">Sesiones activas</div>
         <div *ngIf="sesionMsg" class="sp-msg ok">{{ sesionMsg }}</div>
@@ -170,6 +207,58 @@
         <button *ngIf="mostrarTodasSesiones && sesiones.length > 5" class="sp-edit" (click)="mostrarTodasSesiones = false" style="margin-top:8px;display:block">
           Mostrar menos
         </button>
+      </div>
+    </div>
+
+    <!-- TAB: notificaciones -->
+    <div *ngIf="activeTab === 'notificaciones'">
+      <div class="sp-section">
+        <div class="sp-section-title">Citas médicas</div>
+        <div class="sp-toggle-row">
+          <div>
+            <div class="sp-toggle-label">Recordatorio por email</div>
+            <div class="sp-toggle-desc">Recibirás un correo 24h antes de tu cita</div>
+          </div>
+          <button class="sp-toggle" [class.on]="notifForm.email_citas" (click)="toggleNotif('email_citas')">
+            <span class="sp-toggle-thumb"></span>
+          </button>
+        </div>
+        <div class="sp-toggle-row">
+          <div>
+            <div class="sp-toggle-label">Recordatorio por notificación</div>
+            <div class="sp-toggle-desc">Disponible en la app móvil</div>
+          </div>
+          <button class="sp-toggle" [class.on]="notifForm.push_citas" (click)="toggleNotif('push_citas')">
+            <span class="sp-toggle-thumb"></span>
+          </button>
+        </div>
+      </div>
+
+      <div class="sp-section">
+        <div class="sp-section-title">Recetas y resultados</div>
+        <div class="sp-toggle-row">
+          <div>
+            <div class="sp-toggle-label">Aviso de nueva receta</div>
+            <div class="sp-toggle-desc">Email cuando el médico expida una receta</div>
+          </div>
+          <button class="sp-toggle" [class.on]="notifForm.email_recetas" (click)="toggleNotif('email_recetas')">
+            <span class="sp-toggle-thumb"></span>
+          </button>
+        </div>
+        <div class="sp-toggle-row">
+          <div>
+            <div class="sp-toggle-label">Recordatorios de tratamiento</div>
+            <div class="sp-toggle-desc">Toma de medicamentos según indicaciones</div>
+          </div>
+          <button class="sp-toggle" [class.on]="notifForm.push_recordatorios" (click)="toggleNotif('push_recordatorios')">
+            <span class="sp-toggle-thumb"></span>
+          </button>
+        </div>
+      </div>
+
+      <div class="sp-notice sp-notice-info" style="margin: 0 var(--yol-s-5) var(--yol-s-5)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        Las preferencias se guardan en este dispositivo. Las notificaciones push requieren la app móvil Yoltec.
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.html
@@ -1,103 +1,177 @@
-<section class="content-section perfil-section">
-  <div class="section-header"><h2>Mi Perfil</h2></div>
+<div class="sp-loading" *ngIf="isLoadingPerfil">Cargando perfil...</div>
 
-  <div *ngIf="isLoadingPerfil" class="loading">Cargando perfil...</div>
+<div class="sp-grid" *ngIf="!isLoadingPerfil && perfilMedico">
 
-  <div *ngIf="!isLoadingPerfil && perfilMedico">
-    <!-- Foto -->
-    <div class="foto-perfil-wrap">
-      <div class="foto-perfil-avatar">
-        <img *ngIf="fotoPreview || perfilMedico.foto_perfil" [src]="fotoPreview || perfilMedico.foto_perfil" alt="Foto de perfil" class="foto-perfil-img" />
-        <span *ngIf="!fotoPreview && !perfilMedico.foto_perfil" class="foto-perfil-initials">{{ iniciales }}</span>
+  <!-- ── Columna izquierda: identity card ── -->
+  <div class="sp-card">
+    <div class="sp-id-body">
+      <!-- Avatar / foto -->
+      <div class="sp-avatar">
+        <img *ngIf="fotoPreview || perfilMedico.foto_perfil"
+             [src]="fotoPreview || perfilMedico.foto_perfil"
+             alt="Foto de perfil" />
+        <span *ngIf="!fotoPreview && !perfilMedico.foto_perfil">{{ iniciales }}</span>
       </div>
-      <div class="foto-perfil-actions">
-        <label class="btn-cambiar-foto" [class.loading]="isUploadingFoto">
-          <span>{{ isUploadingFoto ? 'Subiendo...' : 'Cambiar foto' }}</span>
-          <input type="file" accept="image/jpeg,image/png,image/webp" (change)="onFotoChange($event)" [disabled]="isUploadingFoto" hidden />
-        </label>
-        <span *ngIf="fotoMsg" class="foto-msg" [class.error]="fotoMsg.includes('Error')">{{ fotoMsg }}</span>
-      </div>
+      <label class="sp-foto-label" [class.disabled]="isUploadingFoto">
+        {{ isUploadingFoto ? 'Subiendo...' : 'Cambiar foto' }}
+        <input type="file" accept="image/jpeg,image/png,image/webp"
+               (change)="onFotoChange($event)" [disabled]="isUploadingFoto" />
+      </label>
+      <span *ngIf="fotoMsg" class="sp-foto-msg">{{ fotoMsg }}</span>
+
+      <h2 class="sp-name">{{ perfilMedico.nombre }} {{ perfilMedico.apellido }}</h2>
+      <div class="sp-ctrl">{{ perfilMedico.numero_control }}</div>
+      <div class="sp-badge">Cuenta activa</div>
     </div>
 
-    <div class="perfil-grid">
-      <!-- Datos personales -->
-      <div class="perfil-card">
-        <div class="perfil-card-header">
-          <h3>Datos personales</h3>
-          <button *ngIf="!editandoPersonal" class="btn-edit" (click)="startEditPersonal()">Editar</button>
-        </div>
-        <div *ngIf="personalMsg" class="form-msg" [class.success]="!personalMsg.includes('Error')">{{ personalMsg }}</div>
+    <div class="sp-id-actions">
+      <button class="sp-btn-out" (click)="activeTab = 'personal'; startEditPersonal()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11.5 3 4 10.5V20h9.5L21 12.5 11.5 3Z"/><path d="m14 6 4 4"/>
+        </svg>
+        Editar información
+      </button>
+      <button class="sp-btn-out" (click)="activeTab = 'seguridad'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/>
+        </svg>
+        Cambiar contraseña
+      </button>
+    </div>
+  </div>
+
+  <!-- ── Columna derecha: tabs ── -->
+  <div class="sp-card">
+    <div class="sp-tabs">
+      <button class="sp-tab" [class.active]="activeTab === 'personal'" (click)="activeTab = 'personal'">Información personal</button>
+      <button class="sp-tab" [class.active]="activeTab === 'medico'"   (click)="activeTab = 'medico'">Información médica</button>
+      <button class="sp-tab" [class.active]="activeTab === 'seguridad'" (click)="activeTab = 'seguridad'">Seguridad</button>
+    </div>
+
+    <!-- TAB: personal -->
+    <div *ngIf="activeTab === 'personal'">
+      <div class="sp-section">
+        <div class="sp-section-title">Datos personales</div>
+        <div *ngIf="personalMsg" class="sp-msg" [class.ok]="!personalMsg.includes('Error')" [class.err]="personalMsg.includes('Error')">{{ personalMsg }}</div>
+
         <ng-container *ngIf="!editandoPersonal">
-          <div class="perfil-item"><span class="perfil-label">Nombre</span><span>{{ perfilMedico.nombre }} {{ perfilMedico.apellido }}</span></div>
-          <div class="perfil-item"><span class="perfil-label">N° Control</span><span>{{ perfilMedico.numero_control }}</span></div>
-          <div class="perfil-item"><span class="perfil-label">Email</span><span>{{ perfilMedico.email }}</span></div>
-          <div class="perfil-item"><span class="perfil-label">Teléfono</span><span>{{ perfilMedico.telefono || '—' }}</span></div>
-          <div class="perfil-item"><span class="perfil-label">Fecha nacimiento</span><span>{{ perfilMedico.fecha_nacimiento ? (perfilMedico.fecha_nacimiento | date:'dd/MM/yyyy') : '—' }}</span></div>
+          <div class="sp-row">
+            <span class="sp-lab">Nombre completo</span>
+            <span class="sp-val">{{ perfilMedico.nombre }} {{ perfilMedico.apellido }}</span>
+            <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
+          </div>
+          <div class="sp-row">
+            <span class="sp-lab">N° de control</span>
+            <span class="sp-val">{{ perfilMedico.numero_control }}</span>
+            <span></span>
+          </div>
+          <div class="sp-row">
+            <span class="sp-lab">Email</span>
+            <span class="sp-val">{{ perfilMedico.email }}</span>
+            <span></span>
+          </div>
+          <div class="sp-row">
+            <span class="sp-lab">Teléfono</span>
+            <span class="sp-val" [class.muted]="!perfilMedico.telefono">{{ perfilMedico.telefono || 'Sin registrar' }}</span>
+            <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
+          </div>
+          <div class="sp-row">
+            <span class="sp-lab">Fecha de nacimiento</span>
+            <span class="sp-val" [class.muted]="!perfilMedico.fecha_nacimiento">
+              {{ perfilMedico.fecha_nacimiento ? (perfilMedico.fecha_nacimiento | date:'dd/MM/yyyy') : 'Sin registrar' }}
+            </span>
+            <a class="sp-edit" (click)="startEditPersonal()">Editar</a>
+          </div>
         </ng-container>
+
         <ng-container *ngIf="editandoPersonal">
-          <div class="form-group"><label>Nombre</label><input type="text" [(ngModel)]="personalForm.nombre" class="form-input" /></div>
-          <div class="form-group"><label>Apellido</label><input type="text" [(ngModel)]="personalForm.apellido" class="form-input" /></div>
-          <div class="form-group"><label>Email</label><input type="email" [(ngModel)]="personalForm.email" class="form-input" /></div>
-          <div class="form-group"><label>Teléfono</label><input type="text" [(ngModel)]="personalForm.telefono" class="form-input" placeholder="Opcional" /></div>
-          <div class="form-group"><label>Fecha de nacimiento</label><input type="date" [(ngModel)]="personalForm.fecha_nacimiento" class="form-input" /></div>
-          <div class="form-actions">
-            <button class="btn-primary" (click)="submitDatosPersonales()" [disabled]="isSubmittingPersonal">{{ isSubmittingPersonal ? 'Guardando...' : 'Guardar' }}</button>
-            <button class="btn-secondary" (click)="cancelEditPersonal()" [disabled]="isSubmittingPersonal">Cancelar</button>
+          <div class="sp-form-group"><label>Nombre</label><input class="sp-input" type="text" [(ngModel)]="personalForm.nombre" /></div>
+          <div class="sp-form-group"><label>Apellido</label><input class="sp-input" type="text" [(ngModel)]="personalForm.apellido" /></div>
+          <div class="sp-form-group"><label>Email</label><input class="sp-input" type="email" [(ngModel)]="personalForm.email" /></div>
+          <div class="sp-form-group"><label>Teléfono</label><input class="sp-input" type="text" [(ngModel)]="personalForm.telefono" placeholder="Opcional" /></div>
+          <div class="sp-form-group"><label>Fecha de nacimiento</label><input class="sp-input" type="date" [(ngModel)]="personalForm.fecha_nacimiento" /></div>
+          <div class="sp-form-actions">
+            <button class="sp-btn-primary" (click)="submitDatosPersonales()" [disabled]="isSubmittingPersonal">
+              {{ isSubmittingPersonal ? 'Guardando...' : 'Guardar cambios' }}
+            </button>
+            <button class="sp-btn-ghost" (click)="cancelEditPersonal()" [disabled]="isSubmittingPersonal">Cancelar</button>
           </div>
         </ng-container>
       </div>
+    </div>
 
-      <!-- Info médica -->
-      <div class="perfil-card">
-        <h3>Información médica</h3>
-        <div *ngIf="perfilMsg" class="form-msg" [class.success]="perfilMsg.includes('actualizado')">{{ perfilMsg }}</div>
-        <div class="form-group">
+    <!-- TAB: médico -->
+    <div *ngIf="activeTab === 'medico'">
+      <div class="sp-section">
+        <div class="sp-section-title">Información médica</div>
+        <div *ngIf="perfilMsg" class="sp-msg" [class.ok]="!perfilMsg.includes('Error')" [class.err]="perfilMsg.includes('Error')">{{ perfilMsg }}</div>
+
+        <div class="sp-form-group">
           <label>Tipo de sangre</label>
-          <select [(ngModel)]="perfilForm.tipo_sangre" class="form-select">
+          <select class="sp-select" [(ngModel)]="perfilForm.tipo_sangre">
             <option value="">No especificado</option>
             <option *ngFor="let t of ['A+','A-','B+','B-','AB+','AB-','O+','O-']" [value]="t">{{ t }}</option>
           </select>
         </div>
-        <div class="form-group"><label>Alergias</label><textarea [(ngModel)]="perfilForm.alergias" rows="2" placeholder="Ej: Penicilina, polen..."></textarea></div>
-        <div class="form-group"><label>Enfermedades crónicas</label><textarea [(ngModel)]="perfilForm.enfermedades_cronicas" rows="2" placeholder="Ej: Diabetes, hipertensión..."></textarea></div>
-        <button class="btn-primary" (click)="submitPerfil()" [disabled]="isSubmittingPerfil">{{ isSubmittingPerfil ? 'Guardando...' : 'Guardar cambios' }}</button>
+        <div class="sp-form-group">
+          <label>Alergias</label>
+          <textarea class="sp-textarea" [(ngModel)]="perfilForm.alergias" placeholder="Ej: Penicilina, polen..."></textarea>
+        </div>
+        <div class="sp-form-group">
+          <label>Enfermedades crónicas</label>
+          <textarea class="sp-textarea" [(ngModel)]="perfilForm.enfermedades_cronicas" placeholder="Ej: Diabetes, hipertensión..."></textarea>
+        </div>
+        <div class="sp-form-actions">
+          <button class="sp-btn-primary" (click)="submitPerfil()" [disabled]="isSubmittingPerfil">
+            {{ isSubmittingPerfil ? 'Guardando...' : 'Guardar cambios' }}
+          </button>
+        </div>
       </div>
+    </div>
 
+    <!-- TAB: seguridad -->
+    <div *ngIf="activeTab === 'seguridad'">
       <!-- Cambiar contraseña -->
-      <div class="perfil-card">
-        <h3>Cambiar contraseña</h3>
-        <div *ngIf="passwordMsg" class="form-msg" [class.success]="passwordMsg.includes('correctamente')">{{ passwordMsg }}</div>
-        <div class="form-group"><label>Contraseña actual</label><input type="password" [(ngModel)]="passwordForm.password_actual" class="form-input" placeholder="Tu contraseña actual" /></div>
-        <div class="form-group"><label>Nueva contraseña</label><input type="password" [(ngModel)]="passwordForm.password_nuevo" class="form-input" placeholder="Mínimo 8 caracteres" /></div>
-        <div class="form-group"><label>Confirmar nueva contraseña</label><input type="password" [(ngModel)]="passwordForm.password_nuevo_confirmation" class="form-input" /></div>
-        <button class="btn-primary" (click)="submitCambiarPassword()"
-          [disabled]="isSubmittingPassword || !passwordForm.password_actual || !passwordForm.password_nuevo || !passwordForm.password_nuevo_confirmation">
-          {{ isSubmittingPassword ? 'Cambiando...' : 'Cambiar contraseña' }}
-        </button>
+      <div class="sp-section">
+        <div class="sp-section-title">Cambiar contraseña</div>
+        <div *ngIf="passwordMsg" class="sp-msg" [class.ok]="passwordMsg.includes('correctamente')" [class.err]="!passwordMsg.includes('correctamente')">{{ passwordMsg }}</div>
+        <div class="sp-form-group"><label>Contraseña actual</label><input class="sp-input" type="password" [(ngModel)]="passwordForm.password_actual" placeholder="Tu contraseña actual" /></div>
+        <div class="sp-form-group"><label>Nueva contraseña</label><input class="sp-input" type="password" [(ngModel)]="passwordForm.password_nuevo" placeholder="Mínimo 8 caracteres" /></div>
+        <div class="sp-form-group"><label>Confirmar contraseña</label><input class="sp-input" type="password" [(ngModel)]="passwordForm.password_nuevo_confirmation" /></div>
+        <div class="sp-form-actions">
+          <button class="sp-btn-primary" (click)="submitCambiarPassword()"
+            [disabled]="isSubmittingPassword || !passwordForm.password_actual || !passwordForm.password_nuevo || !passwordForm.password_nuevo_confirmation">
+            {{ isSubmittingPassword ? 'Cambiando...' : 'Cambiar contraseña' }}
+          </button>
+        </div>
       </div>
 
       <!-- Sesiones activas -->
-      <div class="perfil-card">
-        <h3>Sesiones activas</h3>
-        <div *ngIf="sesionMsg" class="form-msg success">{{ sesionMsg }}</div>
-        <div *ngIf="isLoadingSesiones" class="loading">Cargando sesiones...</div>
-        <div *ngIf="!isLoadingSesiones && sesiones.length === 0" class="empty-state-small">No hay sesiones activas.</div>
-        <div *ngIf="!isLoadingSesiones && sesiones.length > 1" style="margin-bottom: 0.5rem; text-align: right;">
-          <button class="btn-danger-sm" (click)="revocarTodasSesiones()">Cerrar todas las demás</button>
-        </div>
-        <ul *ngIf="!isLoadingSesiones && sesiones.length > 0" class="sesiones-lista">
-          <li *ngFor="let s of sesionesVisibles" class="sesion-item">
-            <div class="sesion-info">
-              <span class="sesion-nombre">{{ s.nombre }}</span>
-              <span *ngIf="s.es_actual" class="sesion-badge">Sesión actual</span>
-              <span class="sesion-detalle">Último uso: {{ s.ultimo_uso ? (s.ultimo_uso | date:'dd/MM/yyyy HH:mm':'':'es') : 'Nunca' }}</span>
+      <div class="sp-section">
+        <div class="sp-section-title">Sesiones activas</div>
+        <div *ngIf="sesionMsg" class="sp-msg ok">{{ sesionMsg }}</div>
+        <div *ngIf="isLoadingSesiones" style="font-size:13px;color:var(--yol-text-muted)">Cargando sesiones...</div>
+        <div *ngIf="!isLoadingSesiones && sesiones.length === 0" style="font-size:13px;color:var(--yol-text-muted)">No hay sesiones activas.</div>
+        <ul class="sp-sesiones-list" *ngIf="!isLoadingSesiones && sesiones.length > 0">
+          <li class="sp-sesion-item" *ngFor="let s of sesionesVisibles">
+            <div>
+              <div class="sp-sesion-name">
+                {{ s.nombre }}
+                <span class="sp-sesion-actual" *ngIf="s.es_actual">Actual</span>
+              </div>
+              <div class="sp-sesion-meta">Último uso: {{ s.ultimo_uso ? (s.ultimo_uso | date:'dd/MM/yyyy HH:mm') : 'Nunca' }}</div>
             </div>
-            <button *ngIf="!s.es_actual" class="btn-danger-sm" (click)="revocarSesion(s.id)">Cerrar</button>
+            <button class="sp-btn-danger-sm" *ngIf="!s.es_actual" (click)="revocarSesion(s.id)">Cerrar</button>
           </li>
         </ul>
-        <button *ngIf="sesiones.length > 5 && !mostrarTodasSesiones" class="btn-link" (click)="mostrarTodasSesiones = true">Ver todas ({{ sesiones.length }})</button>
-        <button *ngIf="mostrarTodasSesiones && sesiones.length > 5" class="btn-link" (click)="mostrarTodasSesiones = false">Mostrar menos</button>
+        <button *ngIf="sesiones.length > 5 && !mostrarTodasSesiones" class="sp-edit" (click)="mostrarTodasSesiones = true" style="margin-top:8px;display:block">
+          Ver todas ({{ sesiones.length }})
+        </button>
+        <button *ngIf="mostrarTodasSesiones && sesiones.length > 5" class="sp-edit" (click)="mostrarTodasSesiones = false" style="margin-top:8px;display:block">
+          Mostrar menos
+        </button>
       </div>
     </div>
   </div>
-</section>
+
+</div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
@@ -139,7 +139,6 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
   }
 
   revocarTodasSesiones(): void {
-    // Pendiente: agregar revocarTodasSesiones() al PerfilMedicoService
     this.sesionMsg = 'Función no disponible aún.';
   }
 

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
@@ -181,7 +181,7 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
     return { weak: 'Débil', fair: 'Regular', good: 'Buena', strong: 'Fuerte' }[this.strengthClass] ?? '';
   }
 
-  toggleNotif(key: keyof typeof this.notifForm): void {
+  toggleNotif(key: 'email_citas' | 'push_citas' | 'email_recetas' | 'push_recordatorios'): void {
     this.notifForm[key] = !this.notifForm[key];
     localStorage.setItem('yoltec_notif', JSON.stringify(this.notifForm));
   }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
@@ -14,7 +14,7 @@ import { PerfilMedico, PerfilMedicoService, SesionActiva } from '../../../../../
   styleUrls: ['./sd-perfil.component.css'],
 })
 export class SdPerfilComponent implements OnInit, OnDestroy {
-  activeTab: 'personal' | 'medico' | 'seguridad' = 'personal';
+  activeTab: 'personal' | 'medico' | 'seguridad' | 'notificaciones' = 'personal';
 
   perfilMedico: PerfilMedico | null = null;
   isLoadingPerfil = false;
@@ -26,7 +26,7 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
   isUploadingFoto = false;
   fotoMsg: string | null = null;
 
-  personalForm = { nombre: '', apellido: '', email: '', telefono: '', fecha_nacimiento: '' };
+  personalForm = { email: '', telefono: '' };
   isSubmittingPersonal = false;
   personalMsg: string | null = null;
   editandoPersonal = false;
@@ -40,6 +40,13 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
   sesionMsg: string | null = null;
   mostrarTodasSesiones = false;
 
+  notifForm = {
+    email_citas: true,
+    push_citas: false,
+    email_recetas: true,
+    push_recordatorios: true
+  };
+
   private destroy$ = new Subject<void>();
 
   constructor(private perfilMedicoService: PerfilMedicoService) {}
@@ -47,6 +54,7 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.loadPerfil();
     this.loadSesiones();
+    this.loadNotifPrefs();
   }
 
   ngOnDestroy(): void { this.destroy$.next(); this.destroy$.complete(); }
@@ -78,11 +86,8 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
   startEditPersonal(): void {
     if (!this.perfilMedico) return;
     this.personalForm = {
-      nombre: this.perfilMedico.nombre,
-      apellido: this.perfilMedico.apellido,
       email: this.perfilMedico.email,
-      telefono: this.perfilMedico.telefono ?? '',
-      fecha_nacimiento: this.perfilMedico.fecha_nacimiento ?? ''
+      telefono: this.perfilMedico.telefono ?? ''
     };
     this.editandoPersonal = true;
     this.personalMsg = null;
@@ -148,5 +153,43 @@ export class SdPerfilComponent implements OnInit, OnDestroy {
   get iniciales(): string {
     if (!this.perfilMedico) return '?';
     return `${this.perfilMedico.nombre[0]}${this.perfilMedico.apellido[0]}`;
+  }
+
+  get hasUppercase(): boolean { return /[A-Z]/.test(this.passwordForm.password_nuevo); }
+  get hasNumber():    boolean { return /[0-9]/.test(this.passwordForm.password_nuevo); }
+  get hasSymbol():    boolean { return /[^A-Za-z0-9]/.test(this.passwordForm.password_nuevo); }
+
+  get strengthPercent(): number {
+    const p = this.passwordForm.password_nuevo;
+    let score = 0;
+    if (p.length >= 8) score += 25;
+    if (this.hasUppercase) score += 25;
+    if (this.hasNumber)    score += 25;
+    if (this.hasSymbol)    score += 25;
+    return score;
+  }
+
+  get strengthClass(): string {
+    const s = this.strengthPercent;
+    if (s <= 25) return 'weak';
+    if (s <= 50) return 'fair';
+    if (s <= 75) return 'good';
+    return 'strong';
+  }
+
+  get strengthLabel(): string {
+    return { weak: 'Débil', fair: 'Regular', good: 'Buena', strong: 'Fuerte' }[this.strengthClass] ?? '';
+  }
+
+  toggleNotif(key: keyof typeof this.notifForm): void {
+    this.notifForm[key] = !this.notifForm[key];
+    localStorage.setItem('yoltec_notif', JSON.stringify(this.notifForm));
+  }
+
+  private loadNotifPrefs(): void {
+    const saved = localStorage.getItem('yoltec_notif');
+    if (saved) {
+      try { this.notifForm = { ...this.notifForm, ...JSON.parse(saved) }; } catch {}
+    }
   }
 }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
@@ -11,12 +11,11 @@ import { PerfilMedico, PerfilMedicoService, SesionActiva } from '../../../../../
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './sd-perfil.component.html',
-  styles: [`
-    .perfil-item { display: flex; flex-direction: column; margin-bottom: 0.75rem; }
-    .perfil-label { font-size: 0.75rem; font-weight: 600; color: var(--yol-text-subtle, #6b7280); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.15rem; }
-  `],
+  styleUrls: ['./sd-perfil.component.css'],
 })
 export class SdPerfilComponent implements OnInit, OnDestroy {
+  activeTab: 'personal' | 'medico' | 'seguridad' = 'personal';
+
   perfilMedico: PerfilMedico | null = null;
   isLoadingPerfil = false;
   perfilMsg: string | null = null;

--- a/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-perfil/sd-perfil.component.ts
@@ -11,6 +11,10 @@ import { PerfilMedico, PerfilMedicoService, SesionActiva } from '../../../../../
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './sd-perfil.component.html',
+  styles: [`
+    .perfil-item { display: flex; flex-direction: column; margin-bottom: 0.75rem; }
+    .perfil-label { font-size: 0.75rem; font-weight: 600; color: var(--yol-text-subtle, #6b7280); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.15rem; }
+  `],
 })
 export class SdPerfilComponent implements OnInit, OnDestroy {
   perfilMedico: PerfilMedico | null = null;

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.css
@@ -1,8 +1,5 @@
 .recetas-section {
-  padding: var(--space-6) var(--space-4);
-  max-width: 720px;
-  background: var(--color-bg, #f7f9f8);
-  border-radius: var(--radius-lg);
+  max-width: 880px;
 }
 
 /* Header */
@@ -10,52 +7,49 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-4);
-  margin-bottom: var(--space-6);
+  gap: var(--yol-s-4);
+  margin-bottom: var(--yol-s-5);
   flex-wrap: wrap;
 }
 
 .recetas-titulo {
-  font-size: var(--font-xl);
+  font-size: var(--yol-fs-h1);
   font-weight: 700;
-  color: var(--color-text-primary);
+  color: var(--yol-text);
   margin: 0;
 }
 
 /* Buscador */
 .search-box {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-full);
-  padding: var(--space-2) var(--space-3);
-  min-width: 220px;
-  transition: border-color 0.2s;
-}
-
-.search-box:focus-within {
-  border-color: var(--color-primary);
-}
-
-.search-icon {
-  color: var(--color-text-muted);
-  flex-shrink: 0;
-}
-
-.search-input {
-  border: none;
-  background: transparent;
-  outline: none;
-  font-size: var(--font-sm);
-  color: var(--color-text-primary);
+  position: relative;
+  max-width: 340px;
   width: 100%;
 }
 
-.search-input::placeholder {
-  color: var(--color-text-muted);
+.search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--yol-text-subtle);
+  pointer-events: none;
 }
+
+.search-input {
+  width: 100%;
+  height: 40px;
+  background: var(--yol-bg);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r-md);
+  padding: 0 14px 0 38px;
+  font: 500 var(--yol-fs-sm) var(--yol-font);
+  color: var(--yol-text);
+  outline: none;
+  transition: border-color var(--yol-duration-normal);
+}
+
+.search-input::placeholder { color: var(--yol-text-subtle); }
+.search-input:focus { border-color: var(--yol-primary); box-shadow: 0 0 0 3px var(--yol-primary-50); }
 
 /* States */
 .state-card {
@@ -63,108 +57,83 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: var(--space-2);
-  padding: var(--space-10) var(--space-6);
-  border-radius: var(--radius-lg);
+  gap: var(--yol-s-2);
+  padding: var(--yol-s-8) var(--yol-s-6);
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-lg);
   text-align: center;
+  box-shadow: var(--yol-shadow-xs);
 }
 
-.empty-state {
-  background: var(--color-bg-secondary);
-  color: var(--color-text-muted);
-}
+.empty-state { color: var(--yol-text-muted); }
+.empty-state svg { color: var(--yol-text-subtle); opacity: .6; }
+.empty-state p { font-size: var(--yol-fs-body); font-weight: 600; color: var(--yol-text); margin: 0; }
+.empty-state span { font-size: var(--yol-fs-sm); color: var(--yol-text-muted); margin: 0; }
 
-.empty-state svg {
-  color: var(--color-text-muted);
-  opacity: 0.5;
-}
+.error-state { background: var(--yol-cancel-surface); color: var(--yol-danger); font-size: var(--yol-fs-sm); }
 
-.empty-state p {
-  font-size: var(--font-base);
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  margin: 0;
-}
-
-.empty-state span {
-  font-size: var(--font-sm);
-  margin: 0;
-}
-
-.error-state {
-  background: color-mix(in srgb, var(--color-error) 10%, transparent);
-  color: var(--color-error);
-  font-size: var(--font-sm);
-}
-
-.loading-state {
-  color: var(--color-text-muted);
-  font-size: var(--font-sm);
-  gap: var(--space-3);
-}
+.loading-state { color: var(--yol-text-muted); font-size: var(--yol-fs-sm); gap: var(--yol-s-3); }
 
 .spinner {
   width: 24px;
   height: 24px;
-  border: 2px solid var(--color-border);
-  border-top-color: var(--color-primary);
+  border: 2px solid var(--yol-border);
+  border-top-color: var(--yol-primary);
   border-radius: 50%;
-  animation: spin 0.7s linear infinite;
+  animation: spin .7s linear infinite;
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* Lista de cards */
+/* Lista */
 .recetas-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--yol-s-4);
 }
 
 .receta-card {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-4);
-  box-shadow: 0 1px 4px rgba(26, 46, 37, 0.05);
-  transition: box-shadow 0.2s;
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-lg);
+  padding: var(--yol-s-5);
+  box-shadow: var(--yol-shadow-xs);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-3);
 }
 
-.receta-card:hover {
-  box-shadow: 0 4px 12px rgba(26, 46, 37, 0.10);
-}
+.receta-card:hover { box-shadow: var(--yol-shadow-sm); }
 
 /* Top row */
 .card-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: var(--yol-s-3);
 }
 
 .fecha-chip {
-  background: var(--color-bg-secondary, #e8f1ec);
-  color: var(--color-text-secondary, #4a6859);
-  font-size: var(--font-xs);
+  background: var(--yol-bg);
+  color: var(--yol-text-muted);
+  font-size: var(--yol-fs-label);
   font-weight: 600;
-  padding: 3px 10px;
-  border-radius: var(--radius-full);
-  white-space: nowrap;
-  letter-spacing: 0.3px;
+  padding: 4px 10px;
+  border-radius: var(--yol-r-pill);
+  letter-spacing: .4px;
+  font-variant-numeric: tabular-nums;
 }
 
 .doctor-nombre {
-  font-size: var(--font-sm);
-  font-weight: 600;
-  color: var(--color-text-primary);
-  text-align: right;
+  font-size: var(--yol-fs-sm);
+  font-weight: 500;
+  color: var(--yol-text-muted);
 }
 
 /* Divider */
 .divider {
   border: none;
-  border-top: 1px solid var(--color-border);
-  margin: var(--space-3) 0;
+  border-top: 1px solid var(--yol-bg);
+  margin: 0;
 }
 
 /* Medicamentos */
@@ -174,55 +143,52 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--yol-s-2);
 }
 
 .med-item {
   display: flex;
-  align-items: center;
-  gap: var(--space-2);
+  align-items: flex-start;
+  gap: var(--yol-s-2);
+  font-size: var(--yol-fs-body);
+  line-height: 1.4;
 }
 
-.pill-icon {
-  color: var(--color-primary);
-  flex-shrink: 0;
-}
-
-.med-nombre {
-  font-size: var(--font-sm);
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.med-dosis {
-  font-size: var(--font-xs);
-  color: var(--color-text-muted);
-  margin-left: var(--space-1);
-}
+.pill-icon { color: var(--yol-text-subtle); flex-shrink: 0; margin-top: 2px; }
+.med-nombre { font-weight: 500; color: var(--yol-text); }
+.med-dosis { color: var(--yol-text-muted); font-weight: 400; }
 
 /* Notas */
 .notas {
-  font-size: var(--font-sm);
+  font-size: var(--yol-fs-sm);
   font-style: italic;
-  color: var(--color-text-secondary);
+  color: var(--yol-text-subtle);
   margin: 0;
   line-height: 1.5;
 }
 
 /* Footer */
-.card-footer {
-  display: flex;
-  justify-content: flex-end;
-}
+.card-footer { display: flex; justify-content: flex-end; }
 
 .ver-detalle {
-  font-size: var(--font-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--yol-fs-sm);
   font-weight: 600;
-  color: var(--color-success, #16a34a);
+  color: var(--yol-primary);
   cursor: pointer;
-  transition: opacity 0.15s;
 }
 
-.ver-detalle:hover {
-  opacity: 0.75;
-}
+.ver-detalle:hover { text-decoration: underline; }
+
+/* Dark */
+:host-context(.dark) .receta-card { background: #1a2e25; }
+:host-context(.dark) .fecha-chip { background: #0f1a15; color: #7b9e8c; }
+:host-context(.dark) .med-nombre { color: #e8f5ee; }
+:host-context(.dark) .doctor-nombre,
+:host-context(.dark) .med-dosis { color: #a8c4b4; }
+:host-context(.dark) .notas,
+:host-context(.dark) .pill-icon { color: #5a7a6a; }
+:host-context(.dark) .divider { border-top-color: #2a4030; }
+:host-context(.dark) .state-card { background: #1a2e25; }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.css
@@ -1,0 +1,228 @@
+.recetas-section {
+  padding: var(--space-6) var(--space-4);
+  max-width: 720px;
+  background: var(--color-bg, #f7f9f8);
+  border-radius: var(--radius-lg);
+}
+
+/* Header */
+.recetas-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.recetas-titulo {
+  font-size: var(--font-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+/* Buscador */
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  padding: var(--space-2) var(--space-3);
+  min-width: 220px;
+  transition: border-color 0.2s;
+}
+
+.search-box:focus-within {
+  border-color: var(--color-primary);
+}
+
+.search-icon {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.search-input {
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: var(--font-sm);
+  color: var(--color-text-primary);
+  width: 100%;
+}
+
+.search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+/* States */
+.state-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-10) var(--space-6);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+
+.empty-state {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-muted);
+}
+
+.empty-state svg {
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+
+.empty-state p {
+  font-size: var(--font-base);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.empty-state span {
+  font-size: var(--font-sm);
+  margin: 0;
+}
+
+.error-state {
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  color: var(--color-error);
+  font-size: var(--font-sm);
+}
+
+.loading-state {
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+  gap: var(--space-3);
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Lista de cards */
+.recetas-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.receta-card {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  box-shadow: 0 1px 4px rgba(26, 46, 37, 0.05);
+  transition: box-shadow 0.2s;
+}
+
+.receta-card:hover {
+  box-shadow: 0 4px 12px rgba(26, 46, 37, 0.10);
+}
+
+/* Top row */
+.card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.fecha-chip {
+  background: var(--color-bg-secondary, #e8f1ec);
+  color: var(--color-text-secondary, #4a6859);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+  letter-spacing: 0.3px;
+}
+
+.doctor-nombre {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  text-align: right;
+}
+
+/* Divider */
+.divider {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-3) 0;
+}
+
+/* Medicamentos */
+.med-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.med-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.pill-icon {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.med-nombre {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.med-dosis {
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+  margin-left: var(--space-1);
+}
+
+/* Notas */
+.notas {
+  font-size: var(--font-sm);
+  font-style: italic;
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Footer */
+.card-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.ver-detalle {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-success, #16a34a);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.ver-detalle:hover {
+  opacity: 0.75;
+}

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.css
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.css
@@ -192,3 +192,172 @@
 :host-context(.dark) .pill-icon { color: #5a7a6a; }
 :host-context(.dark) .divider { border-top-color: #2a4030; }
 :host-context(.dark) .state-card { background: #1a2e25; }
+
+/* ── Modal detalle ──────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--yol-s-4);
+  animation: fadeIn .15s ease-out;
+}
+
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+.modal-card {
+  background: var(--yol-surface);
+  border-radius: var(--yol-r-lg);
+  box-shadow: var(--yol-shadow-lg);
+  width: 100%;
+  max-width: 540px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: slideUp .2s ease-out;
+}
+
+@keyframes slideUp { from { transform: translateY(12px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: var(--yol-s-5) var(--yol-s-5) var(--yol-s-4);
+  border-bottom: 1px solid var(--yol-border);
+}
+
+.modal-crumb {
+  font-size: var(--yol-fs-label);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: var(--yol-text-muted);
+}
+
+.modal-fecha {
+  font-size: var(--yol-fs-h2);
+  font-weight: 700;
+  color: var(--yol-text);
+  margin-top: 2px;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: var(--yol-text-muted);
+  cursor: pointer;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: var(--yol-r-sm);
+  transition: background var(--yol-duration-normal);
+}
+.modal-close:hover { background: var(--yol-border); }
+
+.modal-body {
+  padding: var(--yol-s-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-4);
+}
+
+.modal-doctor {
+  display: flex;
+  align-items: center;
+  gap: var(--yol-s-2);
+  font-size: var(--yol-fs-sm);
+  font-weight: 600;
+  color: var(--yol-text-muted);
+  background: var(--yol-primary-50);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  border: 1px solid var(--yol-border);
+}
+
+.modal-section-title {
+  font-size: var(--yol-fs-label);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: var(--yol-text-muted);
+  margin-bottom: calc(-1 * var(--yol-s-2));
+}
+
+.modal-med-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yol-s-2);
+}
+
+.modal-med-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--yol-s-3);
+  background: var(--yol-bg);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  border: 1px solid var(--yol-border);
+}
+
+.modal-med-item .med-nombre { display: block; font-weight: 600; color: var(--yol-text); font-size: var(--yol-fs-sm); }
+.modal-med-item .med-dosis  { display: block; font-size: var(--yol-fs-label); color: var(--yol-text-muted); margin-top: 1px; }
+
+.modal-indicaciones,
+.modal-diagnostico {
+  font-size: var(--yol-fs-sm);
+  color: var(--yol-text);
+  line-height: 1.6;
+  margin: 0;
+  background: var(--yol-bg);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  border: 1px solid var(--yol-border);
+}
+
+.modal-nota {
+  display: flex;
+  gap: var(--yol-s-2);
+  align-items: flex-start;
+  font-size: var(--yol-fs-label);
+  color: var(--yol-text-muted);
+  line-height: 1.5;
+  background: var(--yol-primary-50);
+  padding: var(--yol-s-3) var(--yol-s-4);
+  border-radius: var(--yol-r-md);
+  border: 1px solid var(--yol-border);
+}
+
+.modal-footer {
+  padding: var(--yol-s-4) var(--yol-s-5);
+  border-top: 1px solid var(--yol-border);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-btn-close {
+  background: var(--yol-primary);
+  color: #fff;
+  border: none;
+  padding: 8px 20px;
+  border-radius: var(--yol-r-pill);
+  font: 600 var(--yol-fs-sm) var(--yol-font);
+  cursor: pointer;
+  transition: background var(--yol-duration-normal);
+}
+.modal-btn-close:hover { background: var(--yol-primary-600); }
+
+/* Dark modal */
+:host-context(.dark) .modal-card { background: #1a2e25; }
+:host-context(.dark) .modal-header { border-color: #2a4030; }
+:host-context(.dark) .modal-doctor { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .modal-med-item,
+:host-context(.dark) .modal-indicaciones,
+:host-context(.dark) .modal-diagnostico { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .modal-nota { background: #0f1a15; border-color: #2a4030; }
+:host-context(.dark) .modal-footer { border-color: #2a4030; }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.html
@@ -1,29 +1,67 @@
-<section class="content-section">
-  <div class="section-header"><h2>Mis Recetas Médicas</h2></div>
-
-  <div class="recetas-container">
-    <ng-container *ngIf="!isLoading; else loadingTpl">
-      <div *ngIf="error" class="alert error">{{ error }}</div>
-
-      <div *ngIf="!error && recetas.length === 0" class="placeholder-card">
-        <h3>No tienes recetas registradas</h3>
-        <p>Cuando el doctor expida una receta para ti aparecerá en este apartado.</p>
-      </div>
-
-      <div *ngIf="recetas.length > 0" class="cards-grid">
-        <div *ngFor="let r of recetas" class="receta-card">
-          <div class="receta-header">
-            <h3>{{ r.doctor?.nombre }} {{ r.doctor?.apellido }}</h3>
-            <span class="receta-date">Emitida el {{ formatFecha(r.fecha_emision) }}</span>
-          </div>
-          <p class="receta-detail"><strong>Cita asociada:</strong> {{ formatFecha(r.cita?.fecha_cita || '') }} · {{ r.cita?.hora_cita }} hrs</p>
-          <p class="receta-detail"><strong>Medicamentos:</strong></p>
-          <p class="receta-text">{{ r.medicamentos }}</p>
-          <p class="receta-detail" *ngIf="r.indicaciones"><strong>Indicaciones:</strong></p>
-          <p class="receta-text" *ngIf="r.indicaciones">{{ r.indicaciones }}</p>
-        </div>
-      </div>
-    </ng-container>
-    <ng-template #loadingTpl><div class="placeholder-card">Cargando tus recetas...</div></ng-template>
+<section class="recetas-section">
+  <div class="recetas-header">
+    <h2 class="recetas-titulo">Mis Recetas Médicas</h2>
+    <div class="search-box">
+      <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input
+        class="search-input"
+        type="text"
+        [(ngModel)]="busqueda"
+        placeholder="Buscar por medicamento o doctor…"
+        autocomplete="off"
+      />
+    </div>
   </div>
+
+  <ng-container *ngIf="!isLoading; else loadingTpl">
+    <div *ngIf="error" class="state-card error-state">{{ error }}</div>
+
+    <div *ngIf="!error && recetas.length === 0" class="state-card empty-state">
+      <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="13" y2="16"/></svg>
+      <p>No tienes recetas registradas</p>
+      <span>Cuando el doctor expida una receta aparecerá aquí</span>
+    </div>
+
+    <div *ngIf="!error && recetas.length > 0 && recetasFiltradas.length === 0" class="state-card empty-state">
+      <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <p>Sin resultados</p>
+      <span>No hay recetas que coincidan con "{{ busqueda }}"</span>
+    </div>
+
+    <div *ngIf="recetasFiltradas.length > 0" class="recetas-list">
+      <div *ngFor="let r of recetasFiltradas" class="receta-card">
+
+        <div class="card-top">
+          <span class="fecha-chip">{{ formatFecha(r.fecha_emision) }}</span>
+          <span class="doctor-nombre">Dr. {{ r.doctor?.nombre }} {{ r.doctor?.apellido }}</span>
+        </div>
+
+        <hr class="divider" />
+
+        <ul class="med-list">
+          <li *ngFor="let med of parseMedicamentos(r.medicamentos)" class="med-item">
+            <svg class="pill-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 20H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H20a2 2 0 0 1 2 2v3"/><circle cx="18" cy="18" r="3"/><path d="m22 22-1.5-1.5"/></svg>
+            <span class="med-nombre">{{ med.nombre }}</span>
+            <span *ngIf="med.dosis" class="med-dosis">{{ med.dosis }}</span>
+          </li>
+        </ul>
+
+        <p *ngIf="r.indicaciones" class="notas">{{ r.indicaciones }}</p>
+
+        <hr class="divider" />
+
+        <div class="card-footer">
+          <span class="ver-detalle">Ver detalle completo ›</span>
+        </div>
+
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-template #loadingTpl>
+    <div class="state-card loading-state">
+      <div class="spinner"></div>
+      <span>Cargando tus recetas…</span>
+    </div>
+  </ng-template>
 </section>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.html
@@ -51,7 +51,7 @@
         <hr class="divider" />
 
         <div class="card-footer">
-          <span class="ver-detalle">Ver detalle completo ›</span>
+          <span class="ver-detalle" (click)="abrirDetalle(r)">Ver detalle completo ›</span>
         </div>
 
       </div>
@@ -65,3 +65,48 @@
     </div>
   </ng-template>
 </section>
+
+<!-- Modal detalle receta -->
+<div class="modal-overlay" *ngIf="recetaDetalle" (click)="cerrarDetalle()">
+  <div class="modal-card" (click)="$event.stopPropagation()">
+    <div class="modal-header">
+      <div>
+        <div class="modal-crumb">Receta médica</div>
+        <div class="modal-fecha">{{ formatFecha(recetaDetalle.fecha_emision) }}</div>
+      </div>
+      <button class="modal-close" (click)="cerrarDetalle()">✕</button>
+    </div>
+
+    <div class="modal-body">
+      <div class="modal-doctor">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
+        Dr. {{ recetaDetalle.doctor?.nombre }} {{ recetaDetalle.doctor?.apellido }}
+      </div>
+
+      <div class="modal-section-title">Medicamentos</div>
+      <ul class="modal-med-list">
+        <li *ngFor="let med of parseMedicamentos(recetaDetalle.medicamentos)" class="modal-med-item">
+          <svg class="pill-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 20H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H20a2 2 0 0 1 2 2v3"/><circle cx="18" cy="18" r="3"/><path d="m22 22-1.5-1.5"/></svg>
+          <div>
+            <span class="med-nombre">{{ med.nombre }}</span>
+            <span *ngIf="med.dosis" class="med-dosis">{{ med.dosis }}</span>
+          </div>
+        </li>
+      </ul>
+
+      <ng-container *ngIf="recetaDetalle.indicaciones">
+        <div class="modal-section-title">Indicaciones</div>
+        <p class="modal-indicaciones">{{ recetaDetalle.indicaciones }}</p>
+      </ng-container>
+
+      <div class="modal-nota">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        Esta receta fue emitida por el Servicio Médico Universitario Yoltec. Ante cualquier duda consulta con tu médico.
+      </div>
+    </div>
+
+    <div class="modal-footer">
+      <button class="modal-btn-close" (click)="cerrarDetalle()">Cerrar</button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.ts
@@ -56,6 +56,8 @@ export class SdRecetasComponent implements OnInit, OnDestroy {
   }
 
   formatFecha(fecha: string): string {
-    return new Intl.DateTimeFormat('es-MX', { day: '2-digit', month: '2-digit', year: '2-digit' }).format(new Date(fecha));
+    const d = new Date(fecha);
+    const mes = ['ENE','FEB','MAR','ABR','MAY','JUN','JUL','AGO','SEP','OCT','NOV','DIC'][d.getMonth()];
+    return `${d.getDate()} ${mes} ${d.getFullYear()}`;
   }
 }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
 import { of } from 'rxjs';
@@ -8,13 +9,37 @@ import { Receta, RecetaService } from '../../../../../services/receta.service';
 @Component({
   selector: 'app-sd-recetas',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './sd-recetas.component.html',
+  styleUrls: ['./sd-recetas.component.css'],
 })
 export class SdRecetasComponent implements OnInit, OnDestroy {
   recetas: Receta[] = [];
   isLoading = false;
   error: string | null = null;
+  busqueda = '';
+
+  get recetasFiltradas(): Receta[] {
+    const q = this.busqueda.toLowerCase().trim();
+    if (!q) return this.recetas;
+    return this.recetas.filter(r =>
+      r.medicamentos.toLowerCase().includes(q) ||
+      `${r.doctor?.nombre} ${r.doctor?.apellido}`.toLowerCase().includes(q)
+    );
+  }
+
+  // Divide el string de medicamentos en líneas; separa nombre y dosis por " - "
+  parseMedicamentos(texto: string): { nombre: string; dosis: string }[] {
+    return texto.split('\n')
+      .map(l => l.trim())
+      .filter(l => l.length > 0)
+      .map(l => {
+        const idx = l.indexOf(' - ');
+        return idx !== -1
+          ? { nombre: l.substring(0, idx), dosis: l.substring(idx + 3) }
+          : { nombre: l, dosis: '' };
+      });
+  }
 
   private destroy$ = new Subject<void>();
 

--- a/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-recetas/sd-recetas.component.ts
@@ -18,6 +18,7 @@ export class SdRecetasComponent implements OnInit, OnDestroy {
   isLoading = false;
   error: string | null = null;
   busqueda = '';
+  recetaDetalle: Receta | null = null;
 
   get recetasFiltradas(): Receta[] {
     const q = this.busqueda.toLowerCase().trim();
@@ -54,6 +55,9 @@ export class SdRecetasComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$), catchError(() => { this.error = 'Error al cargar recetas.'; return of([]); }), finalize(() => this.isLoading = false))
       .subscribe((data: Receta[]) => this.recetas = data);
   }
+
+  abrirDetalle(r: Receta): void { this.recetaDetalle = r; }
+  cerrarDetalle(): void { this.recetaDetalle = null; }
 
   formatFecha(fecha: string): string {
     const d = new Date(fecha);

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.css
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.css
@@ -1,1573 +1,290 @@
-.student-dashboard {
+/* Layout principal */
+.sd-app {
+  display: flex;
   min-height: 100vh;
-  background-color: var(--yol-bg);
+  background: #f7f9f8;
+  font-family: var(--yol-font);
 }
 
-/* Encabezado */
-.dashboard-header {
-  background: var(--yol-surface);
-  box-shadow: var(--yol-shadow-sm);
+/* ── Sidebar ──────────────────────────────────────── */
+.sd-sidebar {
+  width: 232px;
+  flex-shrink: 0;
+  background: #1a5c3a;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sd-brand {
+  padding: 22px 22px 20px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  border-bottom: 1px solid rgba(255,255,255,.1);
+}
+
+.sd-brand-logo {
+  width: 32px;
+  height: 32px;
+  border-radius: 7px;
+  background: #fff;
+  color: #1a5c3a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -.5px;
+  flex-shrink: 0;
+}
+
+.sd-brand b {
+  display: block;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.3px;
+}
+
+.sd-brand span {
+  display: block;
+  font-size: 11px;
+  opacity: .7;
+  margin-top: 1px;
+  letter-spacing: .3px;
+}
+
+.sd-nav {
+  padding: 14px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+}
+
+.sd-nav-item {
+  padding: 11px 22px;
+  color: rgba(255,255,255,.85);
+  font-size: 13.5px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-left: 3px solid transparent;
+  cursor: pointer;
+  transition: background .15s;
+  user-select: none;
+}
+
+.sd-nav-item:hover {
+  background: rgba(255,255,255,.05);
+}
+
+.sd-nav-item.active {
+  background: rgba(255,255,255,.08);
+  color: #fff;
+  border-left-color: #86efac;
+  font-weight: 600;
+}
+
+.sd-nav-ic {
+  font-size: 14px;
+  width: 16px;
+  text-align: center;
+  opacity: .95;
+}
+
+.sd-user {
+  padding: 16px 22px;
+  border-top: 1px solid rgba(255,255,255,.1);
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.sd-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255,255,255,.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 13px;
+  flex-shrink: 0;
+  text-transform: uppercase;
+}
+
+.sd-user b {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.sd-logout {
+  background: none;
+  border: none;
+  color: rgba(255,255,255,.6);
+  font-size: 11.5px;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 2px;
+  display: block;
+  font-family: inherit;
+  transition: color .15s;
+}
+
+.sd-logout:hover {
+  color: #fff;
+}
+
+/* ── Área principal ───────────────────────────────── */
+.sd-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.sd-header {
+  padding: 28px 36px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8e5;
   position: sticky;
   top: 0;
   z-index: 100;
 }
 
-.header-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  border-bottom: 1px solid var(--yol-border);
-}
-
-.header-content h1 {
-  color: var(--yol-primary);
-  margin: 0;
-  font-size: var(--yol-fs-display);
-  font-family: var(--yol-font);
-}
-
-.user-info {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.user-info span {
-  color: var(--yol-text-muted);
-  font-weight: 500;
-}
-
-.logout-btn {
-  background: var(--yol-cancel-text);
-  color: var(--yol-surface);
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: var(--yol-r);
-  cursor: pointer;
-  font-size: var(--yol-fs-sm);
-  font-family: var(--yol-font);
-  transition: opacity var(--yol-duration-normal) var(--yol-ease);
-}
-
-.logout-btn:hover {
-  opacity: 0.88;
-}
-
-/* Navegacion */
-.dashboard-nav {
-  display: flex;
-  padding: 0 2rem;
-  gap: 0;
-}
-
-.nav-button {
-  padding: 1rem 2rem;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: var(--yol-fs-body);
-  font-weight: 500;
-  color: var(--yol-text-subtle);
-  border-bottom: 3px solid transparent;
-  transition: all var(--yol-duration-normal) var(--yol-ease);
-  font-family: var(--yol-font);
-}
-
-.nav-button:hover {
-  background-color: var(--yol-bg);
-  color: var(--yol-text-muted);
-}
-
-.nav-button.active {
-  color: var(--yol-primary);
-  border-bottom-color: var(--yol-accent);
-  background-color: var(--yol-primary-50);
-}
-
-/* Contenido Principal */
-.dashboard-content {
-  padding: 2rem;
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.content-section {
-  animation: fadeIn 0.3s ease-in;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-/* Tarjetas de Bienvenida */
-.welcome-card {
-  background: var(--yol-surface);
-  padding: 2rem;
-  border-radius: var(--yol-r-md);
-  box-shadow: var(--yol-shadow-sm);
-  margin-bottom: 2rem;
-}
-
-.welcome-card h2 {
-  color: var(--yol-primary);
-  margin-bottom: 1rem;
-}
-
-.quick-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
-  margin-top: 2rem;
-}
-
-.stat-card {
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  padding: 1.5rem;
-  border-radius: var(--yol-r-md);
-  text-align: center;
-}
-
-.stat-card h3 {
-  margin: 0 0 0.5rem 0;
-  font-size: var(--yol-fs-body);
-}
-
-.stat-card p {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: bold;
-}
-
-/* Headers de Seccion */
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
-}
-
-.section-header h2 {
-  color: var(--yol-primary);
-  margin: 0;
-}
-
-.btn-primary {
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  border: none;
-  padding: 0.75rem 1.5rem;
-  border-radius: var(--yol-r);
-  cursor: pointer;
-  font-weight: 600;
-  font-family: var(--yol-font);
-  transition: opacity var(--yol-duration-normal) var(--yol-ease);
-}
-
-.btn-primary:hover {
-  opacity: 0.88;
-}
-
-.btn-secondary {
-  background: transparent;
-  border: 1px solid var(--yol-cancel-text);
-  color: var(--yol-cancel-text);
-  padding: 0.6rem 1.25rem;
-  border-radius: var(--yol-r);
-  cursor: pointer;
-  font-weight: 600;
-  font-family: var(--yol-font);
-  transition: all var(--yol-duration-normal) var(--yol-ease);
-}
-
-.btn-secondary:hover {
-  background: var(--yol-cancel-text);
-  color: var(--yol-surface);
-}
-
-.citas-container {
-  margin-top: 2rem;
-}
-
-.citas-layout {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1.5rem;
-}
-
-.citas-column {
-  background: var(--yol-surface);
-  padding: 1.5rem;
-  border-radius: var(--yol-r-md);
-  box-shadow: var(--yol-shadow-sm);
-  border: 1px solid var(--yol-border);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.citas-column h3 {
-  margin: 0;
-  color: var(--yol-primary);
-  font-size: 1.25rem;
-  border-bottom: 1px solid var(--yol-primary-50);
-  padding-bottom: 0.75rem;
-}
-
-.cita-card {
-  background: var(--yol-bg);
-  border-radius: var(--yol-r-md);
-  border: 1px solid var(--yol-border);
-  padding: 1rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  box-shadow: var(--yol-shadow-xs);
-}
-
-.cita-card.cancelada {
-  border-color: var(--yol-cancel-surface);
-  background: var(--yol-cancel-surface);
-}
-
-.cita-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-}
-
-.cita-header h4 {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--yol-text);
-}
-
-.estatus {
-  padding: 0.25rem 0.75rem;
-  border-radius: var(--yol-r-pill);
-  font-size: var(--yol-fs-cap);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
-.estatus.programada {
-  background: var(--yol-ok-surface);
-  color: var(--yol-ok-text);
-}
-
-.estatus.atendida {
-  background: var(--yol-ia-soft);
-  color: var(--yol-ia-text);
-}
-
-.estatus.cancelada {
-  background: var(--yol-cancel-surface);
-  color: var(--yol-cancel-text);
-}
-
-.estatus.no-asistio {
-  background: var(--yol-warn-surface);
-  color: var(--yol-warn-text);
-}
-
-.cita-card.no-asistio {
-  border-color: var(--yol-warn-surface);
-  background: var(--yol-warn-surface);
-}
-
-.cita-card p {
-  margin: 0;
-  color: var(--yol-text-muted);
-  font-size: var(--yol-fs-body);
-}
-
-.card-actions {
-  margin-top: 0.75rem;
-  display: flex;
-  justify-content: flex-end;
-}
-
-.placeholder-card {
-  background: var(--yol-surface);
-  padding: 2rem;
-  border-radius: var(--yol-r-md);
-  box-shadow: var(--yol-shadow-xs);
-  border-left: 4px solid var(--yol-accent);
-}
-
-.placeholder-card h3 {
-  color: var(--yol-primary);
-  margin-bottom: 1rem;
-}
-
-.placeholder-card ul {
-  margin: 1rem 0;
-  padding-left: 1.5rem;
-}
-
-.placeholder-card li {
-  margin-bottom: 0.5rem;
-  color: var(--yol-text-muted);
-}
-
-.cards-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.bitacora-container,
-.recetas-container {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.bitacora-card,
-.receta-card {
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  border: 1px solid var(--yol-border);
-  padding: 1.75rem;
-  box-shadow: var(--yol-shadow-sm);
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-}
-
-.bitacora-header,
-.receta-header {
+.sd-header-row {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 1rem;
+  gap: 20px;
 }
 
-.bitacora-header h3,
-.receta-header h3 {
+.sd-crumb {
+  font-size: 12px;
+  color: #7b8f86;
+  margin-bottom: 6px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: .4px;
+}
+
+.sd-title {
   margin: 0;
-  font-size: 1.1rem;
-  color: var(--yol-primary);
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -.5px;
+  color: #1a2e25;
 }
 
-.bitacora-date,
-.receta-date {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  background: var(--yol-ok-surface);
-  color: var(--yol-ok-text);
-  border-radius: var(--yol-r-pill);
-  padding: 0.35rem 0.8rem;
-  font-size: var(--yol-fs-cap);
-  font-weight: 600;
-  white-space: nowrap;
+.sd-title span {
+  color: #1a5c3a;
 }
 
-.receta-date {
-  background: var(--yol-ia-soft);
-  color: var(--yol-ia);
-}
-
-.bitacora-detail,
-.receta-detail {
-  margin: 0;
-  color: var(--yol-text-muted);
-  font-size: var(--yol-fs-body);
-  line-height: 1.45;
-}
-
-.bitacora-detail strong,
-.receta-detail strong {
-  color: var(--yol-primary);
-  font-weight: 650;
-}
-
-.bitacora-metrics {
+.sd-header-actions {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+  gap: 10px;
+  align-items: center;
+  flex-shrink: 0;
 }
 
-.bitacora-metrics span {
-  background: var(--yol-primary-50);
-  color: var(--yol-ok-text);
-  border-radius: var(--yol-r-pill);
-  padding: 0.4rem 0.9rem;
-  font-size: var(--yol-fs-sm);
+.sd-btn-ghost {
+  padding: 10px 16px;
+  border-radius: 7px;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  background: none;
+  border: none;
+  color: #4a6859;
+  transition: background .15s;
+}
+
+.sd-btn-ghost:hover {
+  background: #f7f9f8;
+}
+
+.sd-btn-primary {
+  padding: 10px 16px;
+  border-radius: 7px;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  background: #1a5c3a;
+  color: #fff;
+  border: none;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 7px;
+  transition: background .15s;
+}
+
+.sd-btn-primary:hover {
+  background: #144a2e;
+}
+
+.sd-plus {
+  font-size: 16px;
+  font-weight: 300;
   line-height: 1;
 }
 
-.receta-text {
-  background: var(--yol-bg);
-  border: 1px solid var(--yol-border);
-  border-radius: var(--yol-r-md);
-  padding: 0.9rem 1rem;
-  color: var(--yol-text);
-  font-size: var(--yol-fs-body);
-  line-height: 1.6;
-  white-space: pre-line;
+/* Contenido */
+.sd-content {
+  padding: 24px 36px 80px;
+  flex: 1;
 }
 
-.receta-text + .receta-detail {
-  margin-top: 0.75rem;
-}
-
-.receta-card .receta-text + .receta-text {
-  margin-top: -0.5rem;
-}
-
-.form-group input:focus,
-.form-group textarea:focus,
-.form-group select:focus {
-  border-color: var(--yol-accent);
-  box-shadow: 0 0 0 3px rgba(76, 175, 130, 0.2);
-}
-
-.motivo-area {
-  resize: vertical;
-  min-height: 120px;
-  border: 1px solid var(--yol-border);
-  background: var(--yol-bg);
-}
-
-.motivo-area:focus {
-  background: var(--yol-surface);
-}
-
-.alert {
-  background: var(--yol-ok-surface);
-  border-left: 4px solid var(--yol-accent);
-  padding: 1rem 1.5rem;
-}
-
-.citas-c.form-card {
-  background: var(--yol-surface);
-  padding: 2rem;
-  border-radius: var(--yol-r-md);
-  box-shadow: var(--yol-shadow-sm);
-}
-
-.form-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-}
-
-.form-group label {
+/* FAB */
+.sd-fab {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  background: #1a5c3a;
+  color: #fff;
+  border-radius: 999px;
+  padding: 14px 22px;
+  font-size: 14px;
   font-weight: 600;
-  color: var(--yol-primary);
-  margin-bottom: 0.5rem;
-}
-
-.form-group.full-width {
-  grid-column: 1 / -1;
-}
-
-.form-group input,
-.form-group textarea,
-.form-group select {
-  padding: 0.75rem 1rem;
-}
-
-.calendar-card {
-  background: var(--yol-bg);
-  border: 1px solid var(--yol-border);
-  border-radius: var(--yol-r-md);
-  padding: 1rem;
-}
-
-.calendar-header {
-  display: flex;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
-  margin-bottom: 0.75rem;
-}
-
-.calendar-header h4 {
-  margin: 0;
-  text-transform: capitalize;
-  color: var(--yol-primary);
-}
-
-.calendar-nav {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
+  gap: 8px;
+  box-shadow: 0 8px 24px rgba(26,92,58,.32);
+  cursor: pointer;
+  z-index: 50;
   border: none;
-  background: var(--yol-primary-50);
-  color: var(--yol-primary);
-  font-size: 1.25rem;
-  cursor: pointer;
-  transition: background var(--yol-duration-normal) var(--yol-ease);
+  font-family: inherit;
+  transition: all .15s;
 }
 
-.calendar-nav:hover {
-  background: var(--yol-border);
-}
-
-.calendar-nav:disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
-  background: var(--yol-primary-50);
-}
-
-.calendar-legend {
-  display: flex;
-  gap: 1rem;
-  font-size: var(--yol-fs-sm);
-  color: var(--yol-text-muted);
-  margin-bottom: 0.75rem;
-}
-
-.calendar-legend .dot {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-radius: 50%;
-  display: inline-block;
-  margin-right: 0.35rem;
-  vertical-align: middle;
-}
-
-.dot.available { background: var(--yol-ia); }
-.dot.partial { background: var(--yol-warn); }
-.dot.full { background: var(--yol-cancel-text); }
-
-.calendar-weekdays,
-.calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 0.5rem;
-}
-
-.calendar-weekdays span {
-  text-align: center;
-  font-weight: 600;
-  color: var(--yol-text-muted);
-}
-
-.calendar-day {
-  position: relative;
-  background: var(--yol-surface);
-  border: 1px solid var(--yol-border);
-  border-radius: var(--yol-r);
-  padding: 0.65rem 0.5rem;
-  font-size: var(--yol-fs-body);
-  cursor: pointer;
-  color: var(--yol-text);
-  transition: all var(--yol-duration-normal) var(--yol-ease);
-}
-
-.calendar-day:hover {
-  box-shadow: var(--yol-shadow-sm);
-  border-color: var(--yol-accent);
-}
-
-.calendar-day.outside {
-  opacity: 0.35;
-  cursor: default;
-}
-
-.calendar-day.today {
-  border: 2px solid var(--yol-accent);
-}
-
-.calendar-day.selected {
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  box-shadow: var(--yol-shadow-md);
-}
-
-.calendar-day.unavailable {
-  background: var(--yol-cancel-surface);
-  color: var(--yol-cancel-text);
-  border-color: var(--yol-cancel-surface);
-  cursor: not-allowed;
-}
-
-.calendar-day.unavailable:hover {
-  box-shadow: none;
-}
-
-.selected-date-info {
-  margin-top: 0.75rem;
-  padding: 0.75rem 1rem;
-  background: var(--yol-ok-surface);
-  border-radius: var(--yol-r-md);
-  color: var(--yol-ok-text);
-  font-size: var(--yol-fs-body);
-  border: 1px solid var(--yol-border);
-}
-
-.time-slots {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
-  gap: 0.6rem;
-  margin-top: 0.75rem;
-}
-
-.time-slots.disabled {
-  opacity: 0.4;
-  pointer-events: none;
-}
-
-.slot-button {
-  border: 1px solid var(--yol-border);
-  border-radius: var(--yol-r);
-  padding: 0.75rem 0.5rem;
-  background: var(--yol-surface);
-  color: var(--yol-text);
-  font-weight: 600;
-  cursor: pointer;
-  transition: all var(--yol-duration-normal) var(--yol-ease);
-}
-
-.slot-button:hover {
-  box-shadow: var(--yol-shadow-sm);
-  border-color: var(--yol-accent);
-}
-
-.slot-button.selected {
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  border-color: transparent;
-  box-shadow: var(--yol-shadow-md);
-}
-
-.slot-button.booked {
-  background: var(--yol-bg);
-  color: var(--yol-text-subtle);
-  border-style: dashed;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.helper-text {
-  margin-top: 0.5rem;
-  color: var(--yol-text-muted);
-  font-size: var(--yol-fs-sm);
-}
-
-.helper-text.warning {
-  color: var(--yol-cancel-text);
+.sd-fab:hover {
+  background: #144a2e;
+  box-shadow: 0 10px 28px rgba(26,92,58,.4);
+  transform: translateY(-1px);
 }
 
 /* Responsive */
 @media (max-width: 768px) {
-  .header-content {
-    flex-direction: column;
-    gap: 1rem;
-    text-align: center;
+  .sd-sidebar {
+    display: none;
   }
 
-  .dashboard-nav {
-    overflow-x: auto;
-    padding: 0 1rem;
+  .sd-header {
+    padding: 16px 20px 14px;
   }
 
-  .nav-button {
-    padding: 1rem 1.5rem;
-    white-space: nowrap;
-  }
-
-  .section-header {
-    flex-direction: column;
-    gap: 1rem;
-    align-items: flex-start;
-  }
-
-  .quick-stats {
-    grid-template-columns: 1fr;
-  }
-
-  .cards-grid {
-    grid-template-columns: 1fr;
+  .sd-content {
+    padding: 16px 20px 80px;
   }
 }
-
-/* Pre-evaluacion IA - Modal */
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1rem;
-}
-
-.modal-content {
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  width: 100%;
-  max-width: 600px;
-  max-height: 90vh;
-  overflow-y: auto;
-  box-shadow: var(--yol-shadow-lg);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.5rem;
-  border-bottom: 1px solid var(--yol-border);
-}
-
-.modal-header h2 {
-  margin: 0;
-  color: var(--yol-primary);
-  font-size: 1.5rem;
-}
-
-.close-btn {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: var(--yol-text-subtle);
-  cursor: pointer;
-  width: 2rem;
-  height: 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  transition: all var(--yol-duration-normal) var(--yol-ease);
-}
-
-.close-btn:hover {
-  background: var(--yol-bg);
-  color: var(--yol-text);
-}
-
-.modal-body {
-  padding: 1.5rem;
-}
-
-.cita-info {
-  background: var(--yol-ok-surface);
-  padding: 1rem;
-  border-radius: var(--yol-r-md);
-  margin-bottom: 1.5rem;
-}
-
-.cita-info p {
-  margin: 0;
-  color: var(--yol-ok-text);
-}
-
-.progress-bar {
-  height: 8px;
-  background: var(--yol-border);
-  border-radius: var(--yol-r-pill);
-  overflow: hidden;
-  margin-bottom: 0.5rem;
-}
-
-.progress-fill {
-  height: 100%;
-  background: var(--yol-primary);
-  transition: width 0.3s ease;
-}
-
-.progress-text {
-  text-align: center;
-  color: var(--yol-text-muted);
-  font-size: var(--yol-fs-body);
-  margin-bottom: 1.5rem;
-}
-
-.pregunta-container {
-  margin-bottom: 2rem;
-}
-
-.pregunta-text {
-  font-size: 1.2rem;
-  color: var(--yol-text);
-  margin-bottom: 1.5rem;
-  line-height: 1.5;
-}
-
-.opciones-grid {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.opcion-btn {
-  padding: 1rem 1.25rem;
-  border: 2px solid var(--yol-border);
-  border-radius: var(--yol-r);
-  background: var(--yol-surface);
-  cursor: pointer;
-  text-align: left;
-  font-size: var(--yol-fs-body);
-  transition: all var(--yol-duration-normal) var(--yol-ease);
-}
-
-.opcion-btn:hover {
-  border-color: var(--yol-accent);
-  background: var(--yol-primary-50);
-}
-
-.opcion-btn.selected {
-  border-color: var(--yol-accent);
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-}
-
-.modal-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: flex-end;
-  margin-top: 2rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--yol-border);
-}
-
-.btn-ia-submit {
-  background: var(--yol-ia) !important;
-}
-
-.btn-ia-submit:hover {
-  opacity: 0.88;
-}
-
-/* Resultado de pre-evaluacion */
-.resultado-container {
-  text-align: center;
-}
-
-.resultado-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.5rem;
-}
-
-.resultado-header h3 {
-  margin: 0;
-  color: var(--yol-primary);
-}
-
-.confianza-badge {
-  padding: 0.5rem 1rem;
-  border-radius: var(--yol-r-pill);
-  font-weight: 600;
-  font-size: var(--yol-fs-body);
-}
-
-.confianza-alta {
-  background: var(--yol-ok-surface);
-  color: var(--yol-ok-text);
-}
-
-.confianza-media {
-  background: var(--yol-warn-surface);
-  color: var(--yol-warn-text);
-}
-
-.confianza-baja {
-  background: var(--yol-cancel-surface);
-  color: var(--yol-cancel-text);
-}
-
-.confianza-muy-baja {
-  background: var(--yol-ia-soft);
-  color: var(--yol-ia-text);
-}
-
-.diagnostico-principal {
-  background: var(--yol-primary-50);
-  padding: 1.5rem;
-  border-radius: var(--yol-r-md);
-  margin-bottom: 1.5rem;
-}
-
-.diagnostico-principal h4 {
-  margin: 0;
-  color: var(--yol-primary);
-  font-size: 1.3rem;
-}
-
-.sintomas-detectados,
-.posibles-enfermedades,
-.recomendacion {
-  margin-bottom: 1.5rem;
-  text-align: left;
-}
-
-.sintomas-detectados h5,
-.posibles-enfermedades h5,
-.recomendacion h5 {
-  color: var(--yol-text-muted);
-  margin-bottom: 0.75rem;
-}
-
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.tag {
-  background: var(--yol-ia-soft);
-  color: var(--yol-ia);
-  padding: 0.4rem 0.8rem;
-  border-radius: var(--yol-r-pill);
-  font-size: var(--yol-fs-sm);
-}
-
-.posibles-enfermedades ul {
-  margin: 0;
-  padding-left: 1.5rem;
-  color: var(--yol-text-muted);
-}
-
-.posibles-enfermedades li {
-  margin-bottom: 0.5rem;
-}
-
-.recomendacion p {
-  background: var(--yol-warn-surface);
-  padding: 1rem;
-  border-radius: var(--yol-r-md);
-  color: var(--yol-warn-text);
-  line-height: 1.6;
-}
-
-.alert.info {
-  background: var(--yol-ia-soft);
-  border-left-color: var(--yol-ia);
-  color: var(--yol-ia-text);
-}
-
-/* Boton IA en citas */
-.btn-ia {
-  background: var(--yol-ia);
-  color: var(--yol-surface);
-  border: none;
-  padding: 0.6rem 1.25rem;
-  border-radius: var(--yol-r);
-  cursor: pointer;
-  font-weight: 600;
-  font-family: var(--yol-font);
-  transition: opacity var(--yol-duration-normal) var(--yol-ease);
-  margin-left: 0.5rem;
-}
-
-.btn-ia:hover:not(:disabled) {
-  opacity: 0.88;
-}
-
-.btn-ia:disabled {
-  background: var(--yol-border);
-  color: var(--yol-text-subtle);
-  cursor: not-allowed;
-}
-
-/* Responsive modal */
-@media (max-width: 768px) {
-  .modal-content {
-    max-height: 95vh;
-  }
-
-  .modal-actions {
-    flex-direction: column;
-  }
-
-  .modal-actions button {
-    width: 100%;
-  }
-
-  .resultado-header {
-    flex-direction: column;
-    gap: 1rem;
-    text-align: center;
-  }
-}
-
-/* Chat IA Pre-evaluacion */
-.chat-modal {
-  display: flex;
-  flex-direction: column;
-  height: 82vh;
-  max-height: 680px;
-  overflow: hidden;
-}
-
-.chat-modal .modal-header {
-  flex-shrink: 0;
-}
-
-.modal-subtitle {
-  margin: 2px 0 0;
-  font-size: var(--yol-fs-cap);
-  color: var(--yol-text-muted);
-  font-weight: 400;
-}
-
-.chat-messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  background: var(--yol-bg);
-}
-
-.chat-bubble {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  max-width: 82%;
-  animation: fadeInMsg 0.2s ease;
-}
-
-@keyframes fadeInMsg {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-.chat-bubble.assistant { align-self: flex-start; }
-.chat-bubble.user { align-self: flex-end; flex-direction: row-reverse; }
-
-.bubble-avatar { font-size: 22px; flex-shrink: 0; line-height: 1; }
-
-.bubble-content {
-  padding: 10px 14px;
-  border-radius: var(--yol-r-md);
-  font-size: var(--yol-fs-body);
-  line-height: 1.55;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.chat-bubble.assistant .bubble-content {
-  background: var(--yol-surface);
-  color: var(--yol-text);
-  border-bottom-left-radius: var(--yol-r-sm);
-  box-shadow: var(--yol-shadow-xs);
-}
-
-.chat-bubble.user .bubble-content {
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  border-bottom-right-radius: var(--yol-r-sm);
-}
-
-.typing-dots {
-  display: flex;
-  gap: 5px;
-  align-items: center;
-  padding: 12px 16px;
-}
-
-.typing-dots span {
-  width: 8px; height: 8px;
-  border-radius: 50%;
-  background: var(--yol-text-subtle);
-  animation: typingBounce 1.3s infinite ease-in-out;
-}
-
-.typing-dots span:nth-child(2) { animation-delay: 0.2s; }
-.typing-dots span:nth-child(3) { animation-delay: 0.4s; }
-
-@keyframes typingBounce {
-  0%, 80%, 100% { transform: scale(0.75); opacity: 0.4; }
-  40%           { transform: scale(1.1);  opacity: 1; }
-}
-
-.chat-error {
-  flex-shrink: 0;
-  padding: 10px 16px;
-  background: var(--yol-cancel-surface);
-  color: var(--yol-cancel-text);
-  font-size: var(--yol-fs-sm);
-  border-top: 1px solid var(--yol-cancel-surface);
-}
-
-.chat-input-area {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  border-top: 1px solid var(--yol-border);
-  background: var(--yol-surface);
-}
-
-.chat-input {
-  flex: 1;
-  padding: 10px 16px;
-  border: 1.5px solid var(--yol-border);
-  border-radius: var(--yol-r-pill);
-  font-size: var(--yol-fs-body);
-  outline: none;
-  transition: border-color var(--yol-duration-normal);
-  background: var(--yol-bg);
-  font-family: var(--yol-font);
-}
-
-.chat-input:focus { border-color: var(--yol-accent); background: var(--yol-surface); }
-.chat-input:disabled { color: var(--yol-text-subtle); cursor: not-allowed; }
-
-.btn-send {
-  width: 42px; height: 42px;
-  border-radius: 50%;
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  border: none;
-  cursor: pointer;
-  font-size: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: opacity var(--yol-duration-normal);
-  flex-shrink: 0;
-}
-
-.btn-send:disabled { background: var(--yol-border); cursor: not-allowed; }
-.btn-send:hover:not(:disabled) { opacity: 0.88; }
-
-.chat-finalizar-hint {
-  flex-shrink: 0;
-  padding: 6px 16px;
-  background: var(--yol-primary-50);
-  border-top: 1px solid var(--yol-border);
-  text-align: right;
-}
-
-.btn-finalizar {
-  background: none;
-  border: 1.5px solid var(--yol-accent);
-  color: var(--yol-ok-text);
-  padding: 6px 14px;
-  border-radius: var(--yol-r-pill);
-  font-size: var(--yol-fs-cap);
-  cursor: pointer;
-  font-family: var(--yol-font);
-  transition: background var(--yol-duration-normal);
-}
-
-.btn-finalizar:hover {
-  background: var(--yol-primary-50);
-}
-
-.stat-card-alert {
-  border-left: 4px solid var(--yol-warn);
-  background: var(--yol-warn-surface);
-}
-
-.btn-ia-inicio {
-  margin-top: 8px;
-  background: none;
-  border: 1.5px solid var(--yol-accent);
-  color: var(--yol-ok-text);
-  padding: 5px 12px;
-  border-radius: var(--yol-r-pill);
-  font-size: var(--yol-fs-cap);
-  cursor: pointer;
-  font-family: var(--yol-font);
-  transition: background var(--yol-duration-normal);
-  display: inline-block;
-}
-
-.btn-ia-inicio:hover {
-  background: var(--yol-primary-50);
-}
-
-/* Slots mejorados */
-.slots-wrapper { margin-top: 0.75rem; }
-.slots-wrapper.disabled { opacity: 0.4; pointer-events: none; }
-.slots-legend {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  font-size: var(--yol-fs-cap);
-  color: var(--yol-text-muted);
-  margin-bottom: 0.75rem;
-}
-.leg-dot {
-  display: inline-block;
-  width: 12px; height: 12px;
-  border-radius: var(--yol-r-sm);
-  margin-right: 3px;
-  vertical-align: middle;
-}
-.leg-dot.free { background: var(--yol-surface); border: 1px solid var(--yol-border); }
-.leg-dot.selected-dot { background: var(--yol-primary); }
-.leg-dot.booked-dot { background: var(--yol-bg); border: 1px dashed var(--yol-text-subtle); }
-.slots-group { margin-bottom: 1rem; }
-.slots-period {
-  display: block;
-  font-size: var(--yol-fs-cap);
-  font-weight: 700;
-  color: var(--yol-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.5rem;
-}
-
-/* Foto de perfil */
-.foto-perfil-wrap {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  padding: 1.25rem 1.5rem;
-  box-shadow: var(--yol-shadow-xs);
-  margin-bottom: 1.5rem;
-  max-width: 900px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.foto-perfil-avatar {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  overflow: hidden;
-  background: var(--yol-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  border: 3px solid var(--yol-primary-50);
-}
-
-.foto-perfil-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.foto-perfil-initials {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--yol-surface);
-  text-transform: uppercase;
-}
-
-.foto-perfil-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.btn-cambiar-foto {
-  display: inline-block;
-  background: var(--yol-primary-50);
-  border: 1px solid var(--yol-accent);
-  border-radius: var(--yol-r);
-  padding: 0.45rem 1rem;
-  font-size: var(--yol-fs-sm);
-  font-weight: 600;
-  color: var(--yol-ok-text);
-  cursor: pointer;
-  transition: background var(--yol-duration-normal);
-}
-
-.btn-cambiar-foto:hover { background: var(--yol-ok-surface); }
-.btn-cambiar-foto.loading { opacity: 0.7; cursor: not-allowed; }
-
-.foto-msg {
-  font-size: var(--yol-fs-cap);
-  color: var(--yol-accent);
-}
-
-.foto-msg.error { color: var(--yol-cancel-text); }
-
-/* Perfil medico */
-.perfil-section {
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-.perfil-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
-  margin-bottom: 2rem;
-}
-
-@media (max-width: 700px) {
-  .perfil-grid { grid-template-columns: 1fr; }
-}
-
-.perfil-card {
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  padding: 1.5rem;
-  box-shadow: var(--yol-shadow-xs);
-}
-
-.perfil-card h3 {
-  color: var(--yol-primary);
-  font-size: var(--yol-fs-body);
-  margin: 0 0 1rem;
-  border-bottom: 2px solid var(--yol-primary-50);
-  padding-bottom: 0.5rem;
-}
-
-.perfil-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 2px solid var(--yol-primary-50);
-  padding-bottom: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.perfil-card-header h3 {
-  border-bottom: none;
-  padding-bottom: 0;
-  margin: 0;
-}
-
-.btn-edit {
-  background: none;
-  border: 1px solid var(--yol-primary);
-  color: var(--yol-primary);
-  border-radius: var(--yol-r);
-  padding: 0.2rem 0.75rem;
-  font-size: var(--yol-fs-cap);
-  cursor: pointer;
-  transition: background var(--yol-duration-normal);
-}
-
-.btn-edit:hover {
-  background: var(--yol-primary-50);
-}
-
-.form-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--yol-border);
-  border-radius: var(--yol-r);
-  font-size: var(--yol-fs-body);
-  box-sizing: border-box;
-  transition: border-color var(--yol-duration-normal);
-  font-family: var(--yol-font);
-}
-
-.form-input:focus {
-  outline: none;
-  border-color: var(--yol-primary);
-}
-
-.form-actions {
-  display: flex;
-  gap: 0.75rem;
-  margin-top: 1rem;
-}
-
-.perfil-item {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 0.75rem;
-}
-
-.perfil-item label {
-  font-size: var(--yol-fs-label);
-  font-weight: 600;
-  color: var(--yol-text-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.2rem;
-}
-
-.perfil-item span {
-  font-size: var(--yol-fs-body);
-  color: var(--yol-text);
-}
-
-.perfil-label {
-  font-size: var(--yol-fs-label);
-  font-weight: 600;
-  color: var(--yol-text-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.15rem;
-}
-
-.form-select {
-  border: 1px solid var(--yol-border);
-  border-radius: var(--yol-r);
-  padding: 0.5rem 0.75rem;
-  font-size: var(--yol-fs-body);
-  color: var(--yol-text);
-  background: var(--yol-surface);
-  transition: border-color var(--yol-duration-normal);
-  font-family: var(--yol-font);
-}
-
-.form-select:focus {
-  outline: none;
-  border-color: var(--yol-primary);
-}
-
-.perfil-form-card {
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  padding: 1.5rem;
-  box-shadow: var(--yol-shadow-xs);
-  grid-column: 1 / -1;
-}
-
-.perfil-form-card h3 {
-  color: var(--yol-primary);
-  font-size: var(--yol-fs-body);
-  margin: 0 0 1rem;
-  border-bottom: 2px solid var(--yol-primary-50);
-  padding-bottom: 0.5rem;
-}
-
-.perfil-form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-@media (max-width: 700px) {
-  .perfil-form-row { grid-template-columns: 1fr; }
-  .perfil-form-card { grid-column: auto; }
-}
-
-.btn-guardar-perfil {
-  background: var(--yol-primary);
-  color: var(--yol-surface);
-  border: none;
-  border-radius: var(--yol-r);
-  padding: 0.6rem 1.5rem;
-  font-size: var(--yol-fs-body);
-  font-weight: 600;
-  cursor: pointer;
-  margin-top: 0.5rem;
-  transition: opacity var(--yol-duration-normal);
-  font-family: var(--yol-font);
-}
-
-.btn-guardar-perfil:hover { opacity: 0.9; }
-.btn-guardar-perfil:disabled { opacity: 0.6; cursor: not-allowed; }
-
-/* Historial medico */
-.historial-lista {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-.historial-item {
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  box-shadow: var(--yol-shadow-xs);
-  overflow: hidden;
-}
-
-.historial-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 1.25rem;
-  cursor: pointer;
-  user-select: none;
-  transition: background var(--yol-duration-fast);
-}
-
-.historial-header:hover { background: var(--yol-primary-50); }
-
-.historial-fecha {
-  font-weight: 700;
-  color: var(--yol-primary);
-  font-size: var(--yol-fs-body);
-}
-
-.historial-motivo {
-  flex: 1;
-  padding: 0 1rem;
-  color: var(--yol-text-muted);
-  font-size: var(--yol-fs-body);
-}
-
-.historial-clave {
-  font-size: var(--yol-fs-cap);
-  color: var(--yol-text-subtle);
-  margin-right: 0.75rem;
-}
-
-.historial-toggle {
-  color: var(--yol-text-subtle);
-  font-size: var(--yol-fs-sm);
-  transition: transform var(--yol-duration-normal);
-}
-
-.historial-detalle {
-  border-top: 1px solid var(--yol-primary-50);
-  padding: 1rem 1.25rem;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  background: var(--yol-bg);
-}
-
-@media (max-width: 600px) {
-  .historial-detalle { grid-template-columns: 1fr; }
-}
-
-.detalle-bloque h4 {
-  font-size: var(--yol-fs-cap);
-  font-weight: 700;
-  color: var(--yol-text-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin: 0 0 0.4rem;
-}
-
-.detalle-bloque p {
-  font-size: var(--yol-fs-body);
-  color: var(--yol-text);
-  margin: 0;
-  line-height: 1.5;
-}
-
-.no-historial {
-  text-align: center;
-  color: var(--yol-text-subtle);
-  padding: 2rem;
-  background: var(--yol-surface);
-  border-radius: var(--yol-r-md);
-  box-shadow: var(--yol-shadow-xs);
-}
-
-/* Sesiones activas */
-.sesiones-lista { list-style: none; padding: 0; margin: 0.5rem 0 0; display: flex; flex-direction: column; gap: 0.5rem; }
-.sesion-item { display: flex; align-items: center; justify-content: space-between; padding: 0.6rem 0.75rem; background: var(--yol-bg); border-radius: var(--yol-r-md); border: 1px solid var(--yol-border); }
-.sesion-info { display: flex; flex-direction: column; gap: 0.15rem; }
-.sesion-nombre { font-weight: 600; font-size: var(--yol-fs-body); color: var(--yol-text); }
-.sesion-badge { font-size: var(--yol-fs-label); background: var(--yol-ok-surface); color: var(--yol-ok-text); padding: 0.1rem 0.4rem; border-radius: var(--yol-r-sm); width: fit-content; }
-.sesion-detalle { font-size: var(--yol-fs-cap); color: var(--yol-text-subtle); }
-.btn-danger-sm { padding: 0.3rem 0.7rem; background: var(--yol-cancel-surface); color: var(--yol-cancel-text); border: none; border-radius: var(--yol-r); font-size: var(--yol-fs-cap); cursor: pointer; transition: background var(--yol-duration-normal); flex-shrink: 0; }
-.btn-danger-sm:hover { background: var(--yol-cancel-surface); }
-.empty-state-small { font-size: var(--yol-fs-body); color: var(--yol-text-subtle); padding: 0.5rem 0; }

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.css
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.css
@@ -288,3 +288,11 @@
     padding: 16px 20px 80px;
   }
 }
+
+/* ── Dark mode ──────────────────────────────────── */
+:host-context(.dark) .sd-app    { background: #0a1a10; }
+:host-context(.dark) .sd-main   { background: #0a1a10; }
+:host-context(.dark) .sd-header { background: #111d14; border-color: #1e3a22; }
+:host-context(.dark) .sd-crumb  { color: #5a7a6a; }
+:host-context(.dark) .sd-title  { color: #e8f5ee; }
+:host-context(.dark) .sd-title span { color: #86efac; }

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.html
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.html
@@ -1,61 +1,92 @@
-<div class="student-dashboard">
-  <!-- Encabezado -->
-  <header class="dashboard-header">
-    <div class="header-content">
-      <h1>Consultorio Médico</h1>
-      <div class="user-info">
-        <span>Bienvenido, {{ studentName }}</span>
-        <button class="theme-toggle-btn" (click)="themeService.toggle()"
-          [title]="themeService.isDark ? 'Modo claro' : 'Modo oscuro'">
-          {{ themeService.isDark ? '☀️' : '🌙' }}
-        </button>
-        <button class="logout-btn" (click)="logout()">Cerrar Sesión</button>
+<div class="sd-app">
+
+  <!-- Sidebar -->
+  <aside class="sd-sidebar">
+    <div class="sd-brand">
+      <div class="sd-brand-logo">Y</div>
+      <div>
+        <b>Yoltec</b>
+        <span>Servicio médico</span>
       </div>
     </div>
 
-    <!-- Navegación -->
-    <nav class="dashboard-nav">
-      <button [class.active]="activeSection === 'inicio'" (click)="setActiveSection('inicio')" class="nav-button">Inicio</button>
-      <button [class.active]="activeSection === 'citas'" (click)="setActiveSection('citas')" class="nav-button">Citas</button>
-      <button [class.active]="activeSection === 'bitacora'" (click)="setActiveSection('bitacora')" class="nav-button">Bitácora</button>
-      <button [class.active]="activeSection === 'recetas'" (click)="setActiveSection('recetas')" class="nav-button">Recetas</button>
-      <button [class.active]="activeSection === 'perfil'" (click)="setActiveSection('perfil')" class="nav-button">Mi Perfil Médico</button>
-      <button [class.active]="activeSection === 'pre-evaluacion'" (click)="setActiveSection('pre-evaluacion')" class="nav-button">Pre-evaluacion IA</button>
-      <button [class.active]="activeSection === 'historial'" (click)="setActiveSection('historial')" class="nav-button">Historial</button>
+    <nav class="sd-nav">
+      <a class="sd-nav-item" [class.active]="activeSection === 'inicio'" (click)="setActiveSection('inicio')">
+        <span class="sd-nav-ic">▦</span>Inicio
+      </a>
+      <a class="sd-nav-item" [class.active]="activeSection === 'citas'" (click)="setActiveSection('citas')">
+        <span class="sd-nav-ic">⊞</span>Mis citas
+      </a>
+      <a class="sd-nav-item" [class.active]="activeSection === 'pre-evaluacion'" (click)="setActiveSection('pre-evaluacion')">
+        <span class="sd-nav-ic">◔</span>Pre-evaluación IA
+      </a>
+      <a class="sd-nav-item" [class.active]="activeSection === 'recetas'" (click)="setActiveSection('recetas')">
+        <span class="sd-nav-ic">℞</span>Recetas
+      </a>
+      <a class="sd-nav-item" [class.active]="activeSection === 'perfil'" (click)="setActiveSection('perfil')">
+        <span class="sd-nav-ic">◉</span>Mi perfil
+      </a>
     </nav>
-  </header>
 
-  <!-- Contenido Principal -->
-  <main class="dashboard-content">
-    <app-student-dashboard-inicio
-      *ngIf="activeSection === 'inicio'"
-      (navegarACitas)="setActiveSection('citas')"
-      (navegarAAgendar)="setActiveSection('citas')"
-      (navegarARecetas)="setActiveSection('recetas')">
-    </app-student-dashboard-inicio>
+    <div class="sd-user">
+      <div class="sd-avatar">{{ studentName.charAt(0) }}</div>
+      <div>
+        <b>{{ studentName }}</b>
+        <button class="sd-logout" (click)="logout()">Cerrar sesión</button>
+      </div>
+    </div>
+  </aside>
 
-    <app-mis-citas
-      *ngIf="activeSection === 'citas'">
-    </app-mis-citas>
+  <!-- Área principal -->
+  <div class="sd-main">
 
-    <app-sd-bitacora
-      *ngIf="activeSection === 'bitacora'">
-    </app-sd-bitacora>
+    <!-- Header -->
+    <div class="sd-header">
+      <div class="sd-header-row">
+        <div>
+          <div class="sd-crumb">{{ activeSection | uppercase }}</div>
+          <h1 class="sd-title" *ngIf="activeSection === 'inicio'">
+            Bienvenida, <span>{{ studentName }}</span>
+          </h1>
+          <h1 class="sd-title" *ngIf="activeSection === 'citas'">Mis citas</h1>
+          <h1 class="sd-title" *ngIf="activeSection === 'recetas'">Mis recetas</h1>
+          <h1 class="sd-title" *ngIf="activeSection === 'perfil'">Mi perfil</h1>
+          <h1 class="sd-title" *ngIf="activeSection === 'pre-evaluacion'">Pre-evaluación IA</h1>
+          <h1 class="sd-title" *ngIf="activeSection === 'historial'">Historial</h1>
+        </div>
+        <div class="sd-header-actions">
+          <button class="sd-btn-ghost"
+            (click)="themeService.toggle()"
+            [title]="themeService.isDark ? 'Modo claro' : 'Modo oscuro'">
+            {{ themeService.isDark ? '☀' : '🌙' }}
+          </button>
+          <button class="sd-btn-primary" (click)="setActiveSection('citas')">
+            <span class="sd-plus">＋</span>Nueva cita
+          </button>
+        </div>
+      </div>
+    </div>
 
-    <app-sd-recetas
-      *ngIf="activeSection === 'recetas'">
-    </app-sd-recetas>
+    <!-- Contenido -->
+    <div class="sd-content">
+      <app-student-dashboard-inicio
+        *ngIf="activeSection === 'inicio'"
+        (navegarACitas)="setActiveSection('citas')"
+        (navegarAAgendar)="setActiveSection('citas')"
+        (navegarARecetas)="setActiveSection('recetas')">
+      </app-student-dashboard-inicio>
 
-    <app-sd-perfil
-      *ngIf="activeSection === 'perfil'">
-    </app-sd-perfil>
+      <app-mis-citas *ngIf="activeSection === 'citas'"></app-mis-citas>
+      <app-sd-recetas *ngIf="activeSection === 'recetas'"></app-sd-recetas>
+      <app-sd-perfil *ngIf="activeSection === 'perfil'"></app-sd-perfil>
+      <app-pre-evaluacion-ia *ngIf="activeSection === 'pre-evaluacion'"></app-pre-evaluacion-ia>
+      <app-sd-historial *ngIf="activeSection === 'historial'"></app-sd-historial>
+    </div>
+  </div>
 
-    <app-pre-evaluacion-ia
-      *ngIf="activeSection === 'pre-evaluacion'">
-    </app-pre-evaluacion-ia>
+  <!-- FAB -->
+  <button class="sd-fab" (click)="setActiveSection('citas')">
+    <span class="sd-plus">＋</span>Nueva cita
+  </button>
 
-    <app-sd-historial
-      *ngIf="activeSection === 'historial'">
-    </app-sd-historial>
-  </main>
 </div>

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.html
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.html
@@ -52,7 +52,6 @@
           <h1 class="sd-title" *ngIf="activeSection === 'recetas'">Mis recetas</h1>
           <h1 class="sd-title" *ngIf="activeSection === 'perfil'">Mi perfil</h1>
           <h1 class="sd-title" *ngIf="activeSection === 'pre-evaluacion'">Pre-evaluación IA</h1>
-          <h1 class="sd-title" *ngIf="activeSection === 'historial'">Historial</h1>
         </div>
         <div class="sd-header-actions">
           <button class="sd-btn-ghost"
@@ -69,18 +68,17 @@
 
     <!-- Contenido -->
     <div class="sd-content">
-      <app-student-dashboard-inicio
+      <app-sd-inicio
         *ngIf="activeSection === 'inicio'"
         (navegarACitas)="setActiveSection('citas')"
         (navegarAAgendar)="setActiveSection('citas')"
         (navegarARecetas)="setActiveSection('recetas')">
-      </app-student-dashboard-inicio>
+      </app-sd-inicio>
 
       <app-mis-citas *ngIf="activeSection === 'citas'"></app-mis-citas>
       <app-sd-recetas *ngIf="activeSection === 'recetas'"></app-sd-recetas>
       <app-sd-perfil *ngIf="activeSection === 'perfil'"></app-sd-perfil>
       <app-pre-evaluacion-ia *ngIf="activeSection === 'pre-evaluacion'"></app-pre-evaluacion-ia>
-      <app-sd-historial *ngIf="activeSection === 'historial'"></app-sd-historial>
     </div>
   </div>
 

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.html
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.html
@@ -82,9 +82,5 @@
     </div>
   </div>
 
-  <!-- FAB -->
-  <button class="sd-fab" (click)="setActiveSection('citas')">
-    <span class="sd-plus">＋</span>Nueva cita
-  </button>
 
 </div>

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
@@ -9,7 +9,6 @@ import { SdInicioComponent } from './components/sd-inicio/sd-inicio.component';
 import { MisCitasComponent } from '../mis-citas/mis-citas.component';
 import { SdRecetasComponent } from './components/sd-recetas/sd-recetas.component';
 import { SdPerfilComponent } from './components/sd-perfil/sd-perfil.component';
-import { SdHistorialComponent } from './components/sd-historial/sd-historial.component';
 import { PreEvaluacionIaComponent } from '../pre-evaluacion-ia/pre-evaluacion-ia.component';
 
 @Component({
@@ -21,7 +20,6 @@ import { PreEvaluacionIaComponent } from '../pre-evaluacion-ia/pre-evaluacion-ia
     MisCitasComponent,
     SdRecetasComponent,
     SdPerfilComponent,
-    SdHistorialComponent,
     PreEvaluacionIaComponent,
   ],
   templateUrl: './student-dashboard.component.html',

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
@@ -3,13 +3,9 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { AuthService } from '../../../services/auth.service';
-import { CitaService } from '../../../services/cita.service';
-import { RecetaService } from '../../../services/receta.service';
-import { PreEvaluacionIAService } from '../../../services/pre-evaluacion-ia.service';
-import { PerfilMedicoService } from '../../../services/perfil-medico.service';
 import { ThemeService } from '../../../services/theme.service';
 
-import { StudentDashboardInicioComponent } from '../dashboard/student-dashboard.component';
+import { SdInicioComponent } from './components/sd-inicio/sd-inicio.component';
 import { MisCitasComponent } from '../mis-citas/mis-citas.component';
 import { SdRecetasComponent } from './components/sd-recetas/sd-recetas.component';
 import { SdPerfilComponent } from './components/sd-perfil/sd-perfil.component';
@@ -21,7 +17,7 @@ import { PreEvaluacionIaComponent } from '../pre-evaluacion-ia/pre-evaluacion-ia
   standalone: true,
   imports: [
     CommonModule,
-    StudentDashboardInicioComponent,
+    SdInicioComponent,
     MisCitasComponent,
     SdRecetasComponent,
     SdPerfilComponent,
@@ -41,11 +37,6 @@ export class StudentDashboardComponent implements OnInit, OnDestroy {
     private router: Router,
     private authService: AuthService,
     public themeService: ThemeService,
-    // Servicios inyectados para pasarlos a hijos vía DI automática
-    private citaService: CitaService,
-    private recetaService: RecetaService,
-    private preEvaluacionIAService: PreEvaluacionIAService,
-    private perfilMedicoService: PerfilMedicoService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
@@ -4,7 +4,6 @@ import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { AuthService } from '../../../services/auth.service';
 import { CitaService } from '../../../services/cita.service';
-import { BitacoraService } from '../../../services/bitacora.service';
 import { RecetaService } from '../../../services/receta.service';
 import { PreEvaluacionIAService } from '../../../services/pre-evaluacion-ia.service';
 import { PerfilMedicoService } from '../../../services/perfil-medico.service';
@@ -12,7 +11,6 @@ import { ThemeService } from '../../../services/theme.service';
 
 import { StudentDashboardInicioComponent } from '../dashboard/student-dashboard.component';
 import { MisCitasComponent } from '../mis-citas/mis-citas.component';
-import { SdBitacoraComponent } from './components/sd-bitacora/sd-bitacora.component';
 import { SdRecetasComponent } from './components/sd-recetas/sd-recetas.component';
 import { SdPerfilComponent } from './components/sd-perfil/sd-perfil.component';
 import { SdHistorialComponent } from './components/sd-historial/sd-historial.component';
@@ -25,7 +23,6 @@ import { PreEvaluacionIaComponent } from '../pre-evaluacion-ia/pre-evaluacion-ia
     CommonModule,
     StudentDashboardInicioComponent,
     MisCitasComponent,
-    SdBitacoraComponent,
     SdRecetasComponent,
     SdPerfilComponent,
     SdHistorialComponent,
@@ -46,7 +43,6 @@ export class StudentDashboardComponent implements OnInit, OnDestroy {
     public themeService: ThemeService,
     // Servicios inyectados para pasarlos a hijos vía DI automática
     private citaService: CitaService,
-    private bitacoraService: BitacoraService,
     private recetaService: RecetaService,
     private preEvaluacionIAService: PreEvaluacionIAService,
     private perfilMedicoService: PerfilMedicoService,

--- a/frontend/src/app/services/theme.service.ts
+++ b/frontend/src/app/services/theme.service.ts
@@ -6,20 +6,20 @@ export class ThemeService {
 
   constructor() {
     if (localStorage.getItem(this.key) === 'true') {
-      document.body.classList.add('dark-mode');
+      document.documentElement.classList.add('dark');
     }
   }
 
   get isDark(): boolean {
-    return document.body.classList.contains('dark-mode');
+    return document.documentElement.classList.contains('dark');
   }
 
   toggle(): void {
     if (this.isDark) {
-      document.body.classList.remove('dark-mode');
+      document.documentElement.classList.remove('dark');
       localStorage.setItem(this.key, 'false');
     } else {
-      document.body.classList.add('dark-mode');
+      document.documentElement.classList.add('dark');
       localStorage.setItem(this.key, 'true');
     }
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -86,6 +86,31 @@
   --yol-duration-slow:   250ms;
 }
 
+/* Dark mode — token overrides globales */
+html.dark {
+  --yol-bg:              #0a1a10;
+  --yol-surface:         #111d14;
+  --yol-border:          #2a4030;
+
+  --yol-text:            #e8f5ee;
+  --yol-text-muted:      #5a7a6a;
+  --yol-text-subtle:     #3d5c4a;
+
+  --yol-primary-50:      #0f2d1a;
+
+  --yol-ok-surface:      #0f2d1a;
+  --yol-ok-text:         #86efac;
+  --yol-warn-surface:    #2d1800;
+  --yol-warn-text:       #f9a825;
+  --yol-cancel-surface:  #2d0a0a;
+  --yol-cancel-text:     #ef9a9a;
+  --yol-pending-surface: #1a2e25;
+  --yol-pending-text:    #86efac;
+
+  --yol-ia-soft:         #0d1b3e;
+  --yol-ia-text:         #93c5fd;
+}
+
 html, body {
   margin: 0;
   padding: 0;

--- a/mobile/design-reference-dark/Agendar Cita Mobile.html
+++ b/mobile/design-reference-dark/Agendar Cita Mobile.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Agendar cita</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee;
+    --warn:#f59e0b; --warn-bg:#fffbeb;
+    --danger:#dc2626; --danger-bg:#fef2f2;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#f1f5f9;
+    --bg:#fff;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+  .phone{width:390px;height:844px;background:#1a1d27;border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;background:var(--primary);position:relative;z-index:1}
+
+  .hd{background:var(--primary);color:#fff;padding:6px 14px 14px;display:flex;align-items:center;gap:8px}
+  .hd .back{width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer}
+  .hd .back:hover{background:rgba(255,255,255,.08)}
+  .hd h1{flex:1;margin:0;font-size:16px;font-weight:600;text-align:center;letter-spacing:-.2px;padding-right:36px}
+
+  .scroll{flex:1;overflow-y:auto;padding:18px 16px 0;display:flex;flex-direction:column;gap:22px;position:relative}
+
+  .sec-t{font-size:15px;font-weight:600;color:#f9fafb;margin:0}
+
+  /* Calendar */
+  .mo-nav{display:flex;align-items:center;justify-content:space-between;margin-top:12px;margin-bottom:10px}
+  .mo-nav .mo{font-size:14px;font-weight:600;letter-spacing:-.2px}
+  .mo-nav button{width:30px;height:30px;border:0;background:transparent;color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;border-radius:6px}
+  .mo-nav button:hover{background:#0f1117}
+
+  .cal{display:grid;grid-template-columns:repeat(7,1fr);gap:6px}
+  .dh{font-size:12px;color:var(--text-subtle);text-align:center;padding:4px 0;font-weight:500}
+  .cell{height:44px;border-radius:8px;display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;background:#1a1d27;gap:2px}
+  .cell .n{font-size:14px;font-weight:600;color:var(--text);line-height:1;font-variant-numeric:tabular-nums}
+  .cell .ds{font-size:9.5px;font-weight:600;line-height:1}
+  .cell.ok .ds{color:var(--primary)}
+  .cell.lo .ds{color:var(--warn)}
+  .cell.fl{background:var(--danger-bg)}
+  .cell.fl .n{color:var(--danger)}
+  .cell.fl .ds{color:var(--danger)}
+  .cell.past{cursor:not-allowed}
+  .cell.past .n{color:#d1d5db}
+  .cell.sel{background:var(--primary)}
+  .cell.sel .n{color:#fff;font-weight:700}
+  .cell.sel .ds{color:rgba(255,255,255,.85)}
+  .dot{width:4px;height:4px;border-radius:50%;background:currentColor;display:none}
+
+  .legend{display:flex;justify-content:center;gap:8px;font-size:11px;color:var(--text-muted);font-weight:500;margin-top:10px;align-items:center}
+  .legend .it{display:flex;align-items:center;gap:5px}
+  .legend .sep{color:var(--text-subtle)}
+  .legend .d{width:6px;height:6px;border-radius:50%}
+  .legend .d.ok{background:var(--primary)}
+  .legend .d.lo{background:var(--warn)}
+  .legend .d.fl{background:var(--danger)}
+
+  /* Slots */
+  .slots-hd{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:4px}
+  .slots-hd .sub{font-size:13px;color:var(--primary);font-weight:600;text-transform:capitalize}
+  .note{font-size:11px;color:var(--text-muted);margin:0 0 10px;font-weight:500}
+  .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .slot{border:1px solid var(--border);border-radius:8px;padding:10px 8px;text-align:center;cursor:pointer;background:#1a1d27;transition:all .12s}
+  .slot:active{transform:scale(.97)}
+  .slot .h{font-size:15px;font-weight:600;color:var(--text);font-variant-numeric:tabular-nums;line-height:1.1}
+  .slot .e{font-size:12px;color:var(--text-muted);font-weight:500;margin-top:2px;font-variant-numeric:tabular-nums}
+  .slot.sel{background:var(--primary);border-color:var(--primary)}
+  .slot.sel .h{color:#fff}
+  .slot.sel .e{color:rgba(255,255,255,.8)}
+
+  /* Bottom sheet */
+  .sheet-bg{position:absolute;left:0;right:0;bottom:0;top:0;background:rgba(15,23,42,.35);z-index:8}
+  .sheet{position:absolute;left:0;right:0;bottom:0;background:#1a1d27;border-radius:22px 22px 0 0;padding:10px 18px 28px;box-shadow:0 -10px 30px rgba(0,0,0,.18);z-index:9;display:flex;flex-direction:column;gap:12px;height:55%}
+  .handle{width:40px;height:4px;background:#d1d5db;border-radius:99px;align-self:center;margin-bottom:6px}
+  .sheet h2{margin:0;font-size:18px;font-weight:700;letter-spacing:-.3px}
+  .summary{font-size:13.5px;color:var(--primary);font-weight:500;text-transform:capitalize}
+  .sep{height:1px;background:var(--border-soft)}
+  .lbl{font-size:12.5px;color:var(--text-muted);font-weight:500}
+  textarea{width:100%;border:1px solid var(--border);border-radius:10px;padding:12px;font:500 13px 'Inter',sans-serif;color:var(--text);resize:none;outline:none;min-height:64px}
+  textarea:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.12)}
+  .req{font-size:11px;color:var(--danger);font-weight:500;margin-top:-6px}
+  .confirm{width:100%;height:52px;border:0;border-radius:10px;background:var(--primary);color:#fff;font:600 14px 'Inter',sans-serif;cursor:pointer;letter-spacing:.1px}
+  .confirm:hover{background:var(--primary-600)}
+  .cancel-link{text-align:center;font-size:13px;color:var(--text-muted);font-weight:500;cursor:pointer;padding:6px 0}
+</style>
+</head>
+<body>
+<div class="phone">
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div class="back">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
+    </div>
+    <h1>Agendar cita</h1>
+  </div>
+
+  <div class="scroll">
+    <!-- Calendar -->
+    <div>
+      <h3 class="sec-t">Selecciona un día</h3>
+      <div class="mo-nav">
+        <button><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <span class="mo">Mayo 2026</span>
+        <button><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg></button>
+      </div>
+      <div class="cal">
+        <div class="dh">L</div><div class="dh">M</div><div class="dh">X</div><div class="dh">J</div><div class="dh">V</div><div class="dh">S</div><div class="dh">D</div>
+
+        <div class="cell past"><span class="n">27</span></div>
+        <div class="cell past"><span class="n">28</span></div>
+        <div class="cell past"><span class="n">29</span></div>
+        <div class="cell past"><span class="n">30</span></div>
+        <div class="cell fl"><span class="n">1</span><span class="ds">Sin disp</span></div>
+        <div class="cell past"><span class="n">2</span></div>
+        <div class="cell past"><span class="n">3</span></div>
+
+        <div class="cell past"><span class="n">4</span></div>
+        <div class="cell past"><span class="n">5</span></div>
+        <div class="cell past"><span class="n">6</span></div>
+        <div class="cell past"><span class="n">7</span></div>
+        <div class="cell past"><span class="n">8</span></div>
+        <div class="cell past"><span class="n">9</span></div>
+        <div class="cell past"><span class="n">10</span></div>
+
+        <div class="cell past"><span class="n">11</span></div>
+        <div class="cell past"><span class="n">12</span></div>
+        <div class="cell sel"><span class="n">13</span><span class="ds">8 disp</span></div>
+        <div class="cell ok"><span class="n">14</span><span class="ds">6 disp</span></div>
+        <div class="cell fl"><span class="n">15</span><span class="ds">Sin disp</span></div>
+        <div class="cell lo"><span class="n">16</span><span class="ds">2 disp</span></div>
+        <div class="cell past"><span class="n">17</span></div>
+
+        <div class="cell ok"><span class="n">18</span><span class="ds">9 disp</span></div>
+        <div class="cell ok"><span class="n">19</span><span class="ds">7 disp</span></div>
+        <div class="cell lo"><span class="n">20</span><span class="ds">3 disp</span></div>
+        <div class="cell ok"><span class="n">21</span><span class="ds">8 disp</span></div>
+        <div class="cell fl"><span class="n">22</span><span class="ds">Sin disp</span></div>
+        <div class="cell ok"><span class="n">23</span><span class="ds">5 disp</span></div>
+        <div class="cell past"><span class="n">24</span></div>
+
+        <div class="cell ok"><span class="n">25</span><span class="ds">9 disp</span></div>
+        <div class="cell ok"><span class="n">26</span><span class="ds">8 disp</span></div>
+        <div class="cell lo"><span class="n">27</span><span class="ds">2 disp</span></div>
+        <div class="cell ok"><span class="n">28</span><span class="ds">6 disp</span></div>
+        <div class="cell ok"><span class="n">29</span><span class="ds">7 disp</span></div>
+        <div class="cell ok"><span class="n">30</span><span class="ds">4 disp</span></div>
+        <div class="cell past"><span class="n">31</span></div>
+      </div>
+      <div class="legend">
+        <div class="it"><span class="d ok"></span>Disponible</div>
+        <span class="sep">·</span>
+        <div class="it"><span class="d lo"></span>Poca</div>
+        <span class="sep">·</span>
+        <div class="it"><span class="d fl"></span>Lleno</div>
+      </div>
+    </div>
+
+    <!-- Slots -->
+    <div>
+      <div class="slots-hd">
+        <h3 class="sec-t">Horarios disponibles</h3>
+        <span class="sub">Martes, 13 de mayo</span>
+      </div>
+      <p class="note">Solo se muestran horarios libres</p>
+      <div class="grid3">
+        <div class="slot"><div class="h">08:00</div><div class="e">– 08:15</div></div>
+        <div class="slot"><div class="h">08:30</div><div class="e">– 08:45</div></div>
+        <div class="slot sel"><div class="h">09:00</div><div class="e">– 09:15</div></div>
+        <div class="slot"><div class="h">09:30</div><div class="e">– 09:45</div></div>
+        <div class="slot"><div class="h">10:00</div><div class="e">– 10:15</div></div>
+        <div class="slot"><div class="h">10:30</div><div class="e">– 10:45</div></div>
+        <div class="slot"><div class="h">11:00</div><div class="e">– 11:15</div></div>
+        <div class="slot"><div class="h">11:30</div><div class="e">– 11:45</div></div>
+        <div class="slot"><div class="h">12:00</div><div class="e">– 12:15</div></div>
+      </div>
+      <div style="height:16px"></div>
+    </div>
+  </div>
+
+  <!-- Bottom sheet -->
+  <div class="sheet-bg"></div>
+  <div class="sheet">
+    <div class="handle"></div>
+    <h2>Confirmar cita</h2>
+    <div class="summary">Martes 13 mayo · 09:00 – 09:15</div>
+    <div class="sep"></div>
+    <div class="lbl">Motivo de la cita</div>
+    <textarea placeholder="Describe brevemente el motivo..."></textarea>
+    <div class="req">* Campo obligatorio</div>
+    <button class="confirm">Confirmar cita</button>
+    <div class="cancel-link">Cancelar</div>
+  </div>
+</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/design-reference-dark/Inicio Mobile.html
+++ b/mobile/design-reference-dark/Inicio Mobile.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Inicio</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e; --primary-50:#e8f5ee;
+    --danger:#dc2626;
+    --bg:#f8fafc; --surface:#fff;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#eef2f0;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+  .phone{width:390px;height:844px;background:var(--bg);border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;background:var(--primary);position:relative;z-index:1}
+
+  .hd{background:var(--primary);color:#fff;padding:8px 20px 22px;display:flex;align-items:flex-start;justify-content:space-between}
+  .hd h1{margin:0;font-size:20px;font-weight:700;letter-spacing:-.3px;line-height:1.2}
+  .hd .sub{font-size:12.5px;color:rgba(255,255,255,.75);font-weight:500;margin-top:4px;text-transform:capitalize}
+  .bell{width:36px;height:36px;border-radius:50%;background:rgba(255,255,255,.12);display:flex;align-items:center;justify-content:center;flex-shrink:0}
+
+  .scroll{flex:1;overflow-y:auto;padding:16px 16px 88px;display:flex;flex-direction:column;gap:20px}
+
+  /* Next appointment card */
+  .next{background:#1a1d27;border-radius:12px;padding:16px;border-left:3px solid var(--primary);box-shadow:0 1px 3px rgba(0,0,0,.04),0 1px 2px rgba(0,0,0,.06)}
+  .badge{display:inline-flex;font-size:11px;font-weight:600;color:var(--primary);background:var(--primary-50);padding:3px 9px;border-radius:999px;letter-spacing:.4px}
+  .next .date{font-size:15px;font-weight:600;margin-top:10px;text-transform:capitalize}
+  .next .time{font-size:22px;font-weight:700;color:var(--primary);margin-top:2px;letter-spacing:-.5px;font-variant-numeric:tabular-nums}
+  .next .reason{font-size:13px;color:var(--text-muted);margin-top:4px}
+  .sep{height:1px;background:var(--border-soft);margin:14px -16px 0}
+  .cancel{display:block;text-align:right;font-size:13px;color:var(--danger);font-weight:500;margin-top:10px;padding:2px 0;text-decoration:none;cursor:pointer}
+
+  .row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .stat{background:#1a1d27;border-radius:10px;padding:14px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+  .stat .l{font-size:11.5px;color:var(--text-muted);font-weight:500;letter-spacing:.2px}
+  .stat .v{font-size:24px;font-weight:700;margin-top:4px;letter-spacing:-.5px;line-height:1}
+
+  .sec-t{font-size:12px;font-weight:600;color:var(--text-muted);letter-spacing:.6px;text-transform:uppercase;margin:0 0 12px}
+
+  .qg{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .q{aspect-ratio:1;border-radius:12px;padding:18px;display:flex;flex-direction:column;justify-content:space-between;box-shadow:0 1px 2px rgba(0,0,0,.05);cursor:pointer;transition:transform .12s}
+  .q:active{transform:scale(.98)}
+  .q .ic{width:34px;height:34px}
+  .q .lbl{font-size:14px;font-weight:600;color:var(--text);line-height:1.2}
+  .q1{background:#f0faf4}
+  .q1 .ic{color:var(--primary)}
+  .q2{background:#f0f4ff}
+  .q2 .ic{color:#3850c2}
+  .q3{background:#fffbf0}
+  .q3 .ic{color:#a86f00}
+  .q4{background:#f3f3f4}
+  .q4 .ic{color:#3b4252}
+
+  /* Bottom nav */
+  .nav{position:absolute;bottom:0;left:0;right:0;background:#1a1d27;border-top:1px solid var(--border);display:flex;justify-content:space-around;padding:8px 6px 22px}
+  .nav a{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;color:var(--text-subtle);font-size:10.5px;font-weight:500;text-decoration:none;cursor:pointer}
+  .nav a svg{width:22px;height:22px;stroke-width:1.8}
+  .nav a.active{color:var(--primary);font-weight:600}
+  .home-ind{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:134px;height:5px;border-radius:99px;background:#111;z-index:10}
+</style>
+</head>
+<body>
+<div class="phone">
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div>
+      <h1>Hola, Nestor</h1>
+      <div class="sub">Lunes, 11 de mayo 2026</div>
+    </div>
+    <div class="bell">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 16v-5a6 6 0 1 0-12 0v5l-1.5 2h15L18 16Z"/><path d="M10 20a2 2 0 0 0 4 0"/></svg>
+    </div>
+  </div>
+
+  <div class="scroll">
+    <!-- Next appointment -->
+    <div class="next">
+      <span class="badge">CONFIRMADA</span>
+      <div class="date">Miércoles, 14 de mayo</div>
+      <div class="time">10:30 hrs</div>
+      <div class="reason">Control de presión</div>
+      <div class="sep"></div>
+      <a class="cancel">Cancelar cita</a>
+    </div>
+
+    <!-- Mini stats -->
+    <div class="row">
+      <div class="stat"><div class="l">Citas este mes</div><div class="v">3</div></div>
+      <div class="stat"><div class="l">Última visita</div><div class="v">29 abr</div></div>
+    </div>
+
+    <!-- Quick access -->
+    <div>
+      <h3 class="sec-t">Acceso rápido</h3>
+      <div class="qg">
+        <div class="q q1">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+          <div class="lbl">Agendar cita</div>
+        </div>
+        <div class="q q2">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/><rect x="10" y="10" width="4" height="4"/></svg>
+          <div class="lbl">Pre-evaluación IA</div>
+        </div>
+        <div class="q q3">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <div class="lbl">Mis recetas</div>
+        </div>
+        <div class="q q4">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+          <div class="lbl">Mi perfil</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bottom nav -->
+  <div class="nav">
+    <a class="active">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+      Inicio
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+      Citas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+      IA
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+      Recetas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+      Perfil
+    </a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/design-reference-dark/Login Mobile.html
+++ b/mobile/design-reference-dark/Login Mobile.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Iniciar sesión</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-600:#144a2e;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144;
+    --soft:#f9fafb;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+
+  /* Phone frame for preview */
+  .phone{width:390px;height:844px;background:#1a1d27;border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{position:absolute;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;z-index:6}
+  .statusbar .ico{display:flex;gap:6px;font-size:12px}
+
+  /* Top green zone — 35% */
+  .top{flex:35;background:var(--primary);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:60px 28px 56px;position:relative}
+  .logo{width:64px;height:64px;border-radius:16px;background:#1a1d27;display:flex;align-items:center;justify-content:center;color:var(--primary);font-weight:700;font-size:34px;letter-spacing:-1px;line-height:1;font-family:'Inter',sans-serif;margin-bottom:18px;box-shadow:0 6px 20px rgba(0,0,0,.18)}
+  .name{color:#fff;font-size:30px;font-weight:700;letter-spacing:-.6px;margin:0}
+  .tagline{color:rgba(255,255,255,.75);font-size:13px;font-weight:500;margin-top:6px;letter-spacing:.1px}
+
+  /* Bottom white zone — 65% */
+  .bot{flex:65;background:#1a1d27;border-radius:28px 28px 0 0;margin-top:-28px;padding:28px 28px 22px;display:flex;flex-direction:column;position:relative;z-index:2}
+  h1{margin:0;font-size:22px;font-weight:700;letter-spacing:-.3px;color:var(--text)}
+  .sub{margin-top:6px;font-size:13.5px;color:var(--text-muted);font-weight:500}
+
+  form{margin-top:24px;display:flex;flex-direction:column;gap:14px}
+  .field{display:flex;flex-direction:column;gap:7px}
+  label{font-size:12px;font-weight:600;color:#374151;letter-spacing:.1px}
+  .inp{position:relative}
+  .inp input{width:100%;border:1px solid var(--border);border-radius:10px;padding:14px 16px;font-size:15px;font-weight:500;color:var(--text);background:#1a1d27;outline:none;transition:border-color .15s,box-shadow .15s;font-family:inherit;font-variant-numeric:tabular-nums}
+  .inp input:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(26,92,58,.12)}
+  .inp input::placeholder{color:var(--text-subtle);font-weight:400}
+  .inp .eye{position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--text-muted);cursor:pointer;width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:6px;font-size:15px}
+  .inp .eye:hover{background:var(--soft);color:var(--text)}
+
+  .login{margin-top:22px;width:100%;border:none;background:var(--primary);color:#fff;font-size:15px;font-weight:600;padding:14px;border-radius:10px;cursor:pointer;transition:background .15s;font-family:inherit;letter-spacing:.1px}
+  .login:hover{background:var(--primary-600)}
+
+  .forgot{margin-top:18px;text-align:center;font-size:13px;color:var(--primary);font-weight:600;text-decoration:none;cursor:pointer}
+  .forgot:hover{text-decoration:underline}
+
+  .foot{margin-top:auto;text-align:center;padding-top:18px;font-size:11px;color:var(--text-subtle);font-weight:500;letter-spacing:.2px}
+  .home-ind{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:134px;height:5px;border-radius:99px;background:#111}
+</style>
+</head>
+<body>
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="statusbar"><span>9:41</span><span class="ico">●●●●● ●</span></div>
+
+    <div class="top">
+      <div class="logo">Y</div>
+      <h2 class="name">Yoltec</h2>
+      <div class="tagline">Servicio médico universitario</div>
+    </div>
+
+    <div class="bot">
+      <h1>Iniciar sesión</h1>
+      <div class="sub">Ingresa con tu cuenta institucional</div>
+
+      <form onsubmit="return false">
+        <div class="field">
+          <label for="ctrl">Número de control</label>
+          <div class="inp"><input id="ctrl" type="text" inputmode="numeric" value="22690495" placeholder="Ej. 22690495" autocomplete="username"/></div>
+        </div>
+        <div class="field">
+          <label for="nip">NIP</label>
+          <div class="inp">
+            <input id="nip" type="password" value="••••••" placeholder="••••••" autocomplete="current-password"/>
+            <button type="button" class="eye" id="eye" aria-label="Mostrar/ocultar NIP">◎</button>
+          </div>
+        </div>
+
+        <button type="submit" class="login">Iniciar sesión</button>
+      </form>
+
+      <a class="forgot">¿Olvidaste tu NIP?</a>
+
+      <div class="foot">Yoltec · TecNM Campus Valle de México</div>
+    </div>
+
+    <div class="home-ind"></div>
+  </div>
+
+<script>
+  const nip = document.getElementById('nip');
+  const eye = document.getElementById('eye');
+  eye.addEventListener('click',()=>{
+    nip.type = nip.type==='password' ? 'text' : 'password';
+    eye.textContent = nip.type==='password' ? '◎' : '⊘';
+  });
+</script>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/design-reference-dark/Mi Perfil Mobile.html
+++ b/mobile/design-reference-dark/Mi Perfil Mobile.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mi Perfil</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-50:#e8f5ee;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#f3f4f6;
+    --bg:#f8fafc;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+  .phone{width:390px;height:844px;background:var(--bg);border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;background:var(--primary);position:relative;z-index:1}
+
+  /* Header */
+  .hd{background:var(--primary);color:#fff;padding:8px 20px 22px;display:flex;flex-direction:column;align-items:center;gap:10px}
+  .avatar{width:72px;height:72px;border-radius:50%;background:rgba(255,255,255,.15);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:24px;letter-spacing:.5px}
+  .name{font-size:18px;font-weight:700;letter-spacing:-.2px}
+  .meta{font-size:13px;color:rgba(255,255,255,.7);font-weight:400;margin-top:-6px}
+  .badge-active{font-size:11px;font-weight:500;padding:4px 10px;border-radius:99px;background:rgba(255,255,255,.15);color:#fff;display:inline-flex;align-items:center;gap:5px;margin-top:2px}
+  .badge-active::before{content:"";width:6px;height:6px;border-radius:50%;background:#86efac}
+
+  /* Tabs */
+  .tabs{background:#1a1d27;border-bottom:1px solid var(--border);display:flex}
+  .tab{flex:1;text-align:center;padding:12px 0;font-size:13px;font-weight:500;color:var(--text-muted);border-bottom:2px solid transparent;cursor:pointer}
+  .tab.active{color:var(--primary);font-weight:600;border-bottom-color:var(--primary)}
+
+  /* Content */
+  .content{flex:1;overflow-y:auto;background:var(--bg);padding-bottom:88px}
+
+  .edit-bar{display:flex;justify-content:flex-end;padding:14px 18px 6px}
+  .edit-btn{display:inline-flex;align-items:center;gap:6px;color:var(--primary);font-size:13px;font-weight:600;background:none;border:0;cursor:pointer;padding:4px 6px}
+  .edit-btn svg{width:14px;height:14px;stroke-width:1.8}
+
+  .section-title{font-size:11px;font-weight:600;color:var(--text-subtle);text-transform:uppercase;letter-spacing:.6px;margin:8px 22px 8px}
+
+  .card{background:#1a1d27;border-radius:12px;margin:0 16px;box-shadow:0 1px 3px rgba(0,0,0,.06);overflow:hidden}
+  .card + .section-title{margin-top:16px}
+
+  .row{padding:12px 16px;display:flex;flex-direction:column;gap:2px;border-bottom:1px solid var(--border-soft)}
+  .row:last-child{border-bottom:0}
+  .row .label{font-size:11px;color:var(--text-subtle);font-weight:400;text-transform:uppercase;letter-spacing:.4px}
+  .row .val{font-size:15px;color:var(--text);font-weight:500}
+
+  /* Bottom nav */
+  .nav{position:absolute;bottom:0;left:0;right:0;background:#1a1d27;border-top:1px solid var(--border);display:flex;justify-content:space-around;height:64px;padding:8px 6px;padding-bottom:18px}
+  .nav a{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;color:var(--text-subtle);font-size:10px;font-weight:500;text-decoration:none;cursor:pointer}
+  .nav a svg{width:22px;height:22px;stroke-width:1.8}
+  .nav a.active{color:var(--primary);font-weight:600}
+  .home-ind{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:134px;height:5px;border-radius:99px;background:#111;z-index:10}
+</style>
+</head>
+<body>
+<div class="phone">
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div class="avatar">NM</div>
+    <div class="name">Nestor Castillo</div>
+    <div class="meta">22690495 · Ing. Sistemas</div>
+    <div class="badge-active">Activo</div>
+  </div>
+
+  <div class="tabs">
+    <div class="tab active">Info médica</div>
+    <div class="tab">Recetas</div>
+    <div class="tab">Bitácora</div>
+  </div>
+
+  <div class="content">
+    <div class="edit-bar">
+      <button class="edit-btn">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20h4l10-10-4-4L4 16v4Z"/><path d="m13.5 6.5 4 4"/></svg>
+        Editar
+      </button>
+    </div>
+
+    <div class="section-title">Datos físicos</div>
+    <div class="card">
+      <div class="row"><span class="label">Tipo de sangre</span><span class="val">O+</span></div>
+      <div class="row"><span class="label">Peso</span><span class="val">68 kg</span></div>
+      <div class="row"><span class="label">Estatura</span><span class="val">175 cm</span></div>
+    </div>
+
+    <div class="section-title">Información médica</div>
+    <div class="card">
+      <div class="row"><span class="label">Alergias</span><span class="val">Ninguna conocida</span></div>
+      <div class="row"><span class="label">Enfermedades crónicas</span><span class="val">Ninguna</span></div>
+    </div>
+
+    <div class="section-title">Contacto de emergencia</div>
+    <div class="card">
+      <div class="row"><span class="label">Nombre</span><span class="val">María Bautista</span></div>
+      <div class="row"><span class="label">Teléfono</span><span class="val">55 1234 5678</span></div>
+    </div>
+
+    <div style="height:16px"></div>
+  </div>
+
+  <!-- Bottom nav -->
+  <div class="nav">
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+      Inicio
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+      Citas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+      IA
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+      Recetas
+    </a>
+    <a class="active">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+      Perfil
+    </a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/design-reference-dark/Mis Citas Mobile.html
+++ b/mobile/design-reference-dark/Mis Citas Mobile.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mis Citas</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-50:#e8f5ee;
+    --danger:#dc2626; --danger-bg:#fef2f2;
+    --gray-bg:#f3f4f6; --gray-text:#6b7280;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#f3f4f6;
+    --bg:#f8fafc;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px;gap:24px;flex-wrap:wrap}
+  .phone{width:390px;height:844px;background:var(--bg);border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;background:var(--primary);position:relative;z-index:1}
+
+  .hd{background:var(--primary);color:#fff;padding:8px 14px 14px;display:flex;align-items:center;gap:8px}
+  .hd .sp{width:36px;height:36px}
+  .hd h1{flex:1;margin:0;font-size:16px;font-weight:600;text-align:center;letter-spacing:-.2px}
+  .hd .add{width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer}
+  .hd .add:hover{background:rgba(255,255,255,.08)}
+
+  .tabs{background:#1a1d27;border-bottom:1px solid var(--border);display:flex;padding:0 12px;height:46px;align-items:flex-end}
+  .tab{flex:1;text-align:center;padding-bottom:10px;font-size:12.5px;font-weight:500;color:var(--text-muted);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px;display:flex;align-items:center;justify-content:center;gap:6px}
+  .tab.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+  .tab .ct{font-size:10.5px;font-weight:600;padding:1px 7px;border-radius:99px;background:var(--gray-bg);color:var(--gray-text);min-width:18px;text-align:center;font-variant-numeric:tabular-nums}
+  .tab.active .ct{background:var(--primary-50);color:var(--primary)}
+  .tab.prox .ct{background:var(--primary-50);color:var(--primary)}
+
+  .scroll{flex:1;overflow-y:auto;background:var(--bg);padding:16px 16px 88px;display:flex;flex-direction:column;gap:12px}
+
+  .card{background:#1a1d27;border-radius:12px;padding:16px;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+  .top{display:flex;align-items:center;justify-content:space-between;gap:12px}
+  .top .dt{font-size:14px;font-weight:600;color:var(--text);text-transform:capitalize}
+  .bd{font-size:11px;font-weight:600;padding:3px 8px;border-radius:99px;letter-spacing:.3px}
+  .bd-conf{background:var(--primary-50);color:var(--primary)}
+  .bd-pen{background:#fef3e0;color:#b45309}
+  .bd-at{background:var(--primary-50);color:var(--primary)}
+  .bd-can{background:var(--gray-bg);color:var(--gray-text)}
+  .bd-no{background:var(--danger-bg);color:var(--danger)}
+  .time{font-size:20px;font-weight:700;color:var(--primary);margin:6px 0 0;letter-spacing:-.5px;font-variant-numeric:tabular-nums}
+  .time.muted{color:var(--text-muted)}
+  .reason{font-size:13px;color:var(--text-muted);margin-top:2px}
+  .diag{font-size:12.5px;color:var(--text-subtle);margin-top:4px;line-height:1.4}
+  .diag b{color:var(--text-muted);font-weight:600}
+  .sep{height:1px;background:var(--border-soft);margin:12px -16px 0}
+  .cancel{display:block;text-align:right;font-size:13px;color:var(--danger);font-weight:500;margin-top:10px;padding:2px 0;text-decoration:none;cursor:pointer}
+
+  .frame-label{position:absolute;top:-26px;left:0;right:0;text-align:center;color:rgba(255,255,255,.55);font:600 11px 'Inter',sans-serif;letter-spacing:.5px;text-transform:uppercase}
+
+  /* Bottom nav */
+  .nav{position:absolute;bottom:0;left:0;right:0;background:#1a1d27;border-top:1px solid var(--border);display:flex;justify-content:space-around;height:64px;padding:8px 6px;padding-bottom:18px}
+  .nav a{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;color:var(--text-subtle);font-size:10px;font-weight:500;text-decoration:none;cursor:pointer}
+  .nav a svg{width:22px;height:22px;stroke-width:1.8}
+  .nav a.active{color:var(--primary);font-weight:600}
+  .home-ind{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:134px;height:5px;border-radius:99px;background:#111;z-index:10}
+</style>
+</head>
+<body>
+
+<!-- Variante: Próximas activa -->
+<div class="phone">
+  <div class="frame-label">Tab · Próximas</div>
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div class="sp"></div>
+    <h1>Mis Citas</h1>
+    <div class="add">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+    </div>
+  </div>
+
+  <div class="tabs">
+    <div class="tab active prox">Próximas<span class="ct">2</span></div>
+    <div class="tab">Pasadas</div>
+    <div class="tab">Canceladas</div>
+  </div>
+
+  <div class="scroll">
+    <div class="card">
+      <div class="top">
+        <div class="dt">Miércoles, 14 de mayo</div>
+        <span class="bd bd-conf">CONFIRMADA</span>
+      </div>
+      <div class="time">10:30 hrs</div>
+      <div class="reason">Control de presión · Dr. Omar Salas</div>
+      <div class="sep"></div>
+      <a class="cancel">Cancelar cita</a>
+    </div>
+
+    <div class="card">
+      <div class="top">
+        <div class="dt">Martes, 27 de mayo</div>
+        <span class="bd bd-pen">PENDIENTE</span>
+      </div>
+      <div class="time">09:00 hrs</div>
+      <div class="reason">Consulta de seguimiento · Dra. Ramírez</div>
+      <div class="sep"></div>
+      <a class="cancel">Cancelar cita</a>
+    </div>
+  </div>
+
+  <!-- Bottom nav -->
+  <div class="nav">
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+      Inicio
+    </a>
+    <a class="active">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+      Citas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+      IA
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+      Recetas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+      Perfil
+    </a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+
+<!-- Variante: Pasadas activa -->
+<div class="phone">
+  <div class="frame-label">Tab · Pasadas</div>
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div class="sp"></div>
+    <h1>Mis Citas</h1>
+    <div class="add">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+    </div>
+  </div>
+
+  <div class="tabs">
+    <div class="tab prox">Próximas<span class="ct">2</span></div>
+    <div class="tab active">Pasadas</div>
+    <div class="tab">Canceladas</div>
+  </div>
+
+  <div class="scroll">
+    <div class="card">
+      <div class="top">
+        <div class="dt">Jueves, 29 de abril</div>
+        <span class="bd bd-at">ATENDIDA</span>
+      </div>
+      <div class="time muted">11:00 hrs</div>
+      <div class="reason">Dolor de garganta · Dra. Ramírez</div>
+      <div class="diag"><b>Diagnóstico:</b> Faringitis aguda</div>
+    </div>
+
+    <div class="card">
+      <div class="top">
+        <div class="dt">Martes, 14 de abril</div>
+        <span class="bd bd-at">ATENDIDA</span>
+      </div>
+      <div class="time muted">10:30 hrs</div>
+      <div class="reason">Control general · Dr. Omar Salas</div>
+      <div class="diag"><b>Diagnóstico:</b> Sin hallazgos significativos</div>
+    </div>
+
+    <div class="card">
+      <div class="top">
+        <div class="dt">Jueves, 02 de abril</div>
+        <span class="bd bd-at">ATENDIDA</span>
+      </div>
+      <div class="time muted">13:20 hrs</div>
+      <div class="reason">Consulta nutricional · Dra. Cruz</div>
+    </div>
+  </div>
+
+  <div class="nav">
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>Inicio</a>
+    <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Citas</a>
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>IA</a>
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>Perfil</a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+
+<!-- Variante: Canceladas activa -->
+<div class="phone">
+  <div class="frame-label">Tab · Canceladas</div>
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div class="sp"></div>
+    <h1>Mis Citas</h1>
+    <div class="add">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+    </div>
+  </div>
+
+  <div class="tabs">
+    <div class="tab prox">Próximas<span class="ct">2</span></div>
+    <div class="tab">Pasadas</div>
+    <div class="tab active">Canceladas</div>
+  </div>
+
+  <div class="scroll">
+    <div class="card">
+      <div class="top">
+        <div class="dt">Viernes, 04 de abril</div>
+        <span class="bd bd-can">CANCELADA</span>
+      </div>
+      <div class="time muted">10:00 hrs</div>
+      <div class="reason">Cancelada por el alumno</div>
+    </div>
+
+    <div class="card">
+      <div class="top">
+        <div class="dt">Lunes, 24 de marzo</div>
+        <span class="bd bd-no">NO ASISTIÓ</span>
+      </div>
+      <div class="time muted">08:30 hrs</div>
+      <div class="reason">Revisión general · Dr. Salas</div>
+    </div>
+
+    <div class="card">
+      <div class="top">
+        <div class="dt">Miércoles, 12 de marzo</div>
+        <span class="bd bd-can">CANCELADA</span>
+      </div>
+      <div class="time muted">09:15 hrs</div>
+      <div class="reason">Cancelada por el doctor</div>
+    </div>
+  </div>
+
+  <div class="nav">
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>Inicio</a>
+    <a class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>Citas</a>
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>IA</a>
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>Recetas</a>
+    <a><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>Perfil</a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/design-reference-dark/Mis Recetas Mobile.html
+++ b/mobile/design-reference-dark/Mis Recetas Mobile.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Mis Recetas</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-50:#e8f5ee;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#2d3144; --border-soft:#f9fafb;
+    --bg:#f8fafc; --chip-bg:#f3f4f6;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+  .phone{width:390px;height:844px;background:var(--bg);border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;background:var(--primary);position:relative;z-index:1}
+
+  .hd{background:var(--primary);color:#fff;padding:10px 14px 16px;display:flex;align-items:center;justify-content:center}
+  .hd h1{margin:0;font-size:16px;font-weight:600;letter-spacing:-.2px}
+
+  .search-wrap{background:#1a1d27;padding:12px 16px}
+  .search{position:relative}
+  .search svg{position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-subtle)}
+  .search input{width:100%;height:40px;background:var(--chip-bg);border:0;border-radius:8px;padding:0 14px 0 38px;font:500 13.5px 'Inter',sans-serif;color:var(--text);outline:none}
+  .search input::placeholder{color:var(--text-subtle)}
+
+  .list{flex:1;overflow-y:auto;background:var(--bg);padding:16px 16px 88px;display:flex;flex-direction:column;gap:12px}
+
+  .card{background:#1a1d27;border-radius:12px;padding:16px;box-shadow:0 1px 3px rgba(0,0,0,.08);display:flex;flex-direction:column;gap:12px}
+
+  .row-top{display:flex;align-items:center;justify-content:space-between;gap:10px}
+  .date{display:inline-flex;background:var(--chip-bg);color:var(--text-muted);font-size:11px;font-weight:600;padding:4px 10px;border-radius:99px;letter-spacing:.3px;font-variant-numeric:tabular-nums}
+  .doc{font-size:12px;color:var(--text-muted);font-weight:500}
+
+  .sep{height:1px;background:var(--border-soft)}
+
+  .meds{display:flex;flex-direction:column;gap:8px}
+  .med{display:flex;align-items:flex-start;gap:8px;font-size:13.5px;line-height:1.4}
+  .med svg{width:14px;height:14px;color:var(--text-muted);flex-shrink:0;margin-top:3px;stroke-width:1.7}
+  .med .name{color:var(--text);font-weight:500}
+  .med .dose{color:var(--text-muted);font-weight:400}
+
+  .notes{font-size:12px;color:var(--text-subtle);font-style:italic;line-height:1.4}
+
+  .detail{display:flex;align-items:center;justify-content:flex-end;gap:4px;font-size:13px;color:var(--primary);font-weight:600;cursor:pointer;text-decoration:none}
+  .detail svg{width:14px;height:14px;stroke-width:2}
+
+  /* Bottom nav */
+  .nav{position:absolute;bottom:0;left:0;right:0;background:#1a1d27;border-top:1px solid var(--border);display:flex;justify-content:space-around;height:64px;padding:8px 6px;padding-bottom:18px}
+  .nav a{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;color:var(--text-subtle);font-size:10px;font-weight:500;text-decoration:none;cursor:pointer}
+  .nav a svg{width:22px;height:22px;stroke-width:1.8}
+  .nav a.active{color:var(--primary);font-weight:600}
+  .home-ind{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:134px;height:5px;border-radius:99px;background:#111;z-index:10}
+</style>
+</head>
+<body>
+<div class="phone">
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <h1>Mis Recetas</h1>
+  </div>
+
+  <div class="search-wrap">
+    <div class="search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+      <input placeholder="Buscar receta o medicamento...">
+    </div>
+  </div>
+
+  <div class="list">
+    <!-- Receta 1 -->
+    <div class="card">
+      <div class="row-top">
+        <span class="date">7 ABR 2026</span>
+        <span class="doc">Dr. Omar Salas</span>
+      </div>
+      <div class="sep"></div>
+      <div class="meds">
+        <div class="med">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <span><span class="name">Paracetamol 500 mg</span><span class="dose"> — 1 tableta cada 8 hrs</span></span>
+        </div>
+        <div class="med">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <span><span class="name">Amoxicilina 500 mg</span><span class="dose"> — 1 cápsula cada 12 hrs</span></span>
+        </div>
+      </div>
+      <div class="notes">Tomar con alimentos. Suspender si hay reacciones.</div>
+      <div class="sep"></div>
+      <a class="detail">Ver detalle completo
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+      </a>
+    </div>
+
+    <!-- Receta 2 -->
+    <div class="card">
+      <div class="row-top">
+        <span class="date">22 MAR 2026</span>
+        <span class="doc">Dra. Laura Ramírez</span>
+      </div>
+      <div class="sep"></div>
+      <div class="meds">
+        <div class="med">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <span><span class="name">Loratadina 10 mg</span><span class="dose"> — 1 tableta cada 24 hrs</span></span>
+        </div>
+        <div class="med">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <span><span class="name">Mometasona spray nasal</span><span class="dose"> — 2 aplicaciones al día</span></span>
+        </div>
+      </div>
+      <div class="notes">Evitar conducir si presenta somnolencia.</div>
+      <div class="sep"></div>
+      <a class="detail">Ver detalle completo
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+      </a>
+    </div>
+
+    <!-- Receta 3 -->
+    <div class="card">
+      <div class="row-top">
+        <span class="date">14 FEB 2026</span>
+        <span class="doc">Dr. Javier Mendoza</span>
+      </div>
+      <div class="sep"></div>
+      <div class="meds">
+        <div class="med">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <span><span class="name">Ibuprofeno 400 mg</span><span class="dose"> — 1 tableta cada 6 hrs</span></span>
+        </div>
+        <div class="med">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+          <span><span class="name">Omeprazol 20 mg</span><span class="dose"> — 1 cápsula en ayunas</span></span>
+        </div>
+      </div>
+      <div class="notes">Mantener reposo relativo durante 48 horas.</div>
+      <div class="sep"></div>
+      <a class="detail">Ver detalle completo
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+      </a>
+    </div>
+  </div>
+
+  <!-- Bottom nav -->
+  <div class="nav">
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+      Inicio
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+      Citas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+      IA
+    </a>
+    <a class="active">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+      Recetas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+      Perfil
+    </a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab,.cal-nav button{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/design-reference-dark/Pre-evaluación IA Mobile.html
+++ b/mobile/design-reference-dark/Pre-evaluación IA Mobile.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Yoltec · Pre-evaluación IA</title>
+<link rel="icon" href="assets/favicon.ico">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  @font-face{font-family:'Inter';font-weight:400;src:url('fonts/Inter-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:500;src:url('fonts/Inter-Medium.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:600;src:url('fonts/Inter-SemiBold.woff2') format('woff2')}
+  @font-face{font-family:'Inter';font-weight:700;src:url('fonts/Inter-Bold.woff2') format('woff2')}
+  :root{
+    --primary:#1a5c3a; --primary-50:#e8f5ee;
+    --warn-bg:#fffbeb; --warn:#92400e;
+    --text:#111827; --text-muted:#6b7280; --text-subtle:#9ca3af;
+    --border:#e5e7eb; --border-soft:#f3f4f6;
+    --bg:#f8fafc;
+  }
+  *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+  html,body{margin:0;padding:0;min-height:100vh;background:#0f172a}
+  body{font-family:'Inter',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;justify-content:center;padding:24px}
+  .phone{width:390px;height:844px;background:var(--bg);border-radius:44px;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,.35);position:relative;display:flex;flex-direction:column;border:8px solid #111}
+  .notch{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:120px;height:28px;background:#111;border-radius:0 0 18px 18px;z-index:5}
+  .statusbar{height:44px;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-size:14px;font-weight:600;color:#fff;background:var(--primary);position:relative;z-index:1}
+
+  .hd{background:var(--primary);color:#fff;padding:6px 14px 14px;display:flex;align-items:flex-start;gap:8px}
+  .hd .back{width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;flex-shrink:0;margin-top:2px}
+  .hd .back:hover{background:rgba(255,255,255,.08)}
+  .hd-c{flex:1;text-align:center;padding:6px 0 0}
+  .hd h1{margin:0;font-size:16px;font-weight:600;letter-spacing:-.2px}
+  .hd .sub{font-size:11px;color:rgba(255,255,255,.7);font-weight:500;margin-top:2px}
+  .hd .sp{width:36px;flex-shrink:0}
+
+  .chat{flex:1;overflow-y:auto;background:var(--bg);padding:14px 16px 18px 16px;display:flex;flex-direction:column;gap:12px}
+
+  .ai{display:flex;gap:8px;align-items:flex-end;max-width:88%;align-self:flex-start}
+  .av{width:28px;height:28px;border-radius:50%;background:#e5e7eb;display:flex;align-items:center;justify-content:center;color:#6b7280;flex-shrink:0}
+  .av svg{width:14px;height:14px;stroke-width:1.8}
+  .bub-ai{background:#fff;border:1px solid var(--border);border-radius:16px 16px 16px 0;padding:10px 12px;font-size:14px;line-height:1.4;color:var(--text);box-shadow:0 1px 2px rgba(0,0,0,.03)}
+
+  .me{align-self:flex-end;max-width:75%}
+  .bub-me{background:var(--primary-50);border-radius:16px 16px 0 16px;padding:10px 12px;font-size:14px;line-height:1.4;color:var(--text)}
+
+  /* Result card */
+  .result{align-self:stretch;background:#fff;border-left:3px solid var(--primary);border-radius:10px;padding:14px;box-shadow:0 1px 3px rgba(0,0,0,.05);display:flex;flex-direction:column;gap:10px}
+  .result h3{margin:0;font-size:14px;font-weight:600;letter-spacing:-.1px}
+  .dx{display:flex;flex-direction:column;gap:9px;margin-top:2px}
+  .dx-row{display:flex;flex-direction:column;gap:5px}
+  .dx-top{display:flex;justify-content:space-between;align-items:baseline}
+  .dx-name{font-size:13px;color:var(--text);font-weight:500}
+  .dx-pct{font-size:13px;color:var(--text);font-weight:600;font-variant-numeric:tabular-nums}
+  .bar{height:4px;background:var(--primary-50);border-radius:99px;overflow:hidden}
+  .bar > i{display:block;height:100%;background:var(--primary);border-radius:99px}
+  .sep{height:1px;background:var(--border-soft)}
+  .warn{display:inline-flex;align-self:flex-start;background:var(--warn-bg);color:var(--warn);font-size:11px;font-weight:500;padding:5px 9px;border-radius:6px;line-height:1.3}
+  .btn-out{align-self:flex-end;background:#fff;color:var(--primary);font:600 12px 'Inter',sans-serif;border:1px solid var(--primary);border-radius:6px;padding:7px 12px;cursor:pointer}
+  .btn-out:hover{background:var(--primary-50)}
+
+  /* Input */
+  .input-area{background:#fff;border-top:1px solid var(--border);padding:12px 16px;display:flex;align-items:center;gap:10px}
+  .input-area input{flex:1;background:var(--border-soft);border:0;border-radius:20px;padding:10px 16px;font:500 14px 'Inter',sans-serif;color:var(--text);outline:none;height:40px}
+  .input-area input::placeholder{color:var(--text-subtle)}
+  .send{width:40px;height:40px;border-radius:50%;background:var(--primary);color:#fff;border:0;display:flex;align-items:center;justify-content:center;cursor:pointer;flex-shrink:0}
+
+  /* Bottom nav */
+  .nav{background:#fff;border-top:1px solid var(--border);display:flex;justify-content:space-around;height:64px;padding:8px 6px;padding-bottom:18px}
+  .nav a{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;color:var(--text-subtle);font-size:10px;font-weight:500;text-decoration:none;cursor:pointer}
+  .nav a svg{width:22px;height:22px;stroke-width:1.8}
+  .nav a.active{color:var(--primary);font-weight:600}
+  .home-ind{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:134px;height:5px;border-radius:99px;background:#111;z-index:10}
+</style>
+</head>
+<body>
+<div class="phone">
+  <div class="notch"></div>
+  <div class="statusbar"><span>9:41</span><span style="font-size:12px">●●●●● ●</span></div>
+
+  <div class="hd">
+    <div class="back">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
+    </div>
+    <div class="hd-c">
+      <h1>Pre-evaluación IA</h1>
+      <div class="sub">No reemplaza una consulta médica</div>
+    </div>
+    <div class="sp"></div>
+  </div>
+
+  <div class="chat">
+    <div class="ai">
+      <div class="av">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/><rect x="10" y="10" width="4" height="4"/></svg>
+      </div>
+      <div class="bub-ai">Hola, soy tu asistente médico. ¿Qué síntomas presentas hoy?</div>
+    </div>
+
+    <div class="me"><div class="bub-me">Tengo dolor de garganta y fiebre desde ayer</div></div>
+
+    <div class="ai">
+      <div class="av">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/><rect x="10" y="10" width="4" height="4"/></svg>
+      </div>
+      <div class="bub-ai">Entiendo. ¿Tienes dificultad al tragar o inflamación visible en la garganta?</div>
+    </div>
+
+    <div class="me"><div class="bub-me">Sí, me cuesta tragar bastante</div></div>
+
+    <div class="ai">
+      <div class="av">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/><rect x="10" y="10" width="4" height="4"/></svg>
+      </div>
+      <div class="bub-ai">Basándome en tus síntomas, estos son los posibles diagnósticos:</div>
+    </div>
+
+    <div class="result">
+      <h3>Posibles diagnósticos</h3>
+      <div class="dx">
+        <div class="dx-row">
+          <div class="dx-top"><span class="dx-name">Faringitis aguda</span><span class="dx-pct">78%</span></div>
+          <div class="bar"><i style="width:78%"></i></div>
+        </div>
+        <div class="dx-row">
+          <div class="dx-top"><span class="dx-name">Amigdalitis</span><span class="dx-pct">45%</span></div>
+          <div class="bar"><i style="width:45%"></i></div>
+        </div>
+        <div class="dx-row">
+          <div class="dx-top"><span class="dx-name">Resfriado común</span><span class="dx-pct">30%</span></div>
+          <div class="bar"><i style="width:30%"></i></div>
+        </div>
+      </div>
+      <div class="sep"></div>
+      <span class="warn">Solo orientativo · El doctor confirmará el diagnóstico</span>
+      <button class="btn-out">Agendar cita</button>
+    </div>
+  </div>
+
+  <div class="input-area">
+    <input placeholder="Escribe tus síntomas...">
+    <button class="send" aria-label="Enviar">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7Z"/></svg>
+    </button>
+  </div>
+
+  <!-- Bottom nav -->
+  <div class="nav">
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9Z"/></svg>
+      Inicio
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg>
+      Citas
+    </a>
+    <a class="active">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1.5v3M15 1.5v3M9 19.5v3M15 19.5v3M1.5 9h3M1.5 15h3M19.5 9h3M19.5 15h3"/></svg>
+      IA
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="8" width="19" height="8" rx="4" transform="rotate(-35 12 12)"/><path d="M9.8 6.5l7.6 7.6" transform="rotate(-35 12 12)"/></svg>
+      Recetas
+    </a>
+    <a>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/></svg>
+      Perfil
+    </a>
+  </div>
+  <div class="home-ind"></div>
+</div>
+<style id="__dark-mode-overrides">
+:root{--bg:#0f1117 !important;--surface:#1a1d27 !important;--soft:#252836 !important;--text:#f9fafb !important;--text-muted:#9ca3af !important;--text-subtle:#6b7280 !important;--border:#2d3144 !important;--border-soft:#252836 !important;--border-strong:#3a4055 !important;--primary-50:#1e3a2a !important;--primary-100:#1e3a2a !important;--primary-300:#214d33 !important;--gray-bg:#252836 !important;--gray-text:#9ca3af !important;--danger-bg:#2a1518 !important;--danger-50:#2a1518 !important;--warn-50:#2d2410 !important;--info-50:#122738 !important;}
+html,body{background:#0f1117 !important;color:#f9fafb !important}
+.phone{background:#0f1117 !important;border-color:#000 !important;box-shadow:0 30px 80px rgba(0,0,0,.55) !important}
+.notch{background:#000 !important}
+.statusbar{color:#f9fafb !important}
+.card,.modal-wrap,.table-wrap,.tabs,.nav,.search-wrap,.header,.pag,.pagination,.summary,.summary .r,.empty,.field,.filters,.tab{background-color:#1a1d27 !important;color:#f9fafb !important}
+.sb,.side,.sidebar,aside{background:#0d2018 !important;color:#f9fafb !important}
+input,select,textarea{background:#252836 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+input::placeholder,textarea::placeholder{color:#6b7280 !important}
+table{background:#1a1d27 !important;color:#f9fafb !important}
+th{background:#0f1117 !important;color:#9ca3af !important;border-color:#2d3144 !important}
+td{border-color:#2d3144 !important;color:#f9fafb !important}
+tr:hover td{background:#252836 !important}
+hr,.sep{border-color:#2d3144 !important;background:#2d3144 !important}
+.btn.primary{background:#1a5c3a !important;color:#fff !important}
+.btn.secondary,.btn.outline,.btn.gray,.btn.ghost{background:#1a1d27 !important;color:#f9fafb !important;border-color:#2d3144 !important}
+.av,.avatar{background:#1a5c3a !important;color:#fff !important}
+.card,.modal-wrap,.table-wrap{box-shadow:0 1px 3px rgba(0,0,0,.3) !important}
+</style>
+</body>
+</html>

--- a/mobile/lib/models/receta.dart
+++ b/mobile/lib/models/receta.dart
@@ -24,6 +24,9 @@ class Receta {
       medicamentos = meds
           .map((m) => Medicamento.fromJson(m as Map<String, dynamic>))
           .toList();
+    } else if (meds is String && meds.isNotEmpty) {
+      // Backend almacena medicamentos como texto plano — mostrar como entrada única
+      medicamentos = [Medicamento(nombre: meds, dosis: '', frecuencia: '', duracion: '')];
     }
 
     final doctor = json['doctor'] as Map<String, dynamic>?;

--- a/mobile/release.sh
+++ b/mobile/release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Compilar y publicar nueva versión de la app en GitHub Releases
+# Uso: ./release.sh v1.3 "Descripción del release"
+
+VERSION=${1:-""}
+DESCRIPCION=${2:-"Nueva versión"}
+
+if [ -z "$VERSION" ]; then
+  echo "Uso: ./release.sh v1.3 \"Descripción\""
+  exit 1
+fi
+
+echo "Compilando APK release..."
+flutter build apk --release
+
+if [ $? -ne 0 ]; then
+  echo "Error al compilar el APK"
+  exit 1
+fi
+
+APK_PATH="build/app/outputs/flutter-apk/app-release.apk"
+
+echo "Publicando $VERSION en GitHub Releases..."
+gh release create "$VERSION" "$APK_PATH" \
+  --title "Yoltec $VERSION" \
+  --notes "$DESCRIPCION"
+
+echo "Release publicado: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/tag/$VERSION"


### PR DESCRIPTION
## Resumen
Los días pasados en el calendario de días especiales (admin) podían seleccionarse y registrarse — sin sentido para algo que es por definición a futuro (festivos, cierres, vacaciones).

## Cambios

### Frontend
- \`CalDay\` interfaz: agregado \`isPast: boolean\`
- \`buildCalGrid()\`: calcula \`isPast\` comparando contra fecha de hoy
- \`selectDay()\`: bloquea selección de días pasados SIN día especial registrado (los que sí tienen siguen clickables para edición/borrado)
- HTML: nueva clase \`.past\` en celda + leyenda \"Día pasado (no editable)\"
- CSS: fondo gris claro, día tachado, \`cursor: not-allowed\`, \`pointer-events: none\`

### Backend
- \`CalendarioAdminController@store\`: validación \`after_or_equal:today\` en \`fecha\` (defensa en profundidad — el front bloquea, el back también)

## Test plan
- [ ] Admin → Días especiales → días pasados se ven en gris con número tachado
- [ ] Click en día pasado no abre modal
- [ ] Click en día actual o futuro abre modal normalmente
- [ ] Día pasado QUE YA tiene día especial registrado sigue clickable (para borrar)
- [ ] Intentar POST manual con fecha pasada → backend retorna 422