### PR TITLE
feat: hora de cierre para días de horario reducido

### DIFF
--- a/backend/app/Http/Controllers/CalendarioAdminController.php
+++ b/backend/app/Http/Controllers/CalendarioAdminController.php
@@ -22,7 +22,11 @@ class CalendarioAdminController extends Controller
         $dias = DiaEspecial::whereYear('fecha', $year)
             ->whereMonth('fecha', $month)
             ->orderBy('fecha')
-            ->get();
+            ->get()
+            ->map(function ($d) {
+                $d->hora_cierre = $d->hora_cierre ? substr((string) $d->hora_cierre, 0, 5) : null;
+                return $d;
+            });
 
         return response()->json(['dias' => $dias, 'month' => $month, 'year' => $year]);
     }
@@ -30,16 +34,25 @@ class CalendarioAdminController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'fecha'   => 'required|date|after_or_equal:today',
-            'tipo'    => 'required|in:holiday,vacation,reduced',
-            'etiqueta' => 'nullable|string|max:200',
+            'fecha'       => 'required|date|after_or_equal:today',
+            'tipo'        => 'required|in:holiday,vacation,reduced',
+            'etiqueta'    => 'nullable|string|max:200',
+            'hora_cierre' => 'nullable|date_format:H:i|required_if:tipo,reduced|after_or_equal:08:00|before_or_equal:16:45',
         ], [
-            'fecha.after_or_equal' => 'No se pueden registrar días especiales en fechas pasadas.',
+            'fecha.after_or_equal'        => 'No se pueden registrar días especiales en fechas pasadas.',
+            'hora_cierre.required_if'     => 'Especifica la hora de cierre para un día de horario reducido.',
+            'hora_cierre.date_format'     => 'La hora de cierre debe tener formato HH:MM.',
+            'hora_cierre.after_or_equal'  => 'La hora de cierre no puede ser antes de las 08:00.',
+            'hora_cierre.before_or_equal' => 'La hora de cierre no puede ser después de las 16:45.',
         ]);
 
         $dia = DiaEspecial::updateOrCreate(
             ['fecha' => $data['fecha']],
-            ['tipo' => $data['tipo'], 'etiqueta' => $data['etiqueta'] ?? null]
+            [
+                'tipo'        => $data['tipo'],
+                'etiqueta'    => $data['etiqueta'] ?? null,
+                'hora_cierre' => $data['tipo'] === 'reduced' ? $data['hora_cierre'] : null,
+            ]
         );
 
         $this->invalidarCacheDisponibilidad($data['fecha']);

--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -90,13 +90,18 @@ class CitaController extends Controller
         $cita->load(['alumno:id,nombre,apellido,numero_control,fcm_token', 'doctor:id,nombre,apellido']);
         Cache::forget("disp_{$cita->fecha_cita->year}_{$cita->fecha_cita->month}");
 
+        // FCM diferido: envía la notificación DESPUÉS del response (evita bloquear ~2-5s)
         if ($cita->alumno?->fcm_token) {
-            (new FcmService())->send(
-                $cita->alumno->fcm_token,
+            $token = $cita->alumno->fcm_token;
+            $fecha = (string) $cita->fecha_cita;
+            $hora  = (string) $cita->hora_cita;
+            $citaId = (string) $cita->id;
+            defer(fn() => (new FcmService())->send(
+                $token,
                 'Cita confirmada',
-                "Tu cita está programada para el {$cita->fecha_cita} a las {$cita->hora_cita}.",
-                ['cita_id' => (string) $cita->id, 'tipo' => 'cita_confirmada']
-            );
+                "Tu cita está programada para el {$fecha} a las {$hora}.",
+                ['cita_id' => $citaId, 'tipo' => 'cita_confirmada']
+            ));
         }
 
         return response()->json(['message' => 'Cita agendada exitosamente', 'cita' => $cita], 201);
