### PR TITLE
fix(prod): limpiar datos de prueba médicos

### DIFF
--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -79,5 +79,10 @@ class DatabaseSeeder extends Seeder
         );
 
         $this->call(EnsureAdminEmailForResendSeeder::class);
+
+        // Limpiar datos de prueba en campos médicos
+        User::where('numero_control', '22690495')
+            ->whereNotNull('alergias')
+            ->update(['alergias' => null, 'enfermedades_cronicas' => null]);
     }
 }


### PR DESCRIPTION
## Summary
- Seeder limpia `alergias` y `enfermedades_cronicas` del alumno 22690495 (tenía "Trabajo" y "Tu mami")
- Solo limpia si `alergias` no es null (idempotente)