### PR TITLE
feat(mobile): tokens DS alineados a design-reference (Fase 5 Bloque 2)

### DIFF
--- a/mobile/lib/utils/app_theme.dart
+++ b/mobile/lib/utils/app_theme.dart
@@ -1,44 +1,74 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+// Tokens alineados con mobile/design-reference/*.html (DS Yoltec mobile)
 class AppTheme {
-  // Verde medico institucional — Design System Yoltec
-  static const Color primaryColor = Color(0xFF1B6B45);
-  static const Color primaryDark = Color(0xFF155A39);
+  // Brand verde clínico
+  static const Color primaryColor = Color(0xFF1A5C3A);
+  static const Color primaryDark = Color(0xFF144A2E);
   static const Color primaryLight = Color(0xFF4CAF82);
   static const Color primarySurface = Color(0xFFE8F5EE);
 
-  // IA — azul clinico
+  // IA — azul clínico (acento separado del brand)
   static const Color iaColor = Color(0xFF2563EB);
   static const Color iaSurface = Color(0xFFEFF6FF);
 
-  // Colores de estado
-  static const Color success = Color(0xFF1B6B45);
-  static const Color warning = Color(0xFFF57C00);
-  static const Color error = Color(0xFFC62828);
+  // Estados
+  static const Color success = Color(0xFF1A5C3A);
+  static const Color warning = Color(0xFFB45309);
+  static const Color warningSurface = Color(0xFFFEF3E0);
+  static const Color error = Color(0xFFDC2626);
+  static const Color errorSurface = Color(0xFFFEF2F2);
   static const Color info = Color(0xFF2563EB);
 
-  // Neutros verde-tintados
-  static const Color bg = Color(0xFFF7F9F8);
+  // Superficie y texto (light)
+  static const Color bg = Color(0xFFF8FAFC);
   static const Color surface = Color(0xFFFFFFFF);
-  static const Color border = Color(0xFFDDE8E3);
-  static const Color textPrimary = Color(0xFF1A2E25);
-  static const Color textMuted = Color(0xFF4A6859);
-  static const Color textSubtle = Color(0xFF7B8F86);
+  static const Color border = Color(0xFFE5E7EB);
+  static const Color borderSoft = Color(0xFFF3F4F6);
+  static const Color textPrimary = Color(0xFF111827);
+  static const Color textMuted = Color(0xFF6B7280);
+  static const Color textSubtle = Color(0xFF9CA3AF);
 
-  // Grises legacy (para compatibilidad con widgets existentes)
-  static const Color gray50 = Color(0xFFFAFAFA);
-  static const Color gray100 = Color(0xFFF5F5F5);
-  static const Color gray200 = Color(0xFFEEEEEE);
-  static const Color gray300 = Color(0xFFE0E0E0);
-  static const Color gray400 = Color(0xFFBDBDBD);
-  static const Color gray500 = Color(0xFF9E9E9E);
-  static const Color gray600 = Color(0xFF757575);
-  static const Color gray700 = Color(0xFF616161);
-  static const Color gray800 = Color(0xFF424242);
-  static const Color gray900 = Color(0xFF212121);
+  // Superficies dark (alineadas con design-reference-dark)
+  static const Color bgDark = Color(0xFF0F172A);
+  static const Color surfaceDark = Color(0xFF1A1D27);
+  static const Color borderDark = Color(0xFF2D3144);
+  static const Color textPrimaryDark = Color(0xFFE5E7EB);
+  static const Color textMutedDark = Color(0xFF9CA3AF);
+  static const Color textSubtleDark = Color(0xFF6B7280);
+
+  // Grises neutros (Tailwind) — aliases para compatibilidad con widgets existentes
+  static const Color gray50 = Color(0xFFF9FAFB);
+  static const Color gray100 = Color(0xFFF3F4F6);
+  static const Color gray200 = Color(0xFFE5E7EB);
+  static const Color gray300 = Color(0xFFD1D5DB);
+  static const Color gray400 = Color(0xFF9CA3AF);
+  static const Color gray500 = Color(0xFF6B7280);
+  static const Color gray600 = Color(0xFF6B7280);
+  static const Color gray700 = Color(0xFF4B5563);
+  static const Color gray800 = Color(0xFF374151);
+  static const Color gray900 = Color(0xFF111827);
+
+  // Radios
+  static const double radiusSm = 6;
+  static const double radiusMd = 8;
+  static const double radiusLg = 12;
+  static const double radiusPill = 999;
 
   static ThemeData get lightTheme {
+    final textTheme = GoogleFonts.interTextTheme(const TextTheme(
+      headlineLarge: TextStyle(fontSize: 28, fontWeight: FontWeight.w700, color: textPrimary, letterSpacing: -0.5),
+      headlineMedium: TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: textPrimary, letterSpacing: -0.3),
+      headlineSmall: TextStyle(fontSize: 17, fontWeight: FontWeight.w600, color: textPrimary),
+      titleLarge: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: textPrimary),
+      titleMedium: TextStyle(fontSize: 14, fontWeight: FontWeight.w500, color: textMuted),
+      bodyLarge: TextStyle(fontSize: 14, color: textPrimary),
+      bodyMedium: TextStyle(fontSize: 13, color: textMuted),
+      bodySmall: TextStyle(fontSize: 12, color: textSubtle),
+      labelLarge: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: textPrimary),
+    ));
+
     return ThemeData(
       useMaterial3: true,
       brightness: Brightness.light,
@@ -47,36 +77,37 @@ class AppTheme {
         onPrimary: Colors.white,
         primaryContainer: primarySurface,
         onPrimaryContainer: primaryDark,
-        secondary: primaryLight,
+        secondary: iaColor,
         onSecondary: Colors.white,
+        secondaryContainer: iaSurface,
+        onSecondaryContainer: iaColor,
         surface: surface,
         onSurface: textPrimary,
         error: error,
         onError: Colors.white,
+        errorContainer: errorSurface,
+        onErrorContainer: error,
       ),
       scaffoldBackgroundColor: bg,
-      appBarTheme: const AppBarTheme(
+      appBarTheme: AppBarTheme(
         centerTitle: true,
         elevation: 0,
         backgroundColor: primaryColor,
         foregroundColor: Colors.white,
-        titleTextStyle: TextStyle(
-
+        titleTextStyle: GoogleFonts.inter(
           color: Colors.white,
-          fontSize: 17,
+          fontSize: 16,
           fontWeight: FontWeight.w600,
           letterSpacing: -0.2,
         ),
-        iconTheme: IconThemeData(color: Colors.white),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       cardTheme: CardThemeData(
         elevation: 0,
         color: surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
-          side: const BorderSide(color: border),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusLg)),
         margin: EdgeInsets.zero,
+        shadowColor: Colors.black.withValues(alpha: 0.04),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
@@ -84,14 +115,8 @@ class AppTheme {
           foregroundColor: Colors.white,
           elevation: 0,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          textStyle: const TextStyle(
-  
-            fontSize: 15,
-            fontWeight: FontWeight.w600,
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusMd)),
+          textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
@@ -99,32 +124,37 @@ class AppTheme {
           foregroundColor: primaryColor,
           side: const BorderSide(color: primaryColor),
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusMd)),
+          textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: primaryColor,
+          textStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
         fillColor: surface,
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: border),
         ),
         enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: border),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: primaryColor, width: 2),
         ),
         errorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: error),
         ),
         focusedErrorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: error, width: 2),
         ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