@@ -133,12 +138,16 @@ class CitaController extends Controller
         $cita->load('alumno');
 
         if ($cita->alumno?->fcm_token) {
-            (new FcmService())->send(
-                $cita->alumno->fcm_token,
+            $token = $cita->alumno->fcm_token;
+            $fecha = (string) $cita->fecha_cita;
+            $hora  = (string) $cita->hora_cita;
+            $citaId = (string) $cita->id;
+            defer(fn() => (new FcmService())->send(
+                $token,
                 'Cita cancelada',
-                "Tu cita del {$cita->fecha_cita} a las {$cita->hora_cita} fue cancelada.",
-                ['cita_id' => (string) $cita->id, 'tipo' => 'cita_cancelada']
-            );
+                "Tu cita del {$fecha} a las {$hora} fue cancelada.",
+                ['cita_id' => $citaId, 'tipo' => 'cita_cancelada']
+            ));
         }
 
         return response()->json(['message' => 'Cita cancelada exitosamente', 'cita' => $cita]);
@@ -187,12 +196,16 @@ class CitaController extends Controller
         $cita->load(['alumno:id,nombre,apellido,numero_control,fcm_token', 'doctor:id,nombre,apellido']);
 
         if ($cita->alumno?->fcm_token) {
-            (new FcmService())->send(
-                $cita->alumno->fcm_token,
+            $token = $cita->alumno->fcm_token;
+            $fecha = (string) $cita->fecha_cita;
+            $hora  = (string) $cita->hora_cita;
+            $citaId = (string) $cita->id;
+            defer(fn() => (new FcmService())->send(
+                $token,
                 'Cita reprogramada',
-                "Tu cita fue reprogramada para el {$cita->fecha_cita} a las {$cita->hora_cita}.",
-                ['cita_id' => (string) $cita->id, 'tipo' => 'cita_reprogramada']
-            );
+                "Tu cita fue reprogramada para el {$fecha} a las {$hora}.",
+                ['cita_id' => $citaId, 'tipo' => 'cita_reprogramada']
+            ));
         }
 
         return response()->json(['message' => 'Cita reprogramada exitosamente', 'cita' => $cita]);

--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -210,4 +210,28 @@ class CitaController extends Controller
         $cita->update(['estatus' => 'no_asistio']);
         return response()->json(['message' => 'Cita marcada como no asistida', 'cita' => $cita]);
     }
+
+    // Solo doctor — busca alumnos por número de control, nombre o apellido (max 20 resultados)
+    public function buscarAlumno(Request $request)
+    {
+        $q = trim((string) $request->input('q', ''));
+        if (strlen($q) < 2) {
+            return response()->json(['alumnos' => []]);
+        }
+        $alumnos = User::where('tipo', 'alumno')
+            ->where(function ($query) use ($q) {
+                $query->where('numero_control', 'ILIKE', "%{$q}%")
+                    ->orWhere('nombre', 'ILIKE', "%{$q}%")
+                    ->orWhere('apellido', 'ILIKE', "%{$q}%");
+            })
+            ->select('id', 'numero_control', 'nombre', 'apellido')
+            ->limit(20)
+            ->get()
+            ->map(fn($a) => [
+                'id' => $a->id,
+                'numero_control' => $a->numero_control,
+                'nombre' => "{$a->nombre} {$a->apellido}",
+            ]);
+        return response()->json(['alumnos' => $alumnos]);
+    }
 }

--- a/backend/app/Models/DiaEspecial.php
+++ b/backend/app/Models/DiaEspecial.php
@@ -7,6 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 class DiaEspecial extends Model
 {
     protected $table = 'dias_especiales';
-    protected $fillable = ['fecha', 'tipo', 'etiqueta'];
+    protected $fillable = ['fecha', 'tipo', 'etiqueta', 'hora_cierre'];
     protected $casts = ['fecha' => 'date'];
 }

