### PR TITLE
fix(frontend): mostrar Reprogramar en drawer aunque alumno no este cargado

### DIFF
--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
@@ -257,8 +257,8 @@
 
     <!-- Footer para citas programadas -->
     <ng-container *ngIf="drawerCita.estatus === 'programada'">
-      <div class="drawer-foot-top" *ngIf="drawerCita.alumno">
-        <button class="btn-sm btn-outline flex1" (click)="openPerfilAlumno(drawerCita.alumno.id)">Ver expediente</button>
+      <div class="drawer-foot-top">
+        <button *ngIf="drawerCita.alumno" class="btn-sm btn-outline flex1" (click)="openPerfilAlumno(drawerCita.alumno.id)">Ver expediente</button>
         <button class="btn-sm btn-gray flex1" (click)="drawerReprogramar(drawerCita)">Reprogramar</button>
       </div>
       <div class="drawer-foot">


### PR DESCRIPTION
## Resumen
En el drawer de detalle de cita del doctor, el botón **Reprogramar** estaba dentro de un `*ngIf="drawerCita.alumno"` junto con **Ver expediente**. Cuando una cita venía sin el relation `alumno` cargado (o con `alumno_id` nulo), desaparecían ambos botones, dejando al doctor sin manera de reprogramar.

## Fix
Mover el `*ngIf` solo al botón **Ver expediente** (que sí depende de `drawerCita.alumno.id`). **Reprogramar** queda siempre visible para citas programadas, porque solo necesita el id de la cita.

## Plan de prueba
- [ ] En `/doctor-dashboard` → Citas, click en una cita programada
- [ ] Confirmar que el botón **Reprogramar** aparece arriba del bloque Cancelar/No asistió/Consulta
- [ ] Click → abre modal de fecha/hora → confirmar → cita se reprograma + notif push