### PR TITLE
fix: bloquear días especiales al agendar citas + aviso de atención reducida

### DIFF
--- a/backend/app/Http/Controllers/CalendarioAdminController.php
+++ b/backend/app/Http/Controllers/CalendarioAdminController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use App\Models\DiaEspecial;
 use Carbon\Carbon;
 
@@ -41,13 +42,24 @@ class CalendarioAdminController extends Controller
             ['tipo' => $data['tipo'], 'etiqueta' => $data['etiqueta'] ?? null]
         );
 
+        $this->invalidarCacheDisponibilidad($data['fecha']);
+
         return response()->json(['message' => 'Día especial guardado.', 'dia' => $dia], 201);
     }
 
     public function destroy(Request $request, $id)
     {
         $dia = DiaEspecial::findOrFail($id);
+        $fecha = $dia->fecha->toDateString();
         $dia->delete();
+        $this->invalidarCacheDisponibilidad($fecha);
         return response()->json(['message' => 'Día eliminado del calendario.']);
+    }
+
+    // Invalida el cache de disponibilidad del mes/año al que pertenece la fecha
+    private function invalidarCacheDisponibilidad(string $fecha): void
+    {
+        $c = Carbon::parse($fecha);
+        Cache::forget("disp_{$c->year}_{$c->month}");
     }
 }

--- a/backend/app/Services/CitaService.php
+++ b/backend/app/Services/CitaService.php
@@ -61,6 +61,14 @@ class CitaService
         if ($hora < '08:00' || $hora > '16:45') {
             return 'El horario de atención es de 08:00 a 16:45.';
         }
+        $dia = DiaEspecial::where('fecha', $fecha)->first();
+        if ($dia) {
+            $status = config("clinic.types.{$dia->tipo}.status", 'full');
+            if ($status === 'full') {
+                $motivo = $dia->etiqueta ?: ($dia->tipo === 'vacation' ? 'vacaciones' : 'festivo');
+                return "Este día no hay atención ({$motivo}).";
+            }
+        }
         return null;
     }
 

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
@@ -349,6 +349,7 @@
         <div class="selected-date-info" *ngIf="createFormData.fecha_cita">
           <strong>Seleccionaste:</strong> {{ formatDateDisplay(createFormData.fecha_cita) }}
         </div>
+        <div class="warning-banner" *ngIf="selectedDayWarning">⚠ {{ selectedDayWarning }}</div>
         <div class="slots-wrapper" *ngIf="createFormData.fecha_cita"
              [class.disabled]="!hasAvailableSlotsForSelectedDate">
           <div class="slots-legend">

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
@@ -207,6 +207,15 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     return this.currentMonth.getFullYear() === now.getFullYear() && this.currentMonth.getMonth() === now.getMonth();
   }
 
+  // Aviso para días con atención reducida — null si el día es normal o no seleccionado
+  get selectedDayWarning(): string | null {
+    const fecha = this.createFormData.fecha_cita;
+    if (!fecha) return null;
+    const rec = this.getDayRecord(fecha);
+    if (!rec || rec.status !== 'partial') return null;
+    return rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+  }
+
   get hasAvailableSlotsForSelectedDate(): boolean {
     if (!this.createFormData.fecha_cita) return false;
     const record = this.getDayRecord(this.createFormData.fecha_cita);

--- a/frontend/src/app/components/student/student-dashboard/components/sd-citas/sd-citas.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-citas/sd-citas.component.html
@@ -51,6 +51,7 @@
           <div class="selected-date-info" *ngIf="createFormData.fecha_cita">
             <strong>Seleccionaste:</strong> {{ formatDateDisplay(createFormData.fecha_cita) }}
           </div>
+          <div class="warning-banner" *ngIf="selectedDayWarning">⚠ {{ selectedDayWarning }}</div>
           <input type="hidden" name="fecha_cita" [(ngModel)]="createFormData.fecha_cita" required />
         </div>
 

--- a/frontend/src/app/components/student/student-dashboard/components/sd-citas/sd-citas.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-citas/sd-citas.component.ts
@@ -166,6 +166,15 @@ export class SdCitasComponent implements OnInit, OnDestroy {
     return !day.isCurrentMonth || day.isPast || day.availability === 'full' || day.availability === 'none';
   }
 
+  // Aviso para días con atención reducida — null si el día es normal o no seleccionado
+  get selectedDayWarning(): string | null {
+    const fecha = this.createFormData.fecha_cita;
+    if (!fecha) return null;
+    const rec = this.availabilityMap.get(fecha);
+    if (!rec || rec.status !== 'partial') return null;
+    return rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+  }
+
   get hasAvailableSlotsForSelectedDate(): boolean {
     if (!this.createFormData.fecha_cita) return false;
     const rec = this.availabilityMap.get(this.createFormData.fecha_cita);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -119,3 +119,14 @@ html, body {
   font-family: var(--yol-font);
   color: var(--yol-text);
 }
+
+/* Aviso de día con atención reducida (reutilizable) */
+.warning-banner {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: var(--yol-warn-surface);
+  color: var(--yol-warn-text);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Resumen
Cuando el admin marcaba un día como festivo/vacaciones, alumnos y doctores podían agendar citas igualmente — el backend no validaba días especiales en \`validarHorario()\`. Además, el cache de disponibilidad (15min TTL) no se invalidaba al crear/borrar días especiales.

## Cambios

### Backend
- **\`CitaService::validarHorario()\`**: consulta \`DiaEspecial\` y rechaza días con status \`full\` (holiday/vacation) según \`config/clinic.types\`. Mensaje incluye etiqueta o motivo (\"vacaciones\" / \"festivo\").
- **\`CalendarioAdminController\`**: invalida cache \`disp_{year}_{month}\` al guardar (store) y borrar (destroy) días especiales — para que alumno/doctor vean cambios inmediatamente.

### Frontend
- **Bloqueo visual**: el calendario ya respetaba \`day.availability === 'full'\` (no hace falta cambio).
- **Aviso de atención reducida**: nuevo getter \`selectedDayWarning\` en \`sd-citas\` y \`doctor-citas\`. Muestra banner naranja \"⚠ Atención reducida hoy: {etiqueta}\" cuando el día seleccionado es \`reduced\` (status \`partial\`). Permite agendar pero avisa.
- **\`styles.css\`**: clase global \`.warning-banner\` reutilizable usando tokens del DS.

## Test plan
- [ ] Admin marca día futuro como \"Festivo\" → alumno intenta agendar ese día → calendario lo bloquea visualmente
- [ ] Si fuerza POST manual con fecha de día festivo → backend retorna 422 con mensaje del motivo
- [ ] Admin marca día como \"Horario reducido\" → alumno puede seleccionarlo pero ve banner \"⚠ Atención reducida hoy\"
- [ ] Admin crea día especial → alumno recarga citas → ve el cambio inmediatamente (no espera 15min de cache)
- [ ] Admin borra día especial → alumno recarga → vuelve a estar disponible