--- a/backend/app/Services/CitaService.php
+++ b/backend/app/Services/CitaService.php
@@ -40,10 +40,11 @@ class CitaService
                 $date = $dia->fecha->toDateString();
                 $result[$date] = array_merge($result[$date] ?? ['date' => $date, 'taken_slots' => [], 'special' => null], [
                     'special' => [
-                        'type'   => $dia->tipo,
-                        'label'  => $dia->etiqueta,
-                        'status' => $types[$dia->tipo]['status'] ?? 'full',
-                        'color'  => $types[$dia->tipo]['color'] ?? '#ef5350',
+                        'type'        => $dia->tipo,
+                        'label'       => $dia->etiqueta,
+                        'status'      => $types[$dia->tipo]['status'] ?? 'full',
+                        'color'       => $types[$dia->tipo]['color'] ?? '#ef5350',
+                        'hora_cierre' => $dia->hora_cierre ? substr((string) $dia->hora_cierre, 0, 5) : null,
                     ],
                 ]);
             }
@@ -67,6 +68,12 @@ class CitaService
             if ($status === 'full') {
                 $motivo = $dia->etiqueta ?: ($dia->tipo === 'vacation' ? 'vacaciones' : 'festivo');
                 return "Este día no hay atención ({$motivo}).";
+            }
+            if ($status === 'partial' && $dia->hora_cierre) {
+                $cierre = substr((string) $dia->hora_cierre, 0, 5);
+                if ($hora >= $cierre) {
+                    return "Hoy la atención es hasta las {$cierre}. Elige una hora anterior.";
+                }
             }
         }
         return null;

