### PR TITLE
fix(frontend): guard localStorage corrupto en auth

### DIFF
--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -238,7 +238,13 @@ export class AuthService implements OnDestroy {
   // Obtener el usuario almacenado en el almacenamiento local
   private getStoredUser(): User | null {
     const userJson = localStorage.getItem(this.userKey);
-    return userJson ? JSON.parse(userJson) : null;
+    if (!userJson) return null;
+    try {
+      return JSON.parse(userJson);
+    } catch {
+      localStorage.removeItem(this.userKey);
+      return null;
+    }
   }
   
   // Redirigir al usuario según su tipo


### PR DESCRIPTION
## Summary
- `getStoredUser()` crasheaba con `JSON.parse("undefined")` si localStorage tenía datos corruptos
- Ahora hace try/catch: si el parse falla, limpia la key y retorna null

## Test plan
- [ ] Poner `localStorage.setItem('user_data', 'undefined')` en consola → recargar → no crashea, muestra login