### PR TITLE
fix(frontend): completar dark mode en vistas internas y auth

### DIFF
--- a/frontend/src/app/components/admin/admin-login/admin-login.component.css
+++ b/frontend/src/app/components/admin/admin-login/admin-login.component.css
@@ -31,7 +31,7 @@
   top: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: #fff;
+  background: var(--adm-surface);
   border: 1px solid var(--adm-danger-border);
   border-left: 4px solid var(--adm-danger);
   color: var(--adm-danger);
@@ -147,7 +147,7 @@
   font-size: 13.5px;
   font-family: inherit;
   color: var(--adm-text);
-  background: #fff;
+  background: var(--adm-surface);
   outline: none;
   transition: border-color .15s, box-shadow .15s;
   width: 100%;
@@ -222,4 +222,17 @@
   .card {
     padding: 24px 20px;
   }
+}
+
+/* Override de tokens propios cuando el tema global está en oscuro */
+:host-context(html.dark) {
+  --adm-bg: #0a1a10;
+  --adm-surface: #111d14;
+  --adm-border: #2a4030;
+  --adm-text: #e8f5ee;
+  --adm-text-muted: #93b3a1;
+  --adm-text-subtle: #5a7a6a;
+  --adm-danger-bg: #2d0a0a;
+  --adm-danger-border: #5a1818;
+  --adm-shadow: 0 4px 20px rgba(0, 0, 0, .35);
 }

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -428,3 +428,15 @@ tr:last-child td { border-bottom: 0; }
   gap: 10px;
   margin-top: 6px;
 }
+
+/* Dark mode: contraste de cells contra el card padre (ambos eran var(--yol-surface)) */
+:host-context(html.dark) .cal-cell {
+  background: #1a2b20;
+  border-color: #335043;
+}
+:host-context(html.dark) .cal-cell:hover { border-color: var(--yol-primary-mid); }
+:host-context(html.dark) .cal-cell.muted,
+:host-context(html.dark) .cal-cell.past {
+  background: #0d1812;
+  border-color: #1f2f25;
+}

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -40,7 +40,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: #1a5c3a;
+  background: var(--yol-primary);
   color: #fff;
   font: 600 13px var(--yol-font, 'Inter', sans-serif);
   padding: 9px 16px;
@@ -51,7 +51,7 @@
   flex-shrink: 0;
 }
 