--- a/backend/database/migrations/2026_05_15_000003_add_hora_cierre_to_dias_especiales.php
+++ b/backend/database/migrations/2026_05_15_000003_add_hora_cierre_to_dias_especiales.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    // Hora de cierre para días tipo 'reduced' — citas posteriores se bloquean
+    public function up(): void
+    {
+        Schema::table('dias_especiales', function (Blueprint $table) {
+            $table->time('hora_cierre')->nullable()->after('etiqueta');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('dias_especiales', function (Blueprint $table) {
+            $table->dropColumn('hora_cierre');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -63,6 +63,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('/citas/{id}/no-asistio', [CitaController::class, 'noAsistio']);
         Route::post('/citas/{id}/consulta', [ConsultaController::class, 'store']);
         Route::get('/citas/{id}/consulta', [ConsultaController::class, 'show']);
+        Route::get('/alumnos/buscar', [CitaController::class, 'buscarAlumno']);
     });
 
     // Perfil médico e historial

--- a/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.css
+++ b/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.css
@@ -932,6 +932,20 @@
 
 .form-input:focus { border-color: #1a5c3a; }
 
+.form-hint {
+  display: block;
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--yol-text-muted);
+  font-family: var(--yol-font);
+}
+
+.dia-reg-hora {
+  font-size: 11.5px;
+  color: var(--yol-text-muted);
+  margin-left: 4px;
+}
+
 .btn-full { width: 100%; justify-content: center; }
 
 .dia-reg-item {

--- a/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.html
+++ b/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.html
@@ -321,6 +321,13 @@
                   <label>Etiqueta</label>
                   <input type="text" [(ngModel)]="diaForm.etiqueta" placeholder="Ej: Semana Santa, Puente..." class="form-input">
                 </div>
+                @if (diaForm.tipo === 'reduced') {
+                  <div class="form-group" style="margin-top: 12px">
+                    <label>Hora de cierre *</label>
+                    <input type="time" [(ngModel)]="diaForm.hora_cierre" min="08:00" max="16:45" class="form-input">
+                    <small class="form-hint">A partir de esta hora no se podrán agendar citas.</small>
+                  </div>
+                }
                 <button class="btn-pri btn-full" style="margin-top: 16px" (click)="submitDia()" [disabled]="isSubmittingDia">
                   {{ isSubmittingDia ? 'Guardando...' : 'Guardar día' }}
                 </button>
@@ -333,7 +340,12 @@
                     <div class="dia-reg-item">
                       <div class="dia-reg-fecha">{{ formatFechaDia(dia.fecha) }}</div>
                       <span class="dia-preview-tipo" [class]="dia.tipo">{{ tipoLabels[dia.tipo].label }}</span>
-                      <span class="dia-reg-etiqueta">{{ dia.etiqueta || '—' }}</span>
+                      <span class="dia-reg-etiqueta">
+                        {{ dia.etiqueta || '—' }}
+                        @if (dia.tipo === 'reduced' && dia.hora_cierre) {
+                          <small class="dia-reg-hora">· cierre {{ dia.hora_cierre }}</small>
+                        }
+                      </span>
                       <div class="dia-reg-actions">
                         <button class="action-link" (click)="selectCalDay(dia.fecha)">Editar</button>
                         <button class="action-link warn" (click)="deleteDia(dia.id)">Eliminar</button>

--- a/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.ts
@@ -91,7 +91,7 @@ export class AdminDashboardComponent implements OnInit, OnDestroy {
   calWeeks: { date: string; label: number; isCurrentMonth: boolean; isPast: boolean; diaEspecial: DiaEspecial | null }[][] = [];
   diasEspeciales: DiaEspecial[] = [];
   isLoadingCal = false;
-  diaForm = { fecha: '', tipo: 'holiday', etiqueta: '' };
+  diaForm = { fecha: '', tipo: 'holiday', etiqueta: '', hora_cierre: '' };
   diaMsg: string | null = null;
   isSubmittingDia = false;
 
@@ -510,17 +510,28 @@ export class AdminDashboardComponent implements OnInit, OnDestroy {
     if (isPast && !hasDia) return;
     this.diaForm.fecha = fecha;
     const existing = this.diasEspeciales.find(d => d.fecha === fecha);
-    if (existing) { this.diaForm.tipo = existing.tipo; this.diaForm.etiqueta = existing.etiqueta ?? ''; }
-    else { this.diaForm.tipo = 'holiday'; this.diaForm.etiqueta = ''; }
+    if (existing) {
+      this.diaForm.tipo = existing.tipo;
+      this.diaForm.etiqueta = existing.etiqueta ?? '';
+      this.diaForm.hora_cierre = existing.hora_cierre ?? '';
+    } else {
+      this.diaForm.tipo = 'holiday';
+      this.diaForm.etiqueta = '';
+      this.diaForm.hora_cierre = '';
+    }
   }
 
-  resetDiaForm(): void { this.diaForm = { fecha: '', tipo: 'holiday', etiqueta: '' }; this.diaMsg = null; }
+  resetDiaForm(): void { this.diaForm = { fecha: '', tipo: 'holiday', etiqueta: '', hora_cierre: '' }; this.diaMsg = null; }
 
   submitDia(): void {
     if (!this.diaForm.fecha) { this.diaMsg = 'Selecciona una fecha.'; return; }
+    if (this.diaForm.tipo === 'reduced' && !this.diaForm.hora_cierre) {
+      this.diaMsg = 'Especifica la hora de cierre para un día de horario reducido.';
+      return;
+    }
     this.isSubmittingDia = true;
     this.diaMsg = null;
-    this.calendarioService.saveDia(this.diaForm.fecha, this.diaForm.tipo, this.diaForm.etiqueta)
+    this.calendarioService.saveDia(this.diaForm.fecha, this.diaForm.tipo, this.diaForm.etiqueta, this.diaForm.hora_cierre || null)
       .pipe(
         takeUntil(this.destroy$),
         catchError(err => {

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
@@ -14,6 +14,7 @@ interface DayAvailabilityRecord {
   status: AvailabilityStatus;
   color?: string;
   label?: string | null;
+  horaCierre?: string | null;
 }
 
 interface CalendarDay {
@@ -213,7 +214,8 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     if (!fecha) return null;
     const rec = this.getDayRecord(fecha);
     if (!rec || rec.status !== 'partial') return null;
-    return rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+    const baseMsg = rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+    return rec.horaCierre ? `${baseMsg} (cierre a las ${rec.horaCierre})` : baseMsg;
   }
 
   get hasAvailableSlotsForSelectedDate(): boolean {
@@ -635,7 +637,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
       } else {
         status = 'partial';
       }
-      map.set(day.date, { takenSlots, status, color: day.special?.color ?? undefined, label: day.special?.label ?? null });
+      map.set(day.date, { takenSlots, status, color: day.special?.color ?? undefined, label: day.special?.label ?? null, horaCierre: day.special?.hora_cierre ?? null });
     });
     this.availabilityMap = map;
   }
@@ -715,6 +717,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     }
     const record = this.getDayRecord(this.createFormData.fecha_cita);
     if (record?.status === 'full') return true;
+    if (record?.horaCierre && normalizedSlot >= record.horaCierre) return true;
     if (record?.takenSlots.has(normalizedSlot)) return true;
     return this.citas.some(c =>
       c.fecha_cita === this.createFormData.fecha_cita &&

--- a/frontend/src/app/components/shared/agendar-cita/agendar-cita.service.ts
+++ b/frontend/src/app/components/shared/agendar-cita/agendar-cita.service.ts
@@ -17,8 +17,11 @@ export interface Slot {
 
 export interface Cita {
   id: number;
+  fecha: string;          // alias de fecha_cita para compatibilidad
   fecha_cita: string;
   hora_cita: string;
+  hora_inicio: string;    // alias de hora_cita para compatibilidad
+  hora_fin: string;       // hora_cita + 15min
   motivo: string;
   alumno_id: number;
 }
@@ -100,13 +103,20 @@ export class AgendarCitaService {
       motivo: body.motivo,
     };
     if (body.alumno_id) payload['alumno_id'] = body.alumno_id;
-    return this.http.post<{ cita: any }>(`${API}/citas`, payload).pipe(map(r => ({
-      id: r.cita.id,
-      fecha_cita: r.cita.fecha_cita,
-      hora_cita: r.cita.hora_cita,
-      motivo: r.cita.motivo,
-      alumno_id: r.cita.alumno_id,
-    })));
+    return this.http.post<{ cita: any }>(`${API}/citas`, payload).pipe(map(r => {
+      const fechaCita = (r.cita.fecha_cita || '').split('T')[0];
+      const horaCita = (r.cita.hora_cita || '').substring(0, 5);
+      return {
+        id: r.cita.id,
+        fecha: fechaCita,
+        fecha_cita: fechaCita,
+        hora_cita: horaCita,
+        hora_inicio: horaCita,
+        hora_fin: this.addMinutes(horaCita, STEP_MINUTOS),
+        motivo: r.cita.motivo,
+        alumno_id: r.cita.alumno_id,
+      };
+    }));
   }
 
   private buildDispRecord(year: number, month: number, days: BackendDay[]): Record<string, Disponibilidad> {

--- a/frontend/src/app/components/shared/agendar-cita/agendar-cita.service.ts
+++ b/frontend/src/app/components/shared/agendar-cita/agendar-cita.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { API_BASE_URL } from '../../../services/api-config';
 
 export interface Disponibilidad {
   libres: number;
@@ -15,12 +17,10 @@ export interface Slot {
 
 export interface Cita {
   id: number;
-  fecha: string;
-  slot_id: number;
+  fecha_cita: string;
+  hora_cita: string;
   motivo: string;
   alumno_id: number;
-  hora_inicio?: string;
-  hora_fin?: string;
 }
 
 export interface AlumnoBusqueda {
@@ -30,7 +30,22 @@ export interface AlumnoBusqueda {
   carrera?: string;
 }
 
-import { API_BASE_URL } from '../../../services/api-config';
+// Slots fijos del consultorio: 08:00 a 16:45 cada 15min (36 slots)
+const HORA_INICIO = 8;
+const HORA_FIN = 17;
+const STEP_MINUTOS = 15;
+
+interface BackendDay {
+  date: string;
+  taken_slots: string[];
+  special?: { type: string; label?: string | null; status?: 'available' | 'partial' | 'full'; hora_cierre?: string | null } | null;
+}
+
+interface DayInfo {
+  takenSlots: Set<string>;
+  horaCierre: string | null;
+  isFull: boolean;
+}
 
 const API = API_BASE_URL;
 
@@ -38,23 +53,111 @@ const API = API_BASE_URL;
 export class AgendarCitaService {
   private http = inject(HttpClient);
 
-  // GET /api/alumnos/buscar?q=
+  // Cache por mes (key "YYYY-MM") con info por día para generar slots sin segunda llamada
+  private monthCache = new Map<string, Map<string, DayInfo>>();
+  // Map sintético slot_id → "HH:MM" — necesario porque el componente trabaja con slot.id
+  private slotIdToHora = new Map<number, string>();
+  private slotCounter = 0;
+
+  // GET /api/alumnos/buscar?q= — solo doctor
   buscarAlumno(q: string): Observable<AlumnoBusqueda[]> {
-    return this.http.get<AlumnoBusqueda[]>(`${API}/alumnos/buscar`, { params: { q } });
+    return this.http.get<{ alumnos: AlumnoBusqueda[] }>(`${API}/alumnos/buscar`, { params: { q } })
+      .pipe(map(r => r.alumnos ?? []));
   }
 
-  // GET /api/disponibilidad?mes=YYYY-MM → { "2026-05-12": { libres, total } }
+  // Wrapper sobre /api/citas/disponibilidad que adapta a la interfaz Disponibilidad esperada
   getDisponibilidad(mes: string): Observable<Record<string, Disponibilidad>> {
-    return this.http.get<Record<string, Disponibilidad>>(`${API}/disponibilidad`, { params: { mes } });
+    const [yearStr, monthStr] = mes.split('-');
+    const year = Number(yearStr);
+    const month = Number(monthStr);
+    return this.http.get<{ days: BackendDay[] }>(`${API}/citas/disponibilidad`, { params: { month, year } })
+      .pipe(map(r => this.buildDispRecord(year, month, r.days || [])));
   }
 
-  // GET /api/slots?fecha=YYYY-MM-DD
+  // Slots calculados localmente desde el cache del mes (no requiere endpoint adicional)
   getSlots(fecha: string): Observable<Slot[]> {
-    return this.http.get<Slot[]>(`${API}/slots`, { params: { fecha } });
+    const monthKey = fecha.substring(0, 7);
+    const dayInfo = this.monthCache.get(monthKey)?.get(fecha)
+      ?? { takenSlots: new Set<string>(), horaCierre: null, isFull: false };
+    if (dayInfo.isFull) return of([]);
+    const slots: Slot[] = this.allSlots()
+      .filter(h => !dayInfo.takenSlots.has(h) && (!dayInfo.horaCierre || h < dayInfo.horaCierre))
+      .map(h => {
+        const id = ++this.slotCounter;
+        this.slotIdToHora.set(id, h);
+        return { id, hora_inicio: h, hora_fin: this.addMinutes(h, STEP_MINUTOS) };
+      });
+    return of(slots);
   }
 
-  // POST /api/citas
+  // POST /api/citas — traduce slot_id (sintético) a hora_cita antes de enviar
   confirmarCita(body: { fecha: string; slot_id: number; motivo: string; alumno_id?: number }): Observable<Cita> {
-    return this.http.post<Cita>(`${API}/citas`, body);
+    const hora_cita = this.slotIdToHora.get(body.slot_id);
+    if (!hora_cita) return throwError(() => new Error('Slot no encontrado. Recarga la página.'));
+    const payload: Record<string, any> = {
+      fecha_cita: body.fecha,
+      hora_cita,
+      motivo: body.motivo,
+    };
+    if (body.alumno_id) payload['alumno_id'] = body.alumno_id;
+    return this.http.post<{ cita: any }>(`${API}/citas`, payload).pipe(map(r => ({
+      id: r.cita.id,
+      fecha_cita: r.cita.fecha_cita,
+      hora_cita: r.cita.hora_cita,
+      motivo: r.cita.motivo,
+      alumno_id: r.cita.alumno_id,
+    })));
+  }
+
+  private buildDispRecord(year: number, month: number, days: BackendDay[]): Record<string, Disponibilidad> {
+    const total = this.allSlots().length;
+    const result: Record<string, Disponibilidad> = {};
+    const info = new Map<string, DayInfo>();
+    const daysInMonth = new Date(year, month, 0).getDate();
+
+    for (let d = 1; d <= daysInMonth; d++) {
+      const date = `${year}-${String(month).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+      const dow = new Date(year, month - 1, d).getDay();
+      if (dow === 0) continue; // domingo cerrado
+      result[date] = { libres: total, total };
+      info.set(date, { takenSlots: new Set(), horaCierre: null, isFull: false });
+    }
+
+    days.forEach(day => {
+      const dateKey = (day.date || '').split('T')[0];
+      if (!result[dateKey]) return;
+      const isFull = day.special?.status === 'full';
+      const horaCierre = day.special?.hora_cierre ?? null;
+      const takenSlots = new Set(day.taken_slots ?? []);
+      info.set(dateKey, { takenSlots, horaCierre, isFull });
+      if (isFull) {
+        result[dateKey] = { libres: 0, total };
+      } else {
+        const libres = this.allSlots().filter(s =>
+          !takenSlots.has(s) && (!horaCierre || s < horaCierre)
+        ).length;
+        result[dateKey] = { libres, total };
+      }
+    });
+
+    this.monthCache.set(`${year}-${String(month).padStart(2, '0')}`, info);
+    return result;
+  }
+
+  private allSlots(): string[] {
+    const slots: string[] = [];
+    for (let h = HORA_INICIO; h < HORA_FIN; h++) {
+      for (let m = 0; m < 60; m += STEP_MINUTOS) {
+        if (h === HORA_FIN - 1 && m > 45) break; // último slot 16:45
+        slots.push(`${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`);
+      }
+    }
+    return slots;
+  }
+
+  private addMinutes(hhmm: string, mins: number): string {
+    const [h, m] = hhmm.split(':').map(Number);
+    const total = h * 60 + m + mins;
+    return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`;
   }
 }

--- a/frontend/src/app/components/student/student-dashboard/components/sd-citas/sd-citas.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-citas/sd-citas.component.ts
@@ -19,6 +19,7 @@ interface DayAvailabilityRecord {
   status: AvailabilityStatus;
   color?: string;
   label?: string | null;
+  horaCierre?: string | null;
 }
 
 interface CalendarDay {
@@ -172,7 +173,8 @@ export class SdCitasComponent implements OnInit, OnDestroy {
     if (!fecha) return null;
     const rec = this.availabilityMap.get(fecha);
     if (!rec || rec.status !== 'partial') return null;
-    return rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+    const baseMsg = rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+    return rec.horaCierre ? `${baseMsg} (cierre a las ${rec.horaCierre})` : baseMsg;
   }
 
   get hasAvailableSlotsForSelectedDate(): boolean {
@@ -184,7 +186,10 @@ export class SdCitasComponent implements OnInit, OnDestroy {
   isSlotUnavailable(slot: string): boolean {
     if (!this.createFormData.fecha_cita) return true;
     const rec = this.availabilityMap.get(this.createFormData.fecha_cita);
-    return rec ? rec.takenSlots.has(this.normalizeTime(slot)) : false;
+    if (!rec) return false;
+    const normalized = this.normalizeTime(slot);
+    if (rec.horaCierre && normalized >= rec.horaCierre) return true;
+    return rec.takenSlots.has(normalized);
   }
 
   getDayStyle(day: CalendarDay): Record<string, string> {
@@ -249,7 +254,7 @@ export class SdCitasComponent implements OnInit, OnDestroy {
       else if (takenSlots.size === 0) status = 'available';
       else if (takenSlots.size >= this.totalSlotsPerDay) status = 'full';
       else status = 'partial';
-      map.set(day.date, { takenSlots, status, color: day.special?.color ?? undefined, label: day.special?.label ?? null });
+      map.set(day.date, { takenSlots, status, color: day.special?.color ?? undefined, label: day.special?.label ?? null, horaCierre: day.special?.hora_cierre ?? null });
     });
     this.availabilityMap = map;
   }

--- a/frontend/src/app/services/calendario-admin.service.ts
+++ b/frontend/src/app/services/calendario-admin.service.ts
@@ -9,6 +9,7 @@ export interface DiaEspecial {
   fecha: string;
   tipo: 'holiday' | 'vacation' | 'reduced';
   etiqueta: string | null;
+  hora_cierre: string | null;
 }
 
 export const TIPO_LABELS: Record<string, { label: string; color: string }> = {
@@ -28,8 +29,10 @@ export class CalendarioAdminService {
       .pipe(map(r => r.dias.map(d => ({ ...d, fecha: (d.fecha || '').split('T')[0] }))));
   }
 
-  saveDia(fecha: string, tipo: string, etiqueta: string): Observable<any> {
-    return this.http.post(this.base, { fecha, tipo, etiqueta });
+  saveDia(fecha: string, tipo: string, etiqueta: string, horaCierre?: string | null): Observable<any> {
+    const body: Record<string, any> = { fecha, tipo, etiqueta };
+    if (tipo === 'reduced' && horaCierre) body['hora_cierre'] = horaCierre;
+    return this.http.post(this.base, body);
   }
 
   deleteDia(id: number): Observable<any> {

--- a/frontend/src/app/services/cita.service.ts
+++ b/frontend/src/app/services/cita.service.ts
@@ -44,6 +44,7 @@ export interface AvailabilitySpecial {
   label?: string | null;
   status?: AvailabilityStatus;
   color?: string;
+  hora_cierre?: string | null;
 }
 
 export interface CitaAvailabilityDay {


### PR DESCRIPTION
## Resumen
Cuando el admin marca un día como **horario reducido** (suspensión a media jornada), ahora puede especificar la **hora de cierre** — a partir de ese momento no se permiten más citas.

## Cambios

### Backend
- **Migración** \`add_hora_cierre_to_dias_especiales\`: agrega columna \`hora_cierre TIME nullable\` (incremental)
- **\`DiaEspecial\`** model: \`hora_cierre\` en \`$fillable\`
- **\`CalendarioAdminController::store\`**: valida \`hora_cierre\` como \`required_if:tipo,reduced\`, formato HH:MM, dentro de 08:00–16:45. Se persiste solo si \`tipo === 'reduced'\` (sino se guarda \`null\`).
- **\`CalendarioAdminController::index\`**: normaliza \`hora_cierre\` a \`HH:MM\` (Postgres TIME serializa como \`HH:MM:SS\`).
- **\`CitaService::validarHorario\`**: si día es \`partial\` y tiene \`hora_cierre\`, rechaza horas \`>= hora_cierre\` con mensaje \"Hoy la atención es hasta las XX:XX. Elige una hora anterior.\"
- **\`CitaService::getAvailability\`**: incluye \`hora_cierre\` en el payload \`special\`.

### Frontend
- **\`calendario-admin.service\`**: \`DiaEspecial\` con \`hora_cierre\`. \`saveDia\` opcional \`horaCierre\`.
- **\`admin-dashboard\`**: input \`type=time\` condicional cuando \`tipo === 'reduced'\`. Lista \"Días registrados\" muestra \"· cierre HH:MM\" cuando aplica. \`selectCalDay\` precarga \`hora_cierre\` al editar.
- **\`cita.service\`**: \`AvailabilitySpecial\` con \`hora_cierre\`.
- **\`sd-citas\`** (alumno) y **\`doctor-citas\`**: \`isSlotUnavailable\` bloquea slots \`>= hora_cierre\`. Banner \"⚠ Atención reducida hoy: {etiqueta} (cierre a las HH:MM)\".

## Test plan
- [ ] Correr migración: \`php artisan migrate\`
- [ ] Admin marca día futuro como \"Día reducido\" con cierre a las 12:00
- [ ] Alumno intenta agendar ese día: slots de 12:00 en adelante deshabilitados
- [ ] Banner muestra \"Atención reducida hoy: ... (cierre a las 12:00)\"
- [ ] Intentar POST manual con hora 12:30 → backend retorna 422
- [ ] Editar día reducido → input precargado con la hora guardada
- [ ] Cambiar tipo de reduced a holiday → guardado → \`hora_cierre\` se persiste como null