### PR TITLE
fix(prod): 2FA Resend — unificar email admin+doctor

### DIFF
--- a/backend/database/migrations/2026_05_16_230000_drop_email_unique_for_resend_workaround.php
+++ b/backend/database/migrations/2026_05_16_230000_drop_email_unique_for_resend_workaround.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Quita UNIQUE(email) para que admin y doctores compartan email verificado de Resend
+// Login usa username/numero_control, no email — no afecta funcionalidad
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['email']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('email');
+        });
+    }
+};

--- a/backend/database/seeders/EnsureAdminEmailForResendSeeder.php
+++ b/backend/database/seeders/EnsureAdminEmailForResendSeeder.php
@@ -23,16 +23,8 @@ class EnsureAdminEmailForResendSeeder extends Seeder
             return;
         }
 
-        // Resend (free tier) rechaza aliases +tag@gmail.com, solo acepta el email exacto.
-        // Solo admin recibe el email verificado; doctores quedan con alias (no podrán hacer 2FA
-        // en prod hasta verificar dominio en Resend, pero no es bloqueante para la demo).
-        [$local, $domain] = explode('@', $target, 2);
-
-        // 1) Liberar el target si lo tiene otro user (alias previo del propio admin o ex-admin).
-        User::where('email', $target)
-            ->update(['email' => "{$local}+freed-" . now()->timestamp . "@{$domain}"]);
-
-        // 2) Asignar el target al admin.
+        // Resend free tier sin dominio verificado solo entrega al email del owner.
+        // UNIQUE(email) eliminado para permitir que admin y doctores compartan email.
         $admin = User::where('tipo', 'admin')->first();
         if ($admin && $admin->email !== $target) {
             $admin->update(['email' => $target]);
@@ -41,13 +33,12 @@ class EnsureAdminEmailForResendSeeder extends Seeder
             Log::info("EnsureAdminEmailForResendSeeder: admin ya tiene {$target}");
         }
 
-        // 3) Doctores: asignar aliases únicos solo si todavía no los tienen.
+        // Doctores también reciben el email verificado para que 2FA funcione
         $doctores = User::where('tipo', 'doctor')->get();
         foreach ($doctores as $doc) {
-            $slug = $doc->username ?: ('doctor' . $doc->id);
-            $aliasEmail = "{$local}+{$slug}@{$domain}";
-            if ($doc->email !== $aliasEmail) {
-                $doc->update(['email' => $aliasEmail]);
+            if ($doc->email !== $target) {
+                $doc->update(['email' => $target]);
+                Log::info("EnsureAdminEmailForResendSeeder: doctor {$doc->id} actualizado a {$target}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Drop `UNIQUE(email)` para permitir que admin y doctores compartan el mismo email
- Seeder actualizado: doctores reciben `nespiolin05@gmail.com` (en vez de aliases `+tag`)
- Resend free tier sin dominio verificado solo entrega a ese email

## Env vars requeridas en Render (ya agregadas)
- `MAIL_MAILER=resend`
- `MAIL_FROM_ADDRESS=onboarding@resend.dev`
- `MAIL_FROM_NAME=Yoltec`

## Test plan
- [ ] Deploy a Render → verificar que migración y seeder corren
- [ ] Login como doctor → debe mostrar pantalla 2FA → email llega a nespiolin05@gmail.com
- [ ] Login como admin → mismo flujo 2FA funcional
- [ ] Login como alumno → sin 2FA, directo al dashboard