### PR TITLE
fix(prod): admin 2FA flow end-to-end

### DIFF
--- a/backend/database/seeders/EnsureAdminEmailForResendSeeder.php
+++ b/backend/database/seeders/EnsureAdminEmailForResendSeeder.php
@@ -23,10 +23,21 @@ class EnsureAdminEmailForResendSeeder extends Seeder
             return;
         }
 
-        $updated = User::whereIn('tipo', ['admin', 'doctor'])
-            ->where('email', '!=', $target)
-            ->update(['email' => $target]);
+        // Gmail acepta +alias: nespiolin05+admin@gmail.com llega al mismo inbox.
+        // Esto evita violar el UNIQUE de users.email cuando hay >1 usuario admin/doctor.
+        [$local, $domain] = explode('@', $target, 2);
 
-        Log::info("EnsureAdminEmailForResendSeeder: actualizados {$updated} usuarios admin/doctor a {$target}");
+        $usuarios = User::whereIn('tipo', ['admin', 'doctor'])->get();
+        $updated = 0;
+        foreach ($usuarios as $u) {
+            $slug = $u->username ?: ($u->tipo . $u->id);
+            $nuevoEmail = "{$local}+{$slug}@{$domain}";
+            if ($u->email !== $nuevoEmail) {
+                $u->update(['email' => $nuevoEmail]);
+                $updated++;
+            }
+        }
+
+        Log::info("EnsureAdminEmailForResendSeeder: actualizados {$updated} usuarios admin/doctor (alias de {$target})");
     }
 }

--- a/frontend/src/app/components/admin/admin-login/admin-login.component.ts
+++ b/frontend/src/app/components/admin/admin-login/admin-login.component.ts
@@ -46,16 +46,28 @@ export class AdminLoginComponent implements OnDestroy {
       tipo_usuario: 'admin'
     };
 
-    this.http.post<{ token: string; user: { tipo: string } }>(`${API_BASE_URL}/login`, body)
+    this.http.post<{ token?: string; user?: { tipo: string }; requires_2fa?: boolean; user_id?: number; email_masked?: string }>(`${API_BASE_URL}/login`, body)
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => { this.isLoading = false; })
       )
       .subscribe({
         next: (res) => {
-          localStorage.setItem('auth_token', res.token);
-          localStorage.setItem('user_data', JSON.stringify(res.user));
-          this.router.navigate(['/admin-dashboard']);
+          if (res.requires_2fa && res.user_id) {
+            sessionStorage.setItem('pending_2fa', JSON.stringify({
+              user_id: res.user_id,
+              email_masked: res.email_masked ?? '',
+            }));
+            this.router.navigate(['/verify-2fa']);
+            return;
+          }
+          if (res.token && res.user) {
+            localStorage.setItem('auth_token', res.token);
+            localStorage.setItem('user_data', JSON.stringify(res.user));
+            this.router.navigate(['/admin-dashboard']);
+          } else {
+            this.mostrarToast('Respuesta inesperada del servidor');
+          }
         },
         error: (err: HttpErrorResponse) => {
           const backendMsg = (err.error?.message as string | undefined)?.trim();


### PR DESCRIPTION
Backend: seeder usa Gmail aliases (+admin, +doctorOmar, +doctorCarlos) para evitar UNIQUE violation al asignar el mismo email base. Frontend: admin-login detecta requires_2fa y redirige a /verify-2fa con datos en sessionStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)