### PR TITLE
fix(frontend): reemplazar var(--yol-surface-2) inexistente

### DIFF
--- a/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.css
+++ b/frontend/src/app/components/student/pre-evaluacion-ia/pre-evaluacion-ia.component.css
@@ -524,7 +524,7 @@
   gap: 12px;
   padding: 12px 16px;
   border-bottom: 1px solid var(--yol-border);
-  background: var(--yol-surface-2, #fafbfc);
+  background: var(--yol-bg);
   flex-wrap: wrap;
 }
 .pe-cita-picker label {
@@ -579,7 +579,7 @@
 .pe-badge-descartado { background: #fee2e2; color: #991b1b; }
 
 .pe-existing-card {
-  background: var(--yol-surface-2, #fafbfc);
+  background: var(--yol-bg);
   border: 1px solid var(--yol-border);
   border-radius: 10px;
   padding: 16px 18px;


### PR DESCRIPTION
Hallazgo en DevTools: pe-cita-picker y pe-existing-card usaban un token CSS que no existía, aplicando fallback blanco que rompía dark mode. Reemplazado por var(--yol-bg).