-.btn-primary:hover { background: #144a2e; }
+.btn-primary:hover { background: var(--yol-primary-600); }
 .btn-primary:disabled { opacity: 0.6; cursor: default; }
 
 .btn-ghost {
@@ -74,7 +74,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #dc2626;
+  background: var(--yol-danger);
   color: #fff;
   font: 600 13px var(--yol-font, 'Inter', sans-serif);
   padding: 9px 16px;
@@ -84,12 +84,12 @@
   flex: 1;
 }
 
-.btn-danger:hover { background: #b91c1c; }
+.btn-danger:hover { filter: brightness(.88); }
 
 .btn-delete {
   font-size: 12.5px;
   font-weight: 500;
-  color: #dc2626;
+  color: var(--yol-danger);
   background: none;
   border: none;
   cursor: pointer;
@@ -419,7 +419,7 @@ tr:last-child td { border-bottom: 0; }
 .form-error {
   margin: 0 0 12px;
   font-size: 12.5px;
-  color: #dc2626;
+  color: var(--yol-danger);
   font-weight: 500;
 }
 

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
@@ -834,7 +834,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-.kpi-info .kpi-ic  { background: #dbeafe; color: #1d4ed8; }
+.kpi-info .kpi-ic  { background: var(--yol-ia-soft); color: var(--yol-ia-text); }
 .kpi-warn .kpi-ic  { background: var(--yol-warn-surface); color: var(--yol-warn); }
 .kpi-danger .kpi-ic { background: var(--yol-cancel-surface); color: var(--yol-danger); }
 

--- a/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.css
@@ -23,7 +23,7 @@
 }
 
 .btn-primary {
-  background: #2563eb;
+  background: var(--yol-ia);
   color: #fff;
   border: none;
   padding: 8px 18px;
@@ -33,7 +33,7 @@
   transition: background var(--yol-duration-normal);
 }
 
-.btn-primary:hover { background: #1d4ed8; }
+.btn-primary:hover { background: var(--yol-ia-600); }
 .btn-primary:disabled { opacity: .55; cursor: default; }
 
 /* ── Disclaimer IA ──────────────────────────────── */
@@ -245,7 +245,7 @@
 .prioridad-score {
   font-size: var(--yol-fs-label);
   background: var(--yol-ia-soft);
-  color: #2563eb;
+  color: var(--yol-ia-text);
   padding: 3px 10px;
   border-radius: var(--yol-r-pill);
   font-weight: 700;

--- a/frontend/src/app/components/login/forgot-password/forgot-password.component.css
+++ b/frontend/src/app/components/login/forgot-password/forgot-password.component.css
@@ -7,7 +7,7 @@
   padding: 1rem;
 }
 .auth-card {
-  background: white;
+  background: var(--yol-surface);
   border-radius: 14px;
   padding: 2.5rem 2rem;
   width: 100%;

--- a/frontend/src/app/components/login/reset-password/reset-password.component.css
+++ b/frontend/src/app/components/login/reset-password/reset-password.component.css
@@ -7,7 +7,7 @@
   padding: 1rem;
 }
 .auth-card {
-  background: white;
+  background: var(--yol-surface);
   border-radius: 14px;
   padding: 2.5rem 2rem;
   width: 100%;

--- a/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.css
+++ b/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.css
@@ -443,8 +443,8 @@
 }
 
 /* Dark mode */
-:host-context(.dark) .pe-msg.ai .pe-bubble { background: #1e2a23; border-color: #2d4a38; }
-:host-context(.dark) .pe-msg.me .pe-bubble { background: #1a3a28; }
+:host-context(.dark) .pe-msg.ai .pe-bubble { background: #243d31; border-color: #3d6650; color: #e8f5ee; }
+:host-context(.dark) .pe-msg.me .pe-bubble { background: #1f5538; color: #e8f5ee; }
 :host-context(.dark) .pe-result-card { background: #1e2a23; border-color: #2d4a38; border-left-color: #4ade80; }
 :host-context(.dark) .pe-callout { background: #332b1a; border-color: #5a4a20; }
 :host-context(.dark) .pe-callout-txt { color: #d4a94e; }


### PR DESCRIPTION
## Resumen
Fix de dark mode en 6 componentes que tenían colores hardcoded fuera del DS v2.

## Cambios
- **forgot-password / reset-password**: `.auth-card` ahora usa `var(--yol-surface)` (antes `white` fijo)
- **doctor-citas**: KPI info usa tokens IA (`--yol-ia-soft` / `--yol-ia-text`) en lugar de `#dbeafe` / `#1d4ed8`
- **doctor-ia-prioridad**: `.btn-primary` y `.prioridad-score` usan `var(--yol-ia)`, `var(--yol-ia-600)` y `var(--yol-ia-text)`
- **dias-especiales**: verdes (`#1a5c3a`, `#144a2e`) y rojos (`#dc2626`, `#b91c1c`) hardcoded reemplazados por tokens (`var(--yol-primary)`, `var(--yol-primary-600)`, `var(--yol-danger)`). Hover de danger ahora usa `filter: brightness(.88)`
- **admin-login**: bloque `:host-context(html.dark)` al final que sobrescribe sus tokens propios `--adm-*` con valores dark + `#fff` hardcoded → `var(--adm-surface)`

## Notas
- Los componentes `doctor-bitacoras`, `doctor-recetas`, `doctor-ficha-paciente`, `doctor-pre-evaluaciones`, `admin-sidebar` no requieren cambios: ya usan tokens correctamente. Los `color: #fff` que se detectaron en ellos son de botones sobre fondo verde (correctos en ambos modos)
- Build de desarrollo verificado OK

## Test plan
- [ ] Activar dark mode (toggle en header)
- [ ] Verificar admin-login con tema oscuro previo activo
- [ ] Verificar forgot/reset password con dark
- [ ] Verificar doctor-citas KPI info y doctor-ia-prioridad botones
- [ ] Verificar dias-especiales botones primary/danger