### PR TITLE
fix: bloquear agendar/reprogramar a horas ya pasadas del dia

### DIFF
--- a/backend/app/Services/CitaService.php
+++ b/backend/app/Services/CitaService.php
@@ -62,6 +62,9 @@ class CitaService
         if ($hora < '08:00' || $hora > '16:45') {
             return 'El horario de atención es de 08:00 a 16:45.';
         }
+        if (Carbon::parse($fecha)->isToday() && $hora <= Carbon::now()->format('H:i')) {
+            return 'La hora seleccionada ya pasó. Elige una hora futura.';
+        }
         $dia = DiaEspecial::where('fecha', $fecha)->first();
         if ($dia) {
             $status = config("clinic.types.{$dia->tipo}.status", 'full');

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
@@ -543,7 +543,7 @@
       <label>Nueva hora</label>
       <select [(ngModel)]="reprogramarHora" class="filtro-select">
         <option value="">Selecciona hora</option>
-        <option *ngFor="let slot of timeSlots" [value]="normalizeTime(slot)">{{ formatTime(slot) }}</option>
+        <option *ngFor="let slot of slotsParaFecha(reprogramarFecha)" [value]="normalizeTime(slot)">{{ formatTime(slot) }}</option>
       </select>
     </div>
 

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
@@ -796,4 +796,12 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     }
     return slots;
   }
+
+  // Filtra slots a futuras si fecha == hoy; devuelve todos si es fecha posterior.
+  slotsParaFecha(fecha: string): string[] {
+    if (fecha !== this.today) return this.timeSlots;
+    const now = new Date();
+    const horaActual = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+    return this.timeSlots.filter(s => s > horaActual);
+  }
 }


### PR DESCRIPTION
## Resumen
Se podia reprogramar (y agendar) una cita a una hora que ya habia pasado del dia actual (ej: son las 14:00 y eliges 10:00 hoy).

## Cambios
- **backend** `CitaService::validarHorario()`: rechaza si fecha == hoy y hora <= ahora. Aplica a agendar Y reprogramar (ambos pasan por aqui).
- **frontend** modal reprogramar: el dropdown de horas filtra slots pasados cuando la fecha seleccionada es hoy.

## Plan de prueba
- [ ] Reprogramar una cita a hoy con hora pasada -> dropdown ya no la muestra
- [ ] Reprogramar a fecha futura -> dropdown muestra todos los slots
- [ ] Reprogramar a fecha y hora futura del mismo dia -> exito
- [ ] (Backend) Llamar POST/PUT con hora pasada via curl -> 422 con mensaje claro