### PR TITLE
fix(prod): forzar email admin/doctor a Resend verified

### DIFF
--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -77,5 +77,7 @@ class DatabaseSeeder extends Seeder
                 'nip' => Hash::make('789012'),
             ]
         );
+
+        $this->call(EnsureAdminEmailForResendSeeder::class);
     }
 }

--- a/backend/database/seeders/EnsureAdminEmailForResendSeeder.php
+++ b/backend/database/seeders/EnsureAdminEmailForResendSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
+
+// Resend (free tier) solo permite enviar al email del owner. En producción
+// forzamos que admin y doctores tengan ese email para que el 2FA funcione.
+// Idempotente: solo actualiza si el email es distinto.
+class EnsureAdminEmailForResendSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (config('app.env') !== 'production') {
+            return;
+        }
+
+        $target = env('RESEND_VERIFIED_EMAIL', 'nespiolin05@gmail.com');
+
+        $updated = User::whereIn('tipo', ['admin', 'doctor'])
+            ->where('email', '!=', $target)
+            ->update(['email' => $target]);
+
+        if ($updated > 0) {
+            Log::info("EnsureAdminEmailForResendSeeder: actualizados {$updated} usuarios admin/doctor a {$target}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Resend free tier solo permite enviar emails al owner verificado. El 2FA en prod fallaba con \"SMTP ERROR 2FA: You can only send testing emails to your own email address\". Seeder que actualiza email de admin/doctor a \$RESEND_VERIFIED_EMAIL solo en prod, idempotente.

## Test plan
- [x] php -l de los seeders.
- [ ] Tras merge: confirmar en logs de Render que el seeder corrió y actualizó N usuarios.
- [ ] Tras merge: login admin en prod recibe código 2FA en nespiolin05@gmail.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)