@@ -137,94 +167,91 @@ class AppTheme {
         backgroundColor: surface,
         type: BottomNavigationBarType.fixed,
         elevation: 0,
-        selectedLabelStyle: TextStyle(fontSize: 10.5, fontWeight: FontWeight.w500),
+        selectedLabelStyle: TextStyle(fontSize: 10.5, fontWeight: FontWeight.w600),
         unselectedLabelStyle: TextStyle(fontSize: 10.5, fontWeight: FontWeight.w500),
       ),
-      textTheme: GoogleFonts.interTextTheme(const TextTheme(
-        headlineLarge: TextStyle(
-            fontSize: 28, fontWeight: FontWeight.w700, color: textPrimary, letterSpacing: -0.5),
-        headlineMedium: TextStyle(
-            fontSize: 22, fontWeight: FontWeight.w700, color: textPrimary, letterSpacing: -0.2),
-        headlineSmall: TextStyle(
-            fontSize: 17, fontWeight: FontWeight.w600, color: textPrimary),
-        titleLarge: TextStyle(
-            fontSize: 15, fontWeight: FontWeight.w600, color: textPrimary),
-        titleMedium: TextStyle(
-            fontSize: 14, fontWeight: FontWeight.w500, color: textMuted),
-        bodyLarge: TextStyle(fontSize: 14, color: textPrimary),
-        bodyMedium: TextStyle(fontSize: 13, color: textMuted),
-        bodySmall: TextStyle(fontSize: 12, color: textSubtle),
-      )),
-      dividerTheme: const DividerThemeData(
-        color: border,
-        thickness: 1,
-        space: 0,
-      ),
+      textTheme: textTheme,
+      dividerTheme: const DividerThemeData(color: borderSoft, thickness: 1, space: 0),
       chipTheme: ChipThemeData(
         backgroundColor: primarySurface,
         labelStyle: const TextStyle(color: primaryColor, fontSize: 11, fontWeight: FontWeight.w600),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(999),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusPill)),
         padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
