### PR TITLE
fix(prod): dark mode + perfil género/foto (#39)

### DIFF
--- a/backend/app/Http/Controllers/PerfilMedicoController.php
+++ b/backend/app/Http/Controllers/PerfilMedicoController.php
@@ -30,6 +30,8 @@ class PerfilMedicoController extends Controller
                 'email'                => $alumno->email,
                 'telefono'             => $alumno->telefono,
                 'fecha_nacimiento'     => $alumno->fecha_nacimiento,
+                'genero'               => $alumno->genero,
+                'foto_perfil'          => $alumno->foto_perfil,
                 'tipo_sangre'          => $alumno->tipo_sangre,
                 'alergias'             => $alumno->alergias,
                 'enfermedades_cronicas' => $alumno->enfermedades_cronicas,

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -1,7 +1,7 @@
 .admin-app {
   display: flex;
   min-height: 100vh;
-  background: #f8fafc;
+  background: var(--yol-bg, #f8fafc);
   font-family: var(--yol-font, 'Inter', system-ui, sans-serif);
 }
 
@@ -25,13 +25,13 @@
   font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.4px;
-  color: #111827;
+  color: var(--yol-text, #111827);
 }
 
 .subtitle {
   margin: 6px 0 0;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--yol-text-muted, #6b7280);
   font-weight: 500;
 }
 
@@ -58,17 +58,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #fff;
-  color: #374151;
+  background: var(--yol-surface, #fff);
+  color: var(--yol-text, #374151);
   font: 500 13px var(--yol-font, 'Inter', sans-serif);
   padding: 9px 16px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--yol-border, #e5e7eb);
   border-radius: 7px;
   cursor: pointer;
   flex: 1;
 }
 
-.btn-ghost:hover { background: #f9fafb; }
+.btn-ghost:hover { background: var(--yol-bg, #f9fafb); }
 
 .btn-danger {
   display: inline-flex;
@@ -108,16 +108,16 @@
 
 /* Card */
 .card {
-  background: #fff;
+  background: var(--yol-surface, #fff);
   border-radius: 12px;
-  border: 1px solid #eef2f0;
+  border: 1px solid var(--yol-border, #eef2f0);
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
   overflow: hidden;
 }
 
 .card-head {
   padding: 16px 20px;
-  border-bottom: 1px solid #eef2f0;
+  border-bottom: 1px solid var(--yol-border, #eef2f0);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -128,7 +128,7 @@
   font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.2px;
-  color: #111827;
+  color: var(--yol-text, #111827);
 }
 
 .card-body {
@@ -145,17 +145,17 @@
 .nav-btn {
   width: 28px;
   height: 28px;
-  border: 1px solid #e5e7eb;
-  background: #fff;
+  border: 1px solid var(--yol-border, #e5e7eb);
+  background: var(--yol-surface, #fff);
   border-radius: 6px;
-  color: #374151;
+  color: var(--yol-text, #374151);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.nav-btn:hover { background: #f9fafb; }
+.nav-btn:hover { background: var(--yol-bg, #f9fafb); }
 
 .month-label {
   font-size: 14px;
@@ -163,7 +163,7 @@
   letter-spacing: -0.2px;
   min-width: 130px;
   text-align: center;
-  color: #111827;
+  color: var(--yol-text, #111827);
 }
 
 /* Grilla del calendario — Lun a Sáb (6 columnas) */
@@ -176,7 +176,7 @@
 .day-header {
   font-size: 11px;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--yol-text-muted, #6b7280);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   text-align: center;
@@ -185,45 +185,45 @@
 
 .cal-cell {
   aspect-ratio: 1;
-  border: 1px solid #eef2f0;
+  border: 1px solid var(--yol-border, #eef2f0);
   border-radius: 8px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   padding: 7px 8px;
   cursor: pointer;
-  background: #fff;
+  background: var(--yol-surface, #fff);
   position: relative;
   overflow: hidden;
 }
 
-.cal-cell:hover { border-color: #1a5c3a; }
+.cal-cell:hover { border-color: var(--yol-primary, #1a5c3a); }
 
-.cal-cell.muted { background: #fafbfb; }
-.cal-cell.muted .day-num { color: #9ca3af; }
+.cal-cell.muted { background: var(--yol-bg, #fafbfb); }
+.cal-cell.muted .day-num { color: var(--yol-text-subtle, #9ca3af); }
 
 .cal-cell.past {
-  background: #f3f4f6;
+  background: var(--yol-bg, #f3f4f6);
   cursor: not-allowed;
   pointer-events: none;
 }
-.cal-cell.past .day-num { color: #9ca3af; text-decoration: line-through; }
+.cal-cell.past .day-num { color: var(--yol-text-subtle, #9ca3af); text-decoration: line-through; }
 
 .cal-cell.special {
-  background: #fee2e2;
-  border-color: #fecaca;
+  background: var(--yol-cancel-surface, #fee2e2);
+  border-color: var(--yol-cancel-text, #fecaca);
 }
-.cal-cell.special .day-num { color: #b91c1c; }
+.cal-cell.special .day-num { color: var(--yol-danger, #b91c1c); }
 
 .cal-cell.selected {
-  box-shadow: 0 0 0 2px #1a5c3a;
-  border-color: #1a5c3a;
+  box-shadow: 0 0 0 2px var(--yol-primary, #1a5c3a);
+  border-color: var(--yol-primary, #1a5c3a);
 }
 
 .day-num {
   font-size: 13px;
   font-weight: 600;
-  color: #111827;
+  color: var(--yol-text, #111827);
   font-variant-numeric: tabular-nums;
 }
 
@@ -232,7 +232,7 @@
   font-weight: 700;
   letter-spacing: 0.2px;
   text-transform: uppercase;
-  color: #b91c1c;
+  color: var(--yol-danger, #b91c1c);
   line-height: 1.2;
   margin-top: auto;
   overflow: hidden;
@@ -246,7 +246,7 @@
   gap: 16px;
   margin-top: 14px;
   font-size: 12px;
-  color: #6b7280;
+  color: var(--yol-text-muted, #6b7280);
   font-weight: 500;
 }
 
@@ -260,14 +260,14 @@
   width: 12px;
   height: 12px;
   border-radius: 3px;
-  background: #fee2e2;
-  border: 1px solid #fecaca;
+  background: var(--yol-cancel-surface, #fee2e2);
+  border: 1px solid var(--yol-cancel-text, #fecaca);
   flex-shrink: 0;
 }
 
 .swatch.swatch-past {
-  background: #f3f4f6;
-  border-color: #e5e7eb;
+  background: var(--yol-bg, #f3f4f6);
+  border-color: var(--yol-border, #e5e7eb);
 }
 
 /* Tabla */
@@ -282,16 +282,16 @@ th {
   padding: 10px 20px;
   font-size: 11px;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--yol-text-muted, #6b7280);
   letter-spacing: 0.4px;
   text-transform: uppercase;
-  background: #fafbfb;
-  border-bottom: 1px solid #eef2f0;
+  background: var(--yol-bg, #fafbfb);
+  border-bottom: 1px solid var(--yol-border, #eef2f0);
 }
 
 td {
   padding: 12px 20px;
-  border-bottom: 1px solid #eef2f0;
+  border-bottom: 1px solid var(--yol-border, #eef2f0);
   vertical-align: middle;
 }
 
@@ -299,12 +299,12 @@ tr:last-child td { border-bottom: 0; }
 
 .td-date {
   font-weight: 600;
-  color: #111827;
+  color: var(--yol-text, #111827);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
-.td-motivo { color: #374151; }
+.td-motivo { color: var(--yol-text, #374151); }
 
 .td-action { text-align: right; }
 
@@ -312,7 +312,7 @@ tr:last-child td { border-bottom: 0; }
   padding: 32px 20px;
   text-align: center;
   font-size: 13px;
-  color: #9ca3af;
+  color: var(--yol-text-subtle, #9ca3af);
 }
 
 .loading-row {
@@ -324,7 +324,7 @@ tr:last-child td { border-bottom: 0; }
 
 .sk-line {
   height: 14px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(90deg, var(--yol-bg, #f3f4f6) 25%, var(--yol-border, #e5e7eb) 50%, var(--yol-bg, #f3f4f6) 75%);
   background-size: 200% 100%;
   border-radius: 4px;
   animation: shimmer 1.4s infinite;
@@ -348,7 +348,7 @@ tr:last-child td { border-bottom: 0; }
 }
 
 .modal {
-  background: #fff;
+  background: var(--yol-surface, #fff);
   border-radius: 12px;
   padding: 24px;
   width: 100%;
@@ -363,13 +363,13 @@ tr:last-child td { border-bottom: 0; }
   font-size: 16px;
   font-weight: 700;
   letter-spacing: -0.3px;
-  color: #111827;
+  color: var(--yol-text, #111827);
 }
 
 .modal-desc {
   margin: 0 0 20px;
   font-size: 13.5px;
-  color: #374151;
+  color: var(--yol-text-muted, #374151);
   line-height: 1.55;
 }
 
@@ -384,18 +384,18 @@ tr:last-child td { border-bottom: 0; }
 .field label {
   font-size: 12.5px;
   font-weight: 500;
-  color: #374151;
+  color: var(--yol-text-muted, #374151);
 }
 
 .field input,
 .field select {
   height: 40px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--yol-border, #e5e7eb);
   border-radius: 8px;
-  background: #fff;
+  background: var(--yol-surface, #fff);
   padding: 0 12px;
   font: 500 13px var(--yol-font, 'Inter', sans-serif);
-  color: #111827;
+  color: var(--yol-text, #111827);
   outline: none;
   width: 100%;
   box-sizing: border-box;
@@ -403,13 +403,15 @@ tr:last-child td { border-bottom: 0; }
 
 .field input:focus,
 .field select:focus {
-  border-color: #1a5c3a;
+  border-color: var(--yol-primary, #1a5c3a);
   box-shadow: 0 0 0 3px rgba(26, 92, 58, 0.12);
 }
 
+.field select option { background: var(--yol-surface); color: var(--yol-text); }
+
 .field-hint {
   font-weight: 400;
-  color: #6b7280;
+  color: var(--yol-text-muted, #6b7280);
   font-size: 11px;
   margin-left: 4px;
 }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
@@ -347,6 +347,8 @@
 
 .fic { color: var(--yol-text-subtle); font-size: var(--yol-fs-h3); }
 
+.ffld select option { background: var(--yol-surface); color: var(--yol-text); }
+
 .spacer { flex: 1; }
 
 /* --- Modal --- */


### PR DESCRIPTION
## Summary
- **Doctor pre-evaluaciones**: dropdown filtro con fondo correcto en dark mode
- **Admin días especiales**: todos los colores hardcoded reemplazados por tokens del DS
- **PerfilMedicoController::show()**: ahora retorna `genero` y `foto_perfil` (faltaban en el array)

## Nota
Los datos de prueba en alergias/enfermedades se limpian desde la UI (tab Médico → Editar)

## Test plan
- [ ] Doctor → Pre-evaluaciones → dropdown filtro sin fondo blanco en dark mode
- [ ] Admin → Días especiales → calendario adaptado a dark mode
- [ ] Alumno → Mi perfil → género se muestra correctamente después de guardarlo
- [ ] Alumno → Mi perfil → foto persiste al cerrar y abrir sesión