### PR TITLE
fix: bugs doctor pre-evaluaciones + slots pasados + TZ inicio

### DIFF
--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
@@ -301,6 +301,8 @@
 
 .btn-sm { padding: 6px 11px; font-size: var(--yol-fs-cap); }
 
+.btn-modal { min-width: 180px; justify-content: center; }
+
 /* --- Filtros historial --- */
 .filters {
   display: flex;

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.html
@@ -198,8 +198,8 @@
       </div>
       <div class="modal-foot">
         <button class="btn btn-ghost" (click)="cerrarValidar()">Cancelar</button>
-        <button class="btn btn-primary" (click)="confirmarValidar()" [disabled]="enviando">
-          {{ enviando ? 'Validando...' : '✓ Confirmar validación' }}
+        <button class="btn btn-primary btn-modal" (click)="confirmarValidar()" [disabled]="enviando">
+          {{ enviando ? 'Validando...' : 'Confirmar validación' }}
         </button>
       </div>
     </div>
@@ -226,8 +226,8 @@
       </div>
       <div class="modal-foot">
         <button class="btn btn-ghost" (click)="cerrarDescartar()">Cancelar</button>
-        <button class="btn btn-danger-outline" (click)="confirmarDescartar()" [disabled]="enviando">
-          {{ enviando ? 'Descartando...' : '✕ Descartar diagnóstico' }}
+        <button class="btn btn-danger-outline btn-modal" (click)="confirmarDescartar()" [disabled]="enviando">
+          {{ enviando ? 'Descartando...' : 'Descartar diagnóstico' }}
         </button>
       </div>
     </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.html
@@ -199,7 +199,8 @@
       <div class="modal-foot">
         <button class="btn btn-ghost" (click)="cerrarValidar()">Cancelar</button>
         <button class="btn btn-primary btn-modal" (click)="confirmarValidar()" [disabled]="enviando">
-          {{ enviando ? 'Validando...' : 'Confirmar validación' }}
+          <span *ngIf="!enviando">Confirmar validación</span>
+          <span *ngIf="enviando">Validando...</span>
         </button>
       </div>
     </div>
@@ -227,7 +228,8 @@
       <div class="modal-foot">
         <button class="btn btn-ghost" (click)="cerrarDescartar()">Cancelar</button>
         <button class="btn btn-danger-outline btn-modal" (click)="confirmarDescartar()" [disabled]="enviando">
-          {{ enviando ? 'Descartando...' : 'Descartar diagnóstico' }}
+          <span *ngIf="!enviando">Descartar diagnóstico</span>
+          <span *ngIf="enviando">Descartando...</span>
         </button>
       </div>
     </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.html
@@ -60,8 +60,8 @@
           <div class="pc-section">
             <h3>Síntomas detectados</h3>
             <div class="chips">
-              <span *ngFor="let s of pe.sintomas_detectados" class="chip">{{ s }}</span>
-              <span *ngIf="pe.sintomas_detectados.length === 0" class="chip-empty">Sin síntomas registrados</span>
+              <span *ngFor="let s of (pe.sintomas_detectados || [])" class="chip">{{ s }}</span>
+              <span *ngIf="!(pe.sintomas_detectados || []).length" class="chip-empty">Sin síntomas registrados</span>
             </div>
           </div>
           <div class="pc-section">
@@ -69,11 +69,11 @@
             <div class="dx-list">
               <div class="dx">
                 <div class="dx-row">
-                  <span class="dx-nombre">{{ pe.diagnostico_sugerido }}</span>
-                  <span class="dx-pct">{{ (pe.confianza * 100).toFixed(0) }}%</span>
+                  <span class="dx-nombre">{{ pe.diagnostico_sugerido || 'Sin diagnóstico registrado' }}</span>
+                  <span class="dx-pct">{{ ((pe.confianza || 0) * 100).toFixed(0) }}%</span>
                 </div>
                 <div class="bar">
-                  <div class="fill" [style.width.%]="pe.confianza * 100"></div>
+                  <div class="fill" [style.width.%]="(pe.confianza || 0) * 100"></div>
                 </div>
               </div>
             </div>
@@ -149,8 +149,8 @@
           <div class="pc-section">
             <h3>Síntomas detectados</h3>
             <div class="chips">
-              <span *ngFor="let s of pe.sintomas_detectados" class="chip">{{ s }}</span>
-              <span *ngIf="pe.sintomas_detectados.length === 0" class="chip-empty">Sin síntomas registrados</span>
+              <span *ngFor="let s of (pe.sintomas_detectados || [])" class="chip">{{ s }}</span>
+              <span *ngIf="!(pe.sintomas_detectados || []).length" class="chip-empty">Sin síntomas registrados</span>
             </div>
           </div>
           <div class="pc-section">
@@ -158,11 +158,11 @@
             <div class="dx-list">
               <div class="dx">
                 <div class="dx-row">
-                  <span class="dx-nombre">{{ pe.diagnostico_sugerido }}</span>
-                  <span class="dx-pct">{{ (pe.confianza * 100).toFixed(0) }}%</span>
+                  <span class="dx-nombre">{{ pe.diagnostico_sugerido || 'Sin diagnóstico registrado' }}</span>
+                  <span class="dx-pct">{{ ((pe.confianza || 0) * 100).toFixed(0) }}%</span>
                 </div>
                 <div class="bar">
-                  <div class="fill" [style.width.%]="pe.confianza * 100"></div>
+                  <div class="fill" [style.width.%]="(pe.confianza || 0) * 100"></div>
                 </div>
               </div>
             </div>
@@ -187,8 +187,8 @@
       </div>
       <div class="modal-body">
         <p class="modal-sub">
-          ¿El diagnóstico <b>{{ modalValidar.diagnostico_sugerido }}</b> coincidió con el resultado real de la consulta
-          de <b>{{ nombreCompleto(modalValidar) }}</b>?
+          ¿El diagnóstico <b>{{ modalValidar.diagnostico_sugerido || 'sugerido' }}</b> coincidió con el resultado real de la consulta
+          <ng-container *ngIf="tieneAlumno(modalValidar)">de <b>{{ nombreCompleto(modalValidar) }}</b></ng-container>?
         </p>
         <div class="form-group">
           <label>Comentario (opcional)</label>
@@ -214,8 +214,7 @@
       </div>
       <div class="modal-body">
         <p class="modal-sub">
-          Indica por qué el diagnóstico sugerido <b>no coincidió</b> con la consulta de
-          <b>{{ nombreCompleto(modalDescartar) }}</b>.
+          Indica por qué el diagnóstico sugerido <b>no coincidió</b> con la consulta<ng-container *ngIf="tieneAlumno(modalDescartar)"> de <b>{{ nombreCompleto(modalDescartar) }}</b></ng-container>.
         </p>
         <div class="form-group" [class.has-error]="motivoError">
           <label>Motivo <span class="req">*</span></label>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.ts
@@ -210,6 +210,10 @@ export class DoctorPreEvaluacionesComponent implements OnInit, OnDestroy {
     return `${n} ${a}`.trim() || 'Sin nombre';
   }
 
+  tieneAlumno(pe: PreEvaluacion): boolean {
+    return !!(pe.cita?.alumno?.nombre || pe.cita?.alumno?.apellido);
+  }
+
   formatFecha(iso: string): string {
     if (!iso) return '—';
     const [y, m, d] = iso.split('-').map(Number);

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.ts
@@ -214,11 +214,12 @@ export class DoctorPreEvaluacionesComponent implements OnInit, OnDestroy {
     return !!(pe.cita?.alumno?.nombre || pe.cita?.alumno?.apellido);
   }
 
-  formatFecha(iso: string): string {
+  formatFecha(iso: string | null | undefined): string {
     if (!iso) return '—';
-    const [y, m, d] = iso.split('-').map(Number);
+    const [y, m, d] = iso.split('T')[0].split('-').map(Number);
+    if (!y || !m || !d || isNaN(y) || isNaN(m) || isNaN(d)) return '—';
     return new Intl.DateTimeFormat('es-MX', { day: '2-digit', month: 'short', year: 'numeric' })
-      .format(new Date(y, (m ?? 1) - 1, d ?? 1));
+      .format(new Date(y, m - 1, d));
   }
 
   private mostrarToast(mensaje: string, tipo: 'ok' | 'error'): void {

--- a/frontend/src/app/components/shared/agendar-cita/agendar-cita.service.ts
+++ b/frontend/src/app/components/shared/agendar-cita/agendar-cita.service.ts
@@ -137,11 +137,25 @@ export class AgendarCitaService {
     const info = new Map<string, DayInfo>();
     const daysInMonth = new Date(year, month, 0).getDate();
 
+    const now = new Date();
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    const ahoraHHMM = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+
+    // Cuenta slots libres descontando: ocupados, posteriores al cierre y (si es hoy) horas ya pasadas
+    const contarLibres = (date: string, takenSlots: Set<string>, horaCierre: string | null) => {
+      return this.allSlots().filter(s =>
+        !takenSlots.has(s)
+        && (!horaCierre || s < horaCierre)
+        && (date !== todayStr || s > ahoraHHMM)
+      ).length;
+    };
+
     for (let d = 1; d <= daysInMonth; d++) {
       const date = `${year}-${String(month).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
       const dow = new Date(year, month - 1, d).getDay();
       if (dow === 0) continue; // domingo cerrado
-      result[date] = { libres: total, total };
+      const libres = contarLibres(date, new Set(), null);
+      result[date] = { libres, total };
       info.set(date, { takenSlots: new Set(), horaCierre: null, isFull: false });
     }
 
@@ -152,14 +166,9 @@ export class AgendarCitaService {
       const horaCierre = day.special?.hora_cierre ?? null;
       const takenSlots = new Set(day.taken_slots ?? []);
       info.set(dateKey, { takenSlots, horaCierre, isFull });
-      if (isFull) {
-        result[dateKey] = { libres: 0, total };
-      } else {
-        const libres = this.allSlots().filter(s =>
-          !takenSlots.has(s) && (!horaCierre || s < horaCierre)
-        ).length;
-        result[dateKey] = { libres, total };
-      }
+      result[dateKey] = isFull
+        ? { libres: 0, total }
+        : { libres: contarLibres(dateKey, takenSlots, horaCierre), total };
     });
 
     this.monthCache.set(`${year}-${String(month).padStart(2, '0')}`, info);

--- a/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.html
+++ b/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.html
@@ -162,7 +162,7 @@
                 </div>
 
                 <div class="pe-result-cta">
-                  <button class="pe-btn-agendar" (click)="agendarCita()">&#8853; Agendar cita</button>
+                  <button class="pe-btn-agendar" (click)="agendarCita()">Ver mis citas</button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Pre-evaluaciones doctor: defensiva ante cita.alumno null, render coherente en cards/modales, botones del modal con texto visible (causa raíz: RangeError en formatFecha rompía change detection).
- Calendario agendar: contador 'N disp' del día actual descuenta horas ya pasadas.
- sd-inicio alumno: bug TZ que hacía caer la cita de hoy fuera de Próximas + sort por fecha+hora.
- Mis citas alumno: orden cronológico ascendente en próximas, descendente en pasadas/canceladas.
- CTA post-pre-eval IA alumno: 'Agendar cita' → 'Ver mis citas' (ya tiene cita asignada).

## Test plan
- [x] Modales validar/descartar muestran texto.
- [x] Consola sin RangeError al cargar pendientes.
- [x] 14:30 antes que 16:00 en Próximas.
- [x] Inicio refleja citas del día.
- [x] Slots ya pasados no seleccionables en día actual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)