+        side: BorderSide.none,
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusLg)),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: textPrimary,
+        contentTextStyle: const TextStyle(color: Colors.white, fontSize: 13),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusMd)),
+        behavior: SnackBarBehavior.floating,
       ),
     );
   }
 
   static ThemeData get darkTheme {
+    final textTheme = GoogleFonts.interTextTheme(const TextTheme(
+      headlineLarge: TextStyle(fontSize: 28, fontWeight: FontWeight.w700, color: textPrimaryDark, letterSpacing: -0.5),
+      headlineMedium: TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: textPrimaryDark, letterSpacing: -0.3),
+      headlineSmall: TextStyle(fontSize: 17, fontWeight: FontWeight.w600, color: textPrimaryDark),
+      titleLarge: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: textPrimaryDark),
+      titleMedium: TextStyle(fontSize: 14, fontWeight: FontWeight.w500, color: textMutedDark),
+      bodyLarge: TextStyle(fontSize: 14, color: textPrimaryDark),
+      bodyMedium: TextStyle(fontSize: 13, color: textMutedDark),
+      bodySmall: TextStyle(fontSize: 12, color: textSubtleDark),
+      labelLarge: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: textPrimaryDark),
+    ));
+
     return ThemeData(
       useMaterial3: true,
       brightness: Brightness.dark,
       colorScheme: const ColorScheme.dark(
-        primary: primaryLight,
+        primary: primaryColor,
         onPrimary: Colors.white,
         primaryContainer: Color(0xFF1B3A2A),
         onPrimaryContainer: Colors.white,
-        secondary: primaryLight,
+        secondary: iaColor,
         onSecondary: Colors.white,
-        surface: Color(0xFF1E1E1E),
-        onSurface: Color(0xFFE0E0E0),
+        secondaryContainer: Color(0xFF1E293B),
+        onSecondaryContainer: iaColor,
+        surface: surfaceDark,
+        onSurface: textPrimaryDark,
         error: error,
         onError: Colors.white,
+        errorContainer: Color(0xFF3F1414),
+        onErrorContainer: Color(0xFFFCA5A5),
       ),
-      scaffoldBackgroundColor: const Color(0xFF121212),
-      appBarTheme: const AppBarTheme(
+      scaffoldBackgroundColor: bgDark,
+      appBarTheme: AppBarTheme(
         centerTitle: true,
         elevation: 0,
-        backgroundColor: Color(0xFF153D2A),
+        backgroundColor: primaryColor,
         foregroundColor: Colors.white,
-        titleTextStyle: TextStyle(
-
+        titleTextStyle: GoogleFonts.inter(
           color: Colors.white,
-          fontSize: 17,
+          fontSize: 16,
           fontWeight: FontWeight.w600,
           letterSpacing: -0.2,
         ),
-        iconTheme: IconThemeData(color: Colors.white),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       cardTheme: CardThemeData(
         elevation: 0,
-        color: const Color(0xFF1E1E1E),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
-          side: const BorderSide(color: Color(0xFF2C2C2C)),
-        ),
+        color: surfaceDark,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusLg)),
         margin: EdgeInsets.zero,
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: primaryLight,
+          backgroundColor: primaryColor,
           foregroundColor: Colors.white,
           elevation: 0,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          textStyle: const TextStyle(
-  
-            fontSize: 15,
-            fontWeight: FontWeight.w600,
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusMd)),
+          textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
@@ -232,69 +259,70 @@ class AppTheme {
           foregroundColor: primaryLight,
           side: const BorderSide(color: primaryLight),
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusMd)),
+          textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: primaryLight,
+          textStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: const Color(0xFF2C2C2C),
+        fillColor: surfaceDark,
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
-          borderSide: const BorderSide(color: gray700),
+          borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: const BorderSide(color: borderDark),
         ),
         enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
-          borderSide: const BorderSide(color: gray700),
+          borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: const BorderSide(color: borderDark),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: primaryLight, width: 2),
         ),
         errorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: error),
         ),
         focusedErrorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(6),
+          borderRadius: BorderRadius.circular(radiusSm),
           borderSide: const BorderSide(color: error, width: 2),
         ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-        labelStyle: const TextStyle(color: gray400, fontSize: 13),
-        hintStyle: const TextStyle(color: gray600),
+        labelStyle: const TextStyle(color: textMutedDark, fontSize: 13),
+        hintStyle: const TextStyle(color: textSubtleDark),
       ),
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
         selectedItemColor: primaryLight,
-        unselectedItemColor: gray500,
-        backgroundColor: Color(0xFF1E1E1E),
+        unselectedItemColor: textSubtleDark,
+        backgroundColor: surfaceDark,
         type: BottomNavigationBarType.fixed,
         elevation: 0,
