### PR TITLE
fix(frontend): dark mode en calendario REAL del admin-dashboard

### DIFF
--- a/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.css
+++ b/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.css
@@ -993,3 +993,25 @@
   .users-toolbar { flex-direction: column; align-items: stretch; }
   .toolbar-actions { flex-wrap: wrap; }
 }
+
+/* Dark mode: calendario de días especiales */
+:host-context(html.dark) .cal-day {
+  background: #1f3a2a;
+  border-color: #2a4030;
+}
+:host-context(html.dark) .cal-day:hover:not(.other-month):not(.past) {
+  background: #2b4f3a;
+  border-color: var(--yol-primary-mid);
+}
+:host-context(html.dark) .cal-day.past {
+  background: #060c08;
+  opacity: 0.55;
+}
+:host-context(html.dark) .cal-day.past .day-num { color: #5a7a6a; }
+:host-context(html.dark) .cal-day.selected {
+  background: #2b4f3a !important;
+  border-color: var(--yol-primary-mid) !important;
+}
+:host-context(html.dark) .cal-day.fes { background: #3a1414; border-color: #6a2020; }
+:host-context(html.dark) .cal-day.vac { background: #0d1b3e; border-color: #1e3a6e; }
+:host-context(html.dark) .cal-day.red { background: #2d1800; border-color: #5a3a10; }

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -429,18 +429,3 @@ tr:last-child td { border-bottom: 0; }
   margin-top: 6px;
 }
 
-/* Dark mode: contraste explícito de cells contra el card padre */
-:host-context(html.dark) .cal-cell {
-  background: #1f3a2a;
-  border-color: #4a6b56;
-}
-:host-context(html.dark) .cal-cell:hover { border-color: var(--yol-primary-mid); }
-:host-context(html.dark) .cal-cell.muted,
-:host-context(html.dark) .cal-cell.past {
-  background: #060c08;
-  border-color: #1a2820;
-  opacity: 0.55;
-}
-:host-context(html.dark) .cal-cell .day-num { color: #e8f5ee; }
-:host-context(html.dark) .cal-cell.past .day-num,
-:host-context(html.dark) .cal-cell.muted .day-num { color: #5a7a6a; }


### PR DESCRIPTION
Los fixes anteriores (#41, #42) tocaban el componente `dias-especiales` que no es el que se renderiza en /admin-dashboard. El calendario real vive en `admin-dashboard.component.css` con clases `.cal-day` distintas. Identificado vía DevTools.