-        selectedLabelStyle: TextStyle(fontSize: 10.5, fontWeight: FontWeight.w500),
+        selectedLabelStyle: TextStyle(fontSize: 10.5, fontWeight: FontWeight.w600),
         unselectedLabelStyle: TextStyle(fontSize: 10.5, fontWeight: FontWeight.w500),
       ),
-      textTheme: GoogleFonts.interTextTheme(const TextTheme(
-        headlineLarge: TextStyle(fontSize: 28, fontWeight: FontWeight.w700, color: Color(0xFFE0E0E0)),
-        headlineMedium: TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: Color(0xFFE0E0E0)),
-        headlineSmall: TextStyle(fontSize: 17, fontWeight: FontWeight.w600, color: Color(0xFFE0E0E0)),
-        titleLarge: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: Color(0xFFBDBDBD)),
-        titleMedium: TextStyle(fontSize: 14, fontWeight: FontWeight.w500, color: Color(0xFFBDBDBD)),
-        bodyLarge: TextStyle(fontSize: 14, color: Color(0xFFBDBDBD)),
-        bodyMedium: TextStyle(fontSize: 13, color: gray500),
-        bodySmall: TextStyle(fontSize: 12, color: gray600),
-      )),
-      dividerTheme: const DividerThemeData(
-        color: Color(0xFF2C2C2C),
-        thickness: 1,
-        space: 0,
-      ),
+      textTheme: textTheme,
+      dividerTheme: const DividerThemeData(color: borderDark, thickness: 1, space: 0),
       chipTheme: ChipThemeData(
         backgroundColor: const Color(0xFF1B3A2A),
         labelStyle: const TextStyle(color: primaryLight, fontSize: 11, fontWeight: FontWeight.w600),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(999),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusPill)),
         padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
+        side: BorderSide.none,
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: surfaceDark,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusLg)),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: surfaceDark,
+        contentTextStyle: const TextStyle(color: textPrimaryDark, fontSize: 13),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radiusMd)),
+        behavior: SnackBarBehavior.floating,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Bloque 2 de Fase 5 (mobile). Tokens del theme reescritos para coincidir con `mobile/design-reference/*.html` (light) y `mobile/design-reference-dark/*.html` (dark).

**Cambios de tokens:**
| Token | Antes | Ahora | Por que |
|---|---|---|---|
| `primaryColor` | `#1B6B45` | `#1A5C3A` | Match HTML reference |
| `error` | `#C62828` | `#DC2626` | Match HTML reference |
| `textPrimary` | `#1A2E25` (verde-tintado) | `#111827` (gris neutro) | Mas legible, alineado HTML |
| `textMuted` | `#4A6859` (verde-tintado) | `#6B7280` (gris neutro) | Igual |
| `textSubtle` | `#7B8F86` (verde-tintado) | `#9CA3AF` (gris neutro) | Igual |
| `border` | `#DDE8E3` (verde-tintado) | `#E5E7EB` (gris neutro) | Igual |
| `surfaceDark` | `#1E1E1E` | `#1A1D27` | Match design-reference-dark |

**Tokens nuevos:**
- `warning` / `warningSurface` para chips de estado pendiente (`#B45309` + `#FEF3E0`)
- `errorSurface` para chips cancelado/no_asistio (`#FEF2F2`)
- `borderSoft` (`#F3F4F6`) para dividers internos
- Dark: `bgDark`, `surfaceDark`, `borderDark`, `textPrimaryDark/MutedDark/SubtleDark`
- Radii como constantes: `radiusSm` (6), `radiusMd` (8), `radiusLg` (12), `radiusPill` (999)

**Theme adiciones:**
- `textButtonTheme`, `dialogTheme`, `snackBarTheme` (floating, radius consistente)
- AppBarTheme con font Inter explicito en titulo

**Mantenido sin cambio:**
- Azul clinico `#2563EB` exclusivo para componentes IA
- Aliases `gray50-900` apuntando a grises neutros (no rompe widgets existentes)
- `primarySurface`, `iaSurface`, `success`, `info`, etc.

**Verificacion:**
- `flutter analyze` → 0 issues
- API publico de `AppTheme` mantenido — todos los widgets siguen compilando

Despues: Bloque 3 redisena pantallas usando estos tokens, una pantalla por PR (Login, Inicio, Mis Citas, Agendar, IA, Recetas, Perfil).

## Test plan
- [ ] `flutter analyze` sin errores (verificado)
- [ ] `flutter run` arranca con nuevo verde mas oscuro y texto en grises neutros
- [ ] Modo oscuro: fondo `#0F172A`, surface `#1A1D27`
- [ ] Botones primarios usan verde Yoltec
- [ ] Inputs con border `#E5E7EB`, focus verde