### PR TITLE
feat(mobile): Bloque 3 — rediseño de las 7 pantallas (Fase 5)

### DIFF
--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -11,18 +11,16 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  // Controladores estudiante
   final _numeroControlCtrl = TextEditingController();
   final _nipCtrl = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
 
   bool _isLoading = false;
   String? _errorMessage;
   bool _obscureNip = true;
 
-  final _formAlumnoKey = GlobalKey<FormState>();
-
   Future<void> _login() async {
-    if (!_formAlumnoKey.currentState!.validate()) return;
+    if (!_formKey.currentState!.validate()) return;
 
     setState(() {
       _isLoading = true;
@@ -45,15 +43,13 @@ class _LoginScreenState extends State<LoginScreen> {
       }
     });
 
-    if (result['success'] == true) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Bienvenido a Yoltec'),
-            backgroundColor: AppTheme.primaryColor,
-          ),
-        );
-      }
+    if (result['success'] == true && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Bienvenido a Yoltec'),
+          backgroundColor: AppTheme.primaryColor,
+        ),
+      );
     }
   }
 
@@ -66,139 +62,157 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    final textSubtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+
     return Scaffold(
       backgroundColor: AppTheme.primaryColor,
       body: SafeArea(
+        bottom: false,
         child: Column(
           children: [
-            // Encabezado
-            Padding(
-              padding: EdgeInsets.symmetric(
-                  vertical: MediaQuery.of(context).size.height < 700 ? 16 : 32,
-                  horizontal: 24),
-              child: Column(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.2),
-                      shape: BoxShape.circle,
-                    ),
-                    child: Icon(
-                      Icons.local_hospital,
-                      size: MediaQuery.of(context).size.height < 700 ? 36 : 52,
-                      color: Colors.white,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  const Text(
-                    'Yoltec',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 32,
-                      fontWeight: FontWeight.bold,
-                      letterSpacing: 1,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Consultorio Medico',
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.85),
-                      fontSize: 15,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-
-            // Tarjeta de formulario
+            const _ZonaSuperior(),
             Expanded(
-              child: Container(
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface,
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(28),
+              child: Transform.translate(
+                offset: const Offset(0, -28),
+                child: Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: surface,
+                    borderRadius: const BorderRadius.vertical(
+                      top: Radius.circular(28),
+                    ),
                   ),
-                ),
-                child: Column(
-                  children: [
-                    const SizedBox(height: 20),
-
-                    // Formulario
-                    Expanded(
-                      child: SingleChildScrollView(
-                        padding: const EdgeInsets.all(24),
-                        child: Column(
-                          children: [
-                            // Error
-                            if (_errorMessage != null) ...[
-                              Container(
-                                padding: const EdgeInsets.all(12),
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).colorScheme.errorContainer,
-                                  borderRadius: BorderRadius.circular(10),
-                                  border: Border.all(
-                                    color: Theme.of(context).colorScheme.error.withValues(alpha: 0.4),
-                                  ),
-                                ),
-                                child: Row(
-                                  children: [
-                                    const Icon(Icons.error_outline,
-                                        color: AppTheme.error, size: 20),
-                                    const SizedBox(width: 8),
-                                    Expanded(
-                                      child: Text(
-                                        _errorMessage!,
-                                        style: const TextStyle(
-                                          color: AppTheme.error,
-                                          fontSize: 13,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              const SizedBox(height: 16),
-                            ],
-
-                            _buildAlumnoForm(),
-
-                            const SizedBox(height: 20),
-
-                            // Botón principal
-                            SizedBox(
-                              width: double.infinity,
-                              child: ElevatedButton(
-                                onPressed: _isLoading ? null : _login,
-                                child: _isLoading
-                                    ? const SizedBox(
-                                        width: 22,
-                                        height: 22,
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 2.5,
-                                          color: Colors.white,
-                                        ),
-                                      )
-                                    : const Text('Iniciar Sesión'),
-                              ),
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(28, 28, 28, 22),
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            'Iniciar sesión',
+                            style: TextStyle(
+                              fontSize: 22,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: -0.3,
+                              color: textMain,
                             ),
-
-                            const SizedBox(height: 20),
-                            const Text(
-                              'Solo personal autorizado del Instituto Tecnologico',
-                              textAlign: TextAlign.center,
-                              style: TextStyle(
-                                color: AppTheme.gray500,
-                                fontSize: 12,
-                              ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            'Ingresa con tu cuenta institucional',
+                            style: TextStyle(
+                              fontSize: 13.5,
+                              color: textMuted,
+                              fontWeight: FontWeight.w500,
                             ),
+                          ),
+                          const SizedBox(height: 24),
+                          if (_errorMessage != null) ...[
+                            _ErrorBanner(message: _errorMessage!),
+                            const SizedBox(height: 14),
                           ],
-                        ),
+                          const _CampoLabel(label: 'Número de control'),
+                          const SizedBox(height: 7),
+                          TextFormField(
+                            controller: _numeroControlCtrl,
+                            keyboardType: TextInputType.number,
+                            decoration: const InputDecoration(
+                              hintText: 'Ej. 22690495',
+                            ),
+                            validator: (v) {
+                              if (v == null || v.trim().isEmpty) {
+                                return 'Ingresa tu número de control';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          const _CampoLabel(label: 'NIP'),
+                          const SizedBox(height: 7),
+                          TextFormField(
+                            controller: _nipCtrl,
+                            obscureText: _obscureNip,
+                            keyboardType: TextInputType.number,
+                            decoration: InputDecoration(
+                              hintText: '••••••',
+                              suffixIcon: IconButton(
+                                icon: Icon(
+                                  _obscureNip
+                                      ? Icons.visibility_outlined
+                                      : Icons.visibility_off_outlined,
+                                  color: textMuted,
+                                  size: 20,
+                                ),
+                                onPressed: () => setState(
+                                    () => _obscureNip = !_obscureNip),
+                              ),
+                            ),
+                            validator: (v) {
+                              if (v == null || v.isEmpty) {
+                                return 'Ingresa tu NIP';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 22),
+                          SizedBox(
+                            height: 48,
+                            child: ElevatedButton(
+                              onPressed: _isLoading ? null : _login,
+                              child: _isLoading
+                                  ? const SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2.5,
+                                        color: Colors.white,
+                                      ),
+                                    )
+                                  : const Text('Iniciar sesión'),
+                            ),
+                          ),
+                          const SizedBox(height: 18),
+                          Center(
+                            child: TextButton(
+                              onPressed: () {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text(
+                                      'Solicita la recuperación de NIP en el consultorio',
+                                    ),
+                                  ),
+                                );
+                              },
+                              child: const Text(
+                                '¿Olvidaste tu NIP?',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 13,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          Center(
+                            child: Text(
+                              'Yoltec · TecNM Campus Valle de México',
+                              style: TextStyle(
+                                fontSize: 11,
+                                color: textSubtle,
+                                fontWeight: FontWeight.w500,
+                                letterSpacing: 0.2,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
+                  ),
                 ),
               ),
             ),
@@ -207,54 +221,121 @@ class _LoginScreenState extends State<LoginScreen> {
       ),
     );
   }
+}
 
-  Widget _buildAlumnoForm() {
-    return Form(
-      key: _formAlumnoKey,
+class _ZonaSuperior extends StatelessWidget {
+  const _ZonaSuperior();
+
+  @override
+  Widget build(BuildContext context) {
+    final altura = MediaQuery.of(context).size.height;
+    final padTop = altura < 700 ? 32.0 : 56.0;
+
+    return Padding(
+      padding: EdgeInsets.only(top: padTop, bottom: 56, left: 28, right: 28),
       child: Column(
         children: [
-          TextFormField(
-            controller: _numeroControlCtrl,
-            keyboardType: TextInputType.number,
-            decoration: const InputDecoration(
-              labelText: 'Numero de Control',
-              hintText: 'Ej. 22690495',
-              prefixIcon: Icon(Icons.badge_outlined),
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.18),
+                  blurRadius: 20,
+                  offset: const Offset(0, 6),
+                ),
+              ],
             ),
-            validator: (v) {
-              if (v == null || v.isEmpty) {
-                return 'Ingresa tu numero de control';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 16),
-          TextFormField(
-            controller: _nipCtrl,
-            obscureText: _obscureNip,
-            keyboardType: TextInputType.number,
-            decoration: InputDecoration(
-              labelText: 'NIP',
-              hintText: 'Tu NIP de acceso',
-              prefixIcon: const Icon(Icons.lock_outline),
-              suffixIcon: IconButton(
-                icon: Icon(_obscureNip
-                    ? Icons.visibility_off_outlined
-                    : Icons.visibility_outlined),
-                onPressed: () =>
-                    setState(() => _obscureNip = !_obscureNip),
+            child: const Center(
+              child: Text(
+                'Y',
+                style: TextStyle(
+                  color: AppTheme.primaryColor,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 34,
+                  height: 1,
+                  letterSpacing: -1,
+                ),
               ),
             ),
-            validator: (v) {
-              if (v == null || v.isEmpty) {
-                return 'Ingresa tu NIP';
-              }
-              return null;
-            },
+          ),
+          const SizedBox(height: 18),
+          const Text(
+            'Yoltec',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 30,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.6,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Servicio médico universitario',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.75),
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+              letterSpacing: 0.1,
+            ),
           ),
         ],
       ),
     );
   }
+}
 
+class _CampoLabel extends StatelessWidget {
+  final String label;
+  const _CampoLabel({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Text(
+      label,
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: isDark ? AppTheme.textPrimaryDark : const Color(0xFF374151),
+        letterSpacing: 0.1,
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  final String message;
+  const _ErrorBanner({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppTheme.errorSurface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.error.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.error_outline, color: AppTheme.error, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(
+                color: AppTheme.error,
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/mobile/lib/screens/pre_evaluacion_screen.dart
+++ b/mobile/lib/screens/pre_evaluacion_screen.dart
@@ -15,9 +15,9 @@ class PreEvaluacionScreen extends StatefulWidget {
 
 class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
   final List<Map<String, dynamic>> _mensajes = [];
-  final TextEditingController _inputController = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  bool _isChatLoading = false;
+  final TextEditingController _inputCtrl = TextEditingController();
+  final ScrollController _scrollCtrl = ScrollController();
+  bool _isLoading = false;
   Map<String, dynamic>? _resultado;
   String? _errorMsg;
 
@@ -29,8 +29,8 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
 
   @override
   void dispose() {
-    _inputController.dispose();
-    _scrollController.dispose();
+    _inputCtrl.dispose();
+    _scrollCtrl.dispose();
     super.dispose();
   }
 
@@ -40,7 +40,6 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
     final service =
         Provider.of<PreEvaluacionService>(context, listen: false);
 
-    // Si ya existe pre-evaluación, mostrar resultado
     final existente =
         await service.buscarPreEvaluacionDeCita(token, widget.citaId);
     if (existente != null && mounted) {
@@ -48,26 +47,25 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
       return;
     }
 
-    // Mensaje inicial del asistente
     if (mounted) {
       setState(() {
         _mensajes.add({
           'role': 'assistant',
           'content':
-              '¡Hola! Soy tu asistente médico de pre-evaluación. ¿Cuál es tu principal molestia o síntoma hoy?'
+              'Hola, soy tu asistente médico. ¿Qué síntomas presentas hoy?'
         });
       });
     }
   }
 
   Future<void> _enviarMensaje() async {
-    final texto = _inputController.text.trim();
-    if (texto.isEmpty || _isChatLoading) return;
+    final texto = _inputCtrl.text.trim();
+    if (texto.isEmpty || _isLoading) return;
 
-    _inputController.clear();
+    _inputCtrl.clear();
     setState(() {
       _mensajes.add({'role': 'user', 'content': texto});
-      _isChatLoading = true;
+      _isLoading = true;
       _errorMsg = null;
     });
     _scrollToBottom();
@@ -88,17 +86,16 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
 
       if (response == null) {
         setState(() {
-          _isChatLoading = false;
+          _isLoading = false;
           _errorMsg = 'Sin respuesta del servidor.';
         });
         return;
       }
 
       setState(() {
-        _isChatLoading = false;
-        _mensajes
-            .add({'role': 'assistant', 'content': response['message'] ?? ''});
-
+        _isLoading = false;
+        _mensajes.add(
+            {'role': 'assistant', 'content': response['message'] ?? ''});
         if (response['finished'] == true && response['diagnostico'] != null) {
           _resultado = response['diagnostico'] as Map<String, dynamic>;
         }
@@ -107,7 +104,7 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() {
-        _isChatLoading = false;
+        _isLoading = false;
         _errorMsg = e.toString().replaceFirst('Exception: ', '');
       });
     }
@@ -115,9 +112,9 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
 
   void _scrollToBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
+      if (_scrollCtrl.hasClients) {
+        _scrollCtrl.animateTo(
+          _scrollCtrl.position.maxScrollExtent,
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeOut,
         );
@@ -127,218 +124,90 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? AppTheme.bgDark : AppTheme.bg;
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Pre-evaluación IA'),
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () => Navigator.of(context).pop(),
+      backgroundColor: bg,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(64),
+        child: AppBar(
+          backgroundColor: AppTheme.primaryColor,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          centerTitle: true,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          title: const Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Pre-evaluación IA',
+                style:
+                    TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
+              SizedBox(height: 2),
+              Text(
+                'No reemplaza una consulta médica',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.white70,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
       body: _resultado != null ? _buildResultado(_resultado!) : _buildChat(),
     );
   }
 
-  // ─── Chat ──────────────────────────────────────────────────────────────────
-
   Widget _buildChat() {
     return Column(
       children: [
-        // Lista de mensajes
         Expanded(
           child: _mensajes.isEmpty
-              ? const Center(child: CircularProgressIndicator(color: AppTheme.primaryColor))
+              ? const Center(
+                  child: CircularProgressIndicator(
+                      color: AppTheme.primaryColor),
+                )
               : ListView.builder(
-                  controller: _scrollController,
-                  padding: const EdgeInsets.all(16),
-                  itemCount: _mensajes.length + (_isChatLoading ? 1 : 0),
+                  controller: _scrollCtrl,
+                  padding: const EdgeInsets.fromLTRB(16, 14, 16, 18),
+                  itemCount: _mensajes.length + (_isLoading ? 1 : 0),
                   itemBuilder: (context, i) {
-                    if (_isChatLoading && i == _mensajes.length) {
-                      return _buildTypingIndicator();
+                    if (_isLoading && i == _mensajes.length) {
+                      return const _TypingBubble();
                     }
                     final msg = _mensajes[i];
-                    return _buildBubble(
-                      msg['content'] as String,
-                      msg['role'] == 'user',
+                    return _Bubble(
+                      content: msg['content'] as String,
+                      isUser: msg['role'] == 'user',
                     );
                   },
                 ),
         ),
-
-        // Error
         if (_errorMsg != null)
           Container(
             width: double.infinity,
-            color: Theme.of(context).colorScheme.errorContainer,
+            color: AppTheme.errorSurface,
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
-              '⚠️ $_errorMsg',
-              style: TextStyle(color: Theme.of(context).colorScheme.onErrorContainer, fontSize: 13),
+              _errorMsg!,
+              style: const TextStyle(color: AppTheme.error, fontSize: 13),
             ),
           ),
-
-        // Input
-        _buildInputArea(),
+        _InputArea(
+          controller: _inputCtrl,
+          enabled: !_isLoading,
+          onEnviar: _enviarMensaje,
+        ),
       ],
     );
   }
-
-  Widget _buildBubble(String content, bool isUser) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Row(
-        mainAxisAlignment:
-            isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          if (!isUser) ...[
-            const Text('🤖', style: TextStyle(fontSize: 22)),
-            const SizedBox(width: 6),
-          ],
-          Flexible(
-            child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              decoration: BoxDecoration(
-                color: isUser ? AppTheme.primaryColor : Theme.of(context).cardColor,
-                borderRadius: BorderRadius.only(
-                  topLeft: const Radius.circular(18),
-                  topRight: const Radius.circular(18),
-                  bottomLeft: Radius.circular(isUser ? 18 : 4),
-                  bottomRight: Radius.circular(isUser ? 4 : 18),
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.07),
-                    blurRadius: 4,
-                    offset: const Offset(0, 1),
-                  )
-                ],
-              ),
-              child: Text(
-                content,
-                style: TextStyle(
-                  color: isUser ? Colors.white : AppTheme.gray900,
-                  fontSize: 14.5,
-                  height: 1.5,
-                ),
-              ),
-            ),
-          ),
-          if (isUser) ...[
-            const SizedBox(width: 6),
-            const Text('👤', style: TextStyle(fontSize: 20)),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTypingIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          const Text('🤖', style: TextStyle(fontSize: 22)),
-          const SizedBox(width: 6),
-          Container(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            decoration: BoxDecoration(
-              color: Theme.of(context).cardColor,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(18),
-                topRight: Radius.circular(18),
-                bottomRight: Radius.circular(18),
-                bottomLeft: Radius.circular(4),
-              ),
-              boxShadow: [
-                BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.07),
-                    blurRadius: 4,
-                    offset: const Offset(0, 1))
-              ],
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: List.generate(
-                3,
-                (i) => _TypingDot(delay: Duration(milliseconds: i * 200)),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildInputArea() {
-    return Container(
-      padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
-      ),
-      child: SafeArea(
-        top: false,
-        child: Row(
-          children: [
-            Expanded(
-              child: TextField(
-                controller: _inputController,
-                enabled: !_isChatLoading,
-                textCapitalization: TextCapitalization.sentences,
-                onSubmitted: (_) => _enviarMensaje(),
-                decoration: InputDecoration(
-                  hintText: 'Escribe tu respuesta...',
-                  hintStyle: const TextStyle(color: AppTheme.gray400),
-                  filled: true,
-                  fillColor: AppTheme.gray100,
-                  contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 16, vertical: 10),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(24),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: 8),
-            _isChatLoading
-                ? const SizedBox(
-                    width: 42,
-                    height: 42,
-                    child: Center(
-                        child: SizedBox(
-                      width: 22,
-                      height: 22,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2.5,
-                          color: AppTheme.primaryColor),
-                    )),
-                  )
-                : Material(
-                    color: AppTheme.primaryColor,
-                    shape: const CircleBorder(),
-                    child: InkWell(
-                      customBorder: const CircleBorder(),
-                      onTap: _enviarMensaje,
-                      child: const SizedBox(
-                        width: 42,
-                        height: 42,
-                        child: Icon(Icons.send_rounded,
-                            color: Colors.white, size: 20),
-                      ),
-                    ),
-                  ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ─── Resultado ─────────────────────────────────────────────────────────────
 
   Widget _buildResultado(Map<String, dynamic> resultado) {
     final ia = resultado['resultado_ia'] as Map<String, dynamic>?;
@@ -367,143 +236,33 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
         resultado['recomendaciones'] as String? ??
         '';
 
-    final porcentaje = (confianza * 100).round();
-    final color = confianza >= 0.7
-        ? AppTheme.success
-        : confianza >= 0.4
-            ? AppTheme.warning
-            : AppTheme.error;
+    final lista = <Map<String, dynamic>>[
+      {'enfermedad': diagnostico, 'confianza': confianza},
+      ...posibles.skip(1).take(3).map((e) {
+        final map = e as Map<String, dynamic>;
+        var c = double.tryParse(map['confianza']?.toString() ?? '') ?? 0.0;
+        if (c > 1) c = c / 100;
+        return {'enfermedad': map['enfermedad'] ?? '', 'confianza': c};
+      }),
+    ];
 
     return SafeArea(
       child: SingleChildScrollView(
-        padding: const EdgeInsets.all(20),
+        padding: const EdgeInsets.all(16),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Center(
-              child: Column(
-                children: [
-                  DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: AppTheme.primarySurface,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Padding(
-                      padding: EdgeInsets.all(20),
-                      child: Icon(Icons.check_circle_outline,
-                          color: AppTheme.primaryColor, size: 60),
-                    ),
-                  ),
-                  SizedBox(height: 12),
-                  Text('Pre-evaluación completada',
-                      style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: AppTheme.gray900)),
-                  SizedBox(height: 6),
-                  Text(
-                    'El médico revisará tu evaluación antes de la consulta.',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: AppTheme.gray600),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 24),
-
-            // Diagnóstico
-            _resultCard(
-              icon: Icons.medical_information_outlined,
-              title: 'Diagnóstico preliminar',
-              content: diagnostico,
-              color: AppTheme.primaryColor,
-            ),
-
-            const SizedBox(height: 12),
-
-            // Confianza
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(children: [
-                      Icon(Icons.analytics_outlined, color: color, size: 20),
-                      const SizedBox(width: 8),
-                      const Text('Nivel de confianza',
-                          style: TextStyle(fontWeight: FontWeight.w600)),
-                      const Spacer(),
-                      Text('$porcentaje%',
-                          style: TextStyle(
-                              color: color,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16)),
-                    ]),
-                    const SizedBox(height: 10),
-                    LinearProgressIndicator(
-                      value: confianza,
-                      backgroundColor: AppTheme.gray200,
-                      valueColor: AlwaysStoppedAnimation(color),
-                      minHeight: 8,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-            if (posibles.length > 1) ...[
-              const SizedBox(height: 12),
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Row(children: [
-                        Icon(Icons.list_alt,
-                            color: AppTheme.info, size: 20),
-                        SizedBox(width: 8),
-                        Text('Otras posibilidades',
-                            style: TextStyle(fontWeight: FontWeight.w600)),
-                      ]),
-                      const SizedBox(height: 10),
-                      ...posibles.skip(1).take(3).map((e) {
-                        final map = e as Map<String, dynamic>;
-                        final c = double.tryParse(
-                                map['confianza']?.toString() ?? '') ??
-                            0.0;
-                        final pct = (c > 1 ? c : c * 100).round();
-                        return Padding(
-                          padding: const EdgeInsets.only(bottom: 4),
-                          child: Text(
-                              '• ${map['enfermedad']} ($pct%)',
-                              style: const TextStyle(fontSize: 14)),
-                        );
-                      }),
-                    ],
-                  ),
-                ),
-              ),
-            ],
-
+            _ResultCard(diagnosticos: lista),
             if (recomendacion.isNotEmpty) ...[
               const SizedBox(height: 12),
-              _resultCard(
-                icon: Icons.tips_and_updates_outlined,
-                title: 'Recomendación',
-                content: recomendacion,
-                color: AppTheme.warning,
-              ),
+              _RecomendacionCard(texto: recomendacion),
             ],
-
             const SizedBox(height: 24),
             SizedBox(
-              width: double.infinity,
+              height: 48,
               child: ElevatedButton.icon(
                 onPressed: () => Navigator.of(context).pop(),
-                icon: const Icon(Icons.home_outlined),
+                icon: const Icon(Icons.home_outlined, size: 18),
                 label: const Text('Volver al inicio'),
               ),
             ),
@@ -512,33 +271,142 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
       ),
     );
   }
+}
 
-  Widget _resultCard({
-    required IconData icon,
-    required String title,
-    required String content,
-    required Color color,
-  }) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+class _Bubble extends StatelessWidget {
+  final String content;
+  final bool isUser;
+
+  const _Bubble({required this.content, required this.isUser});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final aiBg = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final aiBorder = isDark ? AppTheme.borderDark : AppTheme.border;
+    final aiText = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final meBg = isDark
+        ? AppTheme.primaryColor.withValues(alpha: 0.18)
+        : AppTheme.primarySurface;
+    final meText = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Align(
+        alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width * (isUser ? 0.75 : 0.78),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              if (!isUser) ...[
+                _AvatarIA(),
+                const SizedBox(width: 8),
+              ],
+              Flexible(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: isUser ? meBg : aiBg,
+                    borderRadius: BorderRadius.only(
+                      topLeft: const Radius.circular(16),
+                      topRight: const Radius.circular(16),
+                      bottomLeft: Radius.circular(isUser ? 16 : 0),
+                      bottomRight: Radius.circular(isUser ? 0 : 16),
+                    ),
+                    border: isUser
+                        ? null
+                        : Border.all(color: aiBorder, width: 1),
+                    boxShadow: isUser
+                        ? null
+                        : [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: 0.03),
+                              blurRadius: 2,
+                              offset: const Offset(0, 1),
+                            ),
+                          ],
+                  ),
+                  child: Text(
+                    content,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: isUser ? meText : aiText,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AvatarIA extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 28,
+      height: 28,
+      decoration: const BoxDecoration(
+        color: AppTheme.iaSurface,
+        shape: BoxShape.circle,
+      ),
+      child: const Icon(
+        Icons.smart_toy_outlined,
+        size: 16,
+        color: AppTheme.iaColor,
+      ),
+    );
+  }
+}
+
+class _TypingBubble extends StatelessWidget {
+  const _TypingBubble();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final aiBg = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final aiBorder = isDark ? AppTheme.borderDark : AppTheme.border;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
           children: [
-            Row(children: [
-              Icon(icon, color: color, size: 20),
-              const SizedBox(width: 8),
-              Text(title,
-                  style: const TextStyle(
-                      fontWeight: FontWeight.w600,
-                      color: AppTheme.gray800)),
-            ]),
-            const SizedBox(height: 10),
-            Text(content,
-                style: const TextStyle(
-                    fontSize: 15,
-                    color: AppTheme.gray700,
-                    height: 1.5)),
+            _AvatarIA(),
+            const SizedBox(width: 8),
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              decoration: BoxDecoration(
+                color: aiBg,
+                border: Border.all(color: aiBorder, width: 1),
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                  bottomRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: List.generate(
+                  3,
+                  (i) => _Dot(delay: Duration(milliseconds: i * 200)),
+                ),
+              ),
+            ),
           ],
         ),
       ),
@@ -546,17 +414,15 @@ class _PreEvaluacionScreenState extends State<PreEvaluacionScreen> {
   }
 }
 
-/// Punto animado para indicador de escritura
-class _TypingDot extends StatefulWidget {
+class _Dot extends StatefulWidget {
   final Duration delay;
-  const _TypingDot({required this.delay});
+  const _Dot({required this.delay});
 
   @override
-  State<_TypingDot> createState() => _TypingDotState();
+  State<_Dot> createState() => _DotState();
 }
 
-class _TypingDotState extends State<_TypingDot>
-    with SingleTickerProviderStateMixin {
+class _DotState extends State<_Dot> with SingleTickerProviderStateMixin {
   late final AnimationController _ctrl;
   late final Animation<double> _anim;
 
@@ -564,13 +430,13 @@ class _TypingDotState extends State<_TypingDot>
   void initState() {
     super.initState();
     _ctrl = AnimationController(
-        duration: const Duration(milliseconds: 1300), vsync: this)
-      ..repeat();
+      duration: const Duration(milliseconds: 1300),
+      vsync: this,
+    )..repeat();
     _anim = TweenSequence([
       TweenSequenceItem(tween: Tween(begin: 0.4, end: 1.0), weight: 40),
       TweenSequenceItem(tween: Tween(begin: 1.0, end: 0.4), weight: 60),
     ]).animate(CurvedAnimation(parent: _ctrl, curve: Curves.easeInOut));
-
     Future.delayed(widget.delay, () {
       if (mounted) _ctrl.forward();
     });
@@ -587,13 +453,274 @@ class _TypingDotState extends State<_TypingDot>
     return AnimatedBuilder(
       animation: _anim,
       builder: (_, __) => Container(
-        width: 8,
-        height: 8,
+        width: 7,
+        height: 7,
         margin: const EdgeInsets.symmetric(horizontal: 2),
         decoration: BoxDecoration(
-          color: AppTheme.gray400.withValues(alpha: _anim.value),
+          color: AppTheme.textSubtle.withValues(alpha: _anim.value),
           shape: BoxShape.circle,
         ),
+      ),
+    );
+  }
+}
+
+class _InputArea extends StatelessWidget {
+  final TextEditingController controller;
+  final bool enabled;
+  final VoidCallback onEnviar;
+
+  const _InputArea({
+    required this.controller,
+    required this.enabled,
+    required this.onEnviar,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final border = isDark ? AppTheme.borderDark : AppTheme.border;
+    final fill = isDark
+        ? Colors.white.withValues(alpha: 0.06)
+        : AppTheme.borderSoft;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        border: Border(top: BorderSide(color: border, width: 1)),
+      ),
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller,
+                enabled: enabled,
+                textCapitalization: TextCapitalization.sentences,
+                onSubmitted: (_) => onEnviar(),
+                decoration: InputDecoration(
+                  hintText: 'Escribe tus síntomas...',
+                  filled: true,
+                  fillColor: fill,
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 10),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(20),
+                    borderSide: BorderSide.none,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(20),
+                    borderSide: BorderSide.none,
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(20),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Material(
+              color: AppTheme.primaryColor,
+              shape: const CircleBorder(),
+              child: InkWell(
+                customBorder: const CircleBorder(),
+                onTap: enabled ? onEnviar : null,
+                child: SizedBox(
+                  width: 40,
+                  height: 40,
+                  child: enabled
+                      ? const Icon(Icons.send_rounded,
+                          color: Colors.white, size: 18)
+                      : const Padding(
+                          padding: EdgeInsets.all(10),
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.5,
+                            color: Colors.white,
+                          ),
+                        ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultCard extends StatelessWidget {
+  final List<Map<String, dynamic>> diagnosticos;
+  const _ResultCard({required this.diagnosticos});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final divider = isDark ? AppTheme.borderDark : AppTheme.borderSoft;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(10),
+        border: const Border(
+          left: BorderSide(color: AppTheme.primaryColor, width: 3),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Posibles diagnósticos',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              letterSpacing: -0.1,
+              color: textMain,
+            ),
+          ),
+          const SizedBox(height: 12),
+          ...diagnosticos.map((d) {
+            final nombre = d['enfermedad']?.toString() ?? '';
+            final conf = (d['confianza'] as double?) ?? 0.0;
+            final pct = (conf * 100).round();
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 9),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          nombre,
+                          style: TextStyle(fontSize: 13, color: textMain),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '$pct%',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: textMain,
+                          fontFeatures: const [FontFeature.tabularFigures()],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 5),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(99),
+                    child: LinearProgressIndicator(
+                      value: conf,
+                      backgroundColor: AppTheme.primarySurface,
+                      valueColor: const AlwaysStoppedAnimation(
+                          AppTheme.primaryColor),
+                      minHeight: 4,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+          const SizedBox(height: 4),
+          Divider(height: 1, color: divider),
+          const SizedBox(height: 10),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+              decoration: BoxDecoration(
+                color: AppTheme.warningSurface,
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: const Text(
+                'Solo orientativo · El doctor confirmará el diagnóstico',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppTheme.warning,
+                  fontWeight: FontWeight.w500,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecomendacionCard extends StatelessWidget {
+  final String texto;
+  const _RecomendacionCard({required this.texto});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.tips_and_updates_outlined,
+                color: AppTheme.warning,
+                size: 18,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Recomendación',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: textMain,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            texto,
+            style: TextStyle(
+              fontSize: 13,
+              color: textMuted,
+              height: 1.5,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/screens/student/citas_tab.dart
+++ b/mobile/lib/screens/student/citas_tab.dart
@@ -88,13 +88,9 @@ class CitasTab extends StatelessWidget {
   }
 
   void _mostrarFormNuevaCita(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (_) => const NuevaCitaForm(),
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const NuevaCitaForm()),
     );
   }
 }

--- a/mobile/lib/screens/student/citas_tab.dart
+++ b/mobile/lib/screens/student/citas_tab.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:yoltec_mobile/models/cita.dart';
 import 'package:yoltec_mobile/screens/student/nueva_cita_form.dart';
-import 'package:yoltec_mobile/screens/student/widgets/student_widgets.dart';
 import 'package:yoltec_mobile/services/auth_service.dart';
 import 'package:yoltec_mobile/services/cita_service.dart';
 import 'package:yoltec_mobile/utils/app_theme.dart';
@@ -12,44 +12,79 @@ class CitasTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: RefreshIndicator(
-        color: AppTheme.primaryColor,
-        onRefresh: () async {
-          final token =
-              Provider.of<AuthService>(context, listen: false).token ?? '';
-          await Provider.of<CitaService>(context, listen: false)
-              .cargarCitas(token);
-        },
-        child: Consumer<CitaService>(
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? AppTheme.bgDark : AppTheme.bg;
+
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        backgroundColor: bg,
+        body: Consumer<CitaService>(
           builder: (context, service, _) {
-            if (service.isLoading) {
+            if (service.isLoading && service.citas.isEmpty) {
               return const Center(
-                  child: CircularProgressIndicator(
-                      color: AppTheme.primaryColor));
+                child: CircularProgressIndicator(color: AppTheme.primaryColor),
+              );
             }
-            if (service.citas.isEmpty) {
-              return const Center(
-                  child: Text('No tienes citas registradas.'));
-            }
-            return ListView.separated(
-              padding: const EdgeInsets.all(16),
-              itemCount: service.citas.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 10),
-              itemBuilder: (context, i) =>
-                  _CitaCard(cita: service.citas[i]),
+
+            final proximas = service.citas
+                .where((c) => c.isProgramada)
+                .toList()
+              ..sort((a, b) =>
+                  '${a.fechaCita} ${a.horaCita}'.compareTo('${b.fechaCita} ${b.horaCita}'));
+            final pasadas = service.citas.where((c) => c.isAtendida).toList()
+              ..sort((a, b) =>
+                  '${b.fechaCita} ${b.horaCita}'.compareTo('${a.fechaCita} ${a.horaCita}'));
+            final canceladas = service.citas
+                .where((c) => c.isCancelada || c.isNoAsistio)
+                .toList()
+              ..sort((a, b) =>
+                  '${b.fechaCita} ${b.horaCita}'.compareTo('${a.fechaCita} ${a.horaCita}'));
+
+            return Column(
+              children: [
+                _BarraTabs(proximasCount: proximas.length),
+                Expanded(
+                  child: TabBarView(
+                    children: [
+                      _ListaCitas(
+                        citas: proximas,
+                        vacioMensaje: 'No tienes citas próximas',
+                        onRefresh: () => _recargar(context),
+                      ),
+                      _ListaCitas(
+                        citas: pasadas,
+                        vacioMensaje: 'Aún no tienes citas atendidas',
+                        onRefresh: () => _recargar(context),
+                      ),
+                      _ListaCitas(
+                        citas: canceladas,
+                        vacioMensaje: 'No tienes citas canceladas',
+                        onRefresh: () => _recargar(context),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             );
           },
         ),
-      ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => _mostrarFormNuevaCita(context),
-        backgroundColor: AppTheme.primaryColor,
-        icon: const Icon(Icons.add, color: Colors.white),
-        label:
-            const Text('Nueva Cita', style: TextStyle(color: Colors.white)),
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: () => _mostrarFormNuevaCita(context),
+          backgroundColor: AppTheme.primaryColor,
+          icon: const Icon(Icons.add, color: Colors.white),
+          label: const Text(
+            'Nueva cita',
+            style: TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+          ),
+        ),
       ),
     );
+  }
+
+  Future<void> _recargar(BuildContext context) async {
+    final token = Provider.of<AuthService>(context, listen: false).token ?? '';
+    await Provider.of<CitaService>(context, listen: false).cargarCitas(token);
   }
 
   void _mostrarFormNuevaCita(BuildContext context) {
@@ -64,90 +99,271 @@ class CitasTab extends StatelessWidget {
   }
 }
 
+class _BarraTabs extends StatelessWidget {
+  final int proximasCount;
+  const _BarraTabs({required this.proximasCount});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final border = isDark ? AppTheme.borderDark : AppTheme.border;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        border: Border(bottom: BorderSide(color: border, width: 1)),
+      ),
+      child: TabBar(
+        labelColor: AppTheme.primaryColor,
+        unselectedLabelColor: textMuted,
+        indicatorColor: AppTheme.primaryColor,
+        indicatorWeight: 2,
+        labelStyle:
+            const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        unselectedLabelStyle:
+            const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+        tabs: [
+          Tab(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text('Próximas'),
+                if (proximasCount > 0) ...[
+                  const SizedBox(width: 6),
+                  _Badge(count: proximasCount),
+                ],
+              ],
+            ),
+          ),
+          const Tab(text: 'Pasadas'),
+          const Tab(text: 'Canceladas'),
+        ],
+      ),
+    );
+  }
+}
+
+class _Badge extends StatelessWidget {
+  final int count;
+  const _Badge({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 1),
+      decoration: BoxDecoration(
+        color: AppTheme.primarySurface,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      constraints: const BoxConstraints(minWidth: 20),
+      child: Text(
+        '$count',
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontSize: 10.5,
+          fontWeight: FontWeight.w600,
+          color: AppTheme.primaryColor,
+          fontFeatures: [FontFeature.tabularFigures()],
+        ),
+      ),
+    );
+  }
+}
+
+class _ListaCitas extends StatelessWidget {
+  final List<Cita> citas;
+  final String vacioMensaje;
+  final Future<void> Function() onRefresh;
+
+  const _ListaCitas({
+    required this.citas,
+    required this.vacioMensaje,
+    required this.onRefresh,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      color: AppTheme.primaryColor,
+      onRefresh: onRefresh,
+      child: citas.isEmpty
+          ? ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                const SizedBox(height: 80),
+                Center(child: _Vacio(mensaje: vacioMensaje)),
+              ],
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+              itemCount: citas.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (_, i) => _CitaCard(cita: citas[i]),
+            ),
+    );
+  }
+}
+
+class _Vacio extends StatelessWidget {
+  final String mensaje;
+  const _Vacio({required this.mensaje});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.event_busy, size: 48, color: textMuted),
+        const SizedBox(height: 10),
+        Text(
+          mensaje,
+          style: TextStyle(color: textMuted, fontSize: 14),
+        ),
+      ],
+    );
+  }
+}
+
 class _CitaCard extends StatelessWidget {
   final Cita cita;
   const _CitaCard({required this.cita});
 
   @override
   Widget build(BuildContext context) {
-    final color = _colorEstatus(cita.estatus);
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(14),
-        child: Row(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(10),
-              decoration: BoxDecoration(
-                color: color.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(10),
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    final textSubtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+    final divider = isDark ? AppTheme.borderDark : AppTheme.borderSoft;
+
+    final esFuturo = cita.isProgramada;
+    final esAtendida = cita.isAtendida;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  _fechaTitulo(cita.fechaCita),
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: textMain,
+                  ),
+                ),
               ),
-              child: Icon(Icons.event, color: color, size: 22),
+              const SizedBox(width: 8),
+              _BadgeEstatus(estatus: cita.estatus),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '${cita.horaFormateada} hrs',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.5,
+              color: esFuturo ? AppTheme.primaryColor : textMuted,
+              fontFeatures: const [FontFeature.tabularFigures()],
             ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Text(cita.fechaFormateada,
-                          style: const TextStyle(
-                              fontWeight: FontWeight.w600,
-                              color: AppTheme.gray900)),
-                      const SizedBox(width: 8),
-                      Text('- ${cita.horaFormateada}',
-                          style:
-                              const TextStyle(color: AppTheme.gray600)),
-                    ],
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    cita.motivo.isNotEmpty ? cita.motivo : 'Sin motivo',
-                    style: const TextStyle(
-                        color: AppTheme.gray600, fontSize: 13),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
+          ),
+          if (cita.motivo.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                cita.motivo,
+                style: TextStyle(fontSize: 13, color: textMuted),
               ),
             ),
-            const SizedBox(width: 8),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                EstatusChip(estatus: cita.estatus),
-                if (cita.isProgramada) ...[
-                  const SizedBox(height: 6),
-                  GestureDetector(
-                    onTap: () => _cancelar(context, cita),
-                    child: const Text('Cancelar',
-                        style: TextStyle(
-                            color: AppTheme.error, fontSize: 12)),
-                  ),
-                ],
-              ],
+          if (esAtendida)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(
+                      text: 'Diagnóstico: ',
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.w600,
+                        color: textMuted,
+                      ),
+                    ),
+                    TextSpan(
+                      text: 'Disponible en consulta',
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        color: textSubtle,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          if (esFuturo) ...[
+            const SizedBox(height: 12),
+            Divider(height: 1, color: divider),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () => _confirmarCancelar(context, cita),
+                style: TextButton.styleFrom(
+                  foregroundColor: AppTheme.error,
+                  padding: const EdgeInsets.symmetric(horizontal: 6),
+                  minimumSize: const Size(0, 28),
+                ),
+                child: const Text(
+                  'Cancelar cita',
+                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+                ),
+              ),
             ),
           ],
-        ),
+        ],
       ),
     );
   }
 
-  Color _colorEstatus(String estatus) {
-    switch (estatus) {
-      case 'programada':
-        return AppTheme.primaryColor;
-      case 'atendida':
-        return AppTheme.success;
-      case 'cancelada':
-        return AppTheme.error;
-      default:
-        return AppTheme.gray500;
+  String _fechaTitulo(String fechaIso) {
+    final partes = fechaIso.split('-');
+    if (partes.length != 3) return fechaIso;
+    try {
+      final fecha = DateTime(
+        int.parse(partes[0]),
+        int.parse(partes[1]),
+        int.parse(partes[2]),
+      );
+      final formato =
+          DateFormat('EEEE, d \'de\' MMMM', 'es_MX').format(fecha);
+      return formato[0].toUpperCase() + formato.substring(1);
+    } catch (_) {
+      return fechaIso;
     }
   }
 
-  void _cancelar(BuildContext context, Cita cita) {
+  void _confirmarCancelar(BuildContext context, Cita cita) {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -155,23 +371,95 @@ class _CitaCard extends StatelessWidget {
         content: const Text('¿Seguro que deseas cancelar esta cita?'),
         actions: [
           TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('No')),
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('No'),
+          ),
           ElevatedButton(
-            style:
-                ElevatedButton.styleFrom(backgroundColor: AppTheme.error),
+            style: ElevatedButton.styleFrom(backgroundColor: AppTheme.error),
             onPressed: () async {
               Navigator.pop(ctx);
               final token =
-                  Provider.of<AuthService>(context, listen: false).token ??
-                      '';
-              await Provider.of<CitaService>(context, listen: false)
+                  Provider.of<AuthService>(context, listen: false).token ?? '';
+              final ok = await Provider.of<CitaService>(context, listen: false)
                   .cancelarCita(token, cita.id);
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(ok ? 'Cita cancelada' : 'No se pudo cancelar')),
+                );
+              }
             },
-            child: const Text('Si, cancelar'),
+            child: const Text('Sí, cancelar'),
           ),
         ],
       ),
     );
   }
+}
+
+class _BadgeEstatus extends StatelessWidget {
+  final String estatus;
+  const _BadgeEstatus({required this.estatus});
+
+  @override
+  Widget build(BuildContext context) {
+    final spec = _spec(estatus);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: spec.bg,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        spec.label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: spec.fg,
+          letterSpacing: 0.3,
+        ),
+      ),
+    );
+  }
+
+  _BadgeSpec _spec(String estatus) {
+    switch (estatus) {
+      case 'programada':
+        return const _BadgeSpec(
+          label: 'CONFIRMADA',
+          bg: AppTheme.primarySurface,
+          fg: AppTheme.primaryColor,
+        );
+      case 'atendida':
+        return const _BadgeSpec(
+          label: 'ATENDIDA',
+          bg: AppTheme.primarySurface,
+          fg: AppTheme.primaryColor,
+        );
+      case 'cancelada':
+        return const _BadgeSpec(
+          label: 'CANCELADA',
+          bg: Color(0xFFF3F4F6),
+          fg: AppTheme.textMuted,
+        );
+      case 'no_asistio':
+        return const _BadgeSpec(
+          label: 'NO ASISTIÓ',
+          bg: AppTheme.errorSurface,
+          fg: AppTheme.error,
+        );
+      default:
+        return const _BadgeSpec(
+          label: 'PENDIENTE',
+          bg: AppTheme.warningSurface,
+          fg: AppTheme.warning,
+        );
+    }
+  }
+}
+
+class _BadgeSpec {
+  final String label;
+  final Color bg;
+  final Color fg;
+  const _BadgeSpec({required this.label, required this.bg, required this.fg});
 }

--- a/mobile/lib/screens/student/inicio_tab.dart
+++ b/mobile/lib/screens/student/inicio_tab.dart
@@ -1,93 +1,298 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:yoltec_mobile/models/cita.dart';
 import 'package:yoltec_mobile/screens/pre_evaluacion_screen.dart';
-import 'package:yoltec_mobile/screens/student/widgets/student_widgets.dart';
 import 'package:yoltec_mobile/services/auth_service.dart';
 import 'package:yoltec_mobile/services/cita_service.dart';
 import 'package:yoltec_mobile/utils/app_theme.dart';
 
 class InicioTab extends StatelessWidget {
   final VoidCallback onNuevaCita;
+  final VoidCallback onIrRecetas;
+  final VoidCallback onIrPerfil;
 
-  const InicioTab({super.key, required this.onNuevaCita});
+  const InicioTab({
+    super.key,
+    required this.onNuevaCita,
+    required this.onIrRecetas,
+    required this.onIrPerfil,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return RefreshIndicator(
-      color: AppTheme.primaryColor,
-      onRefresh: () async {
-        final token =
-            Provider.of<AuthService>(context, listen: false).token ?? '';
-        await Provider.of<CitaService>(context, listen: false)
-            .cargarCitas(token);
-      },
-      child: Consumer<CitaService>(
-        builder: (context, citaService, _) {
-          final proxima = citaService.proximaCita;
-          final programadas = citaService.citasProgramadas;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? AppTheme.bgDark : AppTheme.bg;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
 
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: [
-              Row(
-                children: [
-                  StatCard(
-                    label: 'Citas programadas',
-                    value: programadas.length.toString(),
-                    icon: Icons.event,
-                    color: AppTheme.primaryColor,
-                  ),
-                  const SizedBox(width: 12),
-                  StatCard(
-                    label: 'Total de citas',
-                    value: citaService.citas.length.toString(),
-                    icon: Icons.history,
-                    color: AppTheme.info,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              const Text(
-                'Proxima cita',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: AppTheme.gray800,
-                ),
-              ),
-              const SizedBox(height: 10),
-              proxima == null
-                  ? _buildSinCita()
-                  : _buildProximaCitaCard(context, proxima),
-              const SizedBox(height: 20),
-              OutlinedButton.icon(
-                onPressed: onNuevaCita,
-                icon: const Icon(Icons.add, size: 18),
-                label: const Text('Agendar nueva cita'),
-                style: OutlinedButton.styleFrom(
-                  minimumSize: const Size(double.infinity, 48),
-                ),
-              ),
-            ],
-          );
+    return Container(
+      color: bg,
+      child: RefreshIndicator(
+        color: AppTheme.primaryColor,
+        onRefresh: () async {
+          final token =
+              Provider.of<AuthService>(context, listen: false).token ?? '';
+          await Provider.of<CitaService>(context, listen: false)
+              .cargarCitas(token);
         },
+        child: Consumer<CitaService>(
+          builder: (context, citaService, _) {
+            final proxima = citaService.proximaCita;
+            final atendidas =
+                citaService.citas.where((c) => c.isAtendida).toList();
+            final mesActual = DateTime.now().month;
+            final yearActual = DateTime.now().year;
+            final citasMes = citaService.citas.where((c) {
+              final partes = c.fechaCita.split('-');
+              if (partes.length != 3) return false;
+              return int.tryParse(partes[1]) == mesActual &&
+                  int.tryParse(partes[0]) == yearActual;
+            }).length;
+
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+              children: [
+                _SubTituloFecha(textMuted: textMuted),
+                const SizedBox(height: 16),
+                proxima == null
+                    ? const _CardSinCita()
+                    : _CardProximaCita(cita: proxima),
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _MiniStat(
+                        label: 'Citas este mes',
+                        value: '$citasMes',
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _MiniStat(
+                        label: 'Última visita',
+                        value: _ultimaVisitaTexto(atendidas),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                _SeccionTitulo(text: 'ACCESO RÁPIDO', color: textMuted),
+                const SizedBox(height: 12),
+                GridView.count(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  crossAxisCount: 2,
+                  mainAxisSpacing: 12,
+                  crossAxisSpacing: 12,
+                  childAspectRatio: 1,
+                  children: [
+                    _QuickAccess(
+                      icon: Icons.calendar_today_outlined,
+                      label: 'Agendar cita',
+                      bg: const Color(0xFFF0FAF4),
+                      bgDark: AppTheme.primaryColor.withValues(alpha: 0.12),
+                      iconColor: AppTheme.primaryColor,
+                      onTap: onNuevaCita,
+                    ),
+                    _QuickAccess(
+                      icon: Icons.psychology_outlined,
+                      label: 'Pre-evaluación IA',
+                      bg: const Color(0xFFF0F4FF),
+                      bgDark: AppTheme.iaColor.withValues(alpha: 0.12),
+                      iconColor: const Color(0xFF3850C2),
+                      onTap: () => _abrirIa(context, proxima),
+                    ),
+                    _QuickAccess(
+                      icon: Icons.medication_outlined,
+                      label: 'Mis recetas',
+                      bg: const Color(0xFFFFFBF0),
+                      bgDark: AppTheme.warning.withValues(alpha: 0.14),
+                      iconColor: const Color(0xFFA86F00),
+                      onTap: onIrRecetas,
+                    ),
+                    _QuickAccess(
+                      icon: Icons.person_outline,
+                      label: 'Mi perfil',
+                      bg: const Color(0xFFF3F3F4),
+                      bgDark: Colors.white.withValues(alpha: 0.06),
+                      iconColor: const Color(0xFF3B4252),
+                      onTap: onIrPerfil,
+                    ),
+                  ],
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }
 
-  Widget _buildSinCita() {
-    return const Card(
+  String _ultimaVisitaTexto(List<Cita> atendidas) {
+    if (atendidas.isEmpty) return '—';
+    atendidas.sort((a, b) => b.fechaCita.compareTo(a.fechaCita));
+    final partes = atendidas.first.fechaCita.split('-');
+    if (partes.length != 3) return '—';
+    final dia = int.tryParse(partes[2]) ?? 1;
+    final mes = int.tryParse(partes[1]) ?? 1;
+    final meses = [
+      'ene', 'feb', 'mar', 'abr', 'may', 'jun',
+      'jul', 'ago', 'sep', 'oct', 'nov', 'dic',
+    ];
+    return '$dia ${meses[mes - 1]}';
+  }
+
+  void _abrirIa(BuildContext context, Cita? proxima) {
+    if (proxima == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Agenda una cita para iniciar tu pre-evaluación.'),
+        ),
+      );
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => PreEvaluacionScreen(citaId: proxima.id),
+      ),
+    );
+  }
+}
+
+class _SubTituloFecha extends StatelessWidget {
+  final Color textMuted;
+  const _SubTituloFecha({required this.textMuted});
+
+  @override
+  Widget build(BuildContext context) {
+    final hoy = DateFormat('EEEE, d \'de\' MMMM y', 'es_MX').format(DateTime.now());
+    final capitalizado = hoy[0].toUpperCase() + hoy.substring(1);
+    return Text(
+      capitalizado,
+      style: TextStyle(
+        fontSize: 13,
+        color: textMuted,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+  }
+}
+
+class _CardProximaCita extends StatelessWidget {
+  final Cita cita;
+  const _CardProximaCita({required this.cita});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    final divider = isDark ? AppTheme.borderDark : AppTheme.borderSoft;
+
+    final fechaTitulo = _fechaCard(cita.fechaCita);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(12),
+        border: const Border(
+          left: BorderSide(color: AppTheme.primaryColor, width: 3),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
       child: Padding(
-        padding: EdgeInsets.all(20),
+        padding: const EdgeInsets.all(16),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(Icons.event_available, size: 40, color: AppTheme.gray400),
-            SizedBox(height: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
+              decoration: BoxDecoration(
+                color: AppTheme.primarySurface,
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: const Text(
+                'CONFIRMADA',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: AppTheme.primaryColor,
+                  letterSpacing: 0.4,
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
             Text(
-              'Sin citas proximas',
+              fechaTitulo,
               style: TextStyle(
-                  color: AppTheme.gray600, fontWeight: FontWeight.w500),
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: textMain,
+              ),
+            ),
+            Text(
+              '${cita.horaFormateada} hrs',
+              style: const TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.w700,
+                color: AppTheme.primaryColor,
+                letterSpacing: -0.5,
+                fontFeatures: [FontFeature.tabularFigures()],
+              ),
+            ),
+            if (cita.motivo.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  cita.motivo,
+                  style: TextStyle(fontSize: 13, color: textMuted),
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              child: Divider(height: 1, color: divider),
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: () async {
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              PreEvaluacionScreen(citaId: cita.id),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.psychology_outlined, size: 18),
+                    label: const Text('Pre-evaluación IA'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                TextButton(
+                  onPressed: () => _confirmarCancelar(context, cita),
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppTheme.error,
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                  ),
+                  child: const Text(
+                    'Cancelar',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ],
         ),
@@ -95,68 +300,215 @@ class InicioTab extends StatelessWidget {
     );
   }
 
-  Widget _buildProximaCitaCard(BuildContext context, Cita cita) {
+  String _fechaCard(String fechaIso) {
+    final partes = fechaIso.split('-');
+    if (partes.length != 3) return fechaIso;
+    try {
+      final fecha = DateTime(
+        int.parse(partes[0]),
+        int.parse(partes[1]),
+        int.parse(partes[2]),
+      );
+      final formato = DateFormat('EEEE, d \'de\' MMMM', 'es_MX').format(fecha);
+      return formato[0].toUpperCase() + formato.substring(1);
+    } catch (_) {
+      return fechaIso;
+    }
+  }
+
+  void _confirmarCancelar(BuildContext context, Cita cita) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Cancelar cita'),
+        content: const Text('¿Estás seguro de cancelar esta cita?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('No'),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(backgroundColor: AppTheme.error),
+            onPressed: () async {
+              Navigator.pop(ctx);
+              final token =
+                  Provider.of<AuthService>(context, listen: false).token ?? '';
+              final ok = await Provider.of<CitaService>(context, listen: false)
+                  .cancelarCita(token, cita.id);
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(ok ? 'Cita cancelada' : 'No se pudo cancelar'),
+                  ),
+                );
+              }
+            },
+            child: const Text('Sí, cancelar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardSinCita extends StatelessWidget {
+  const _CardSinCita();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(20),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(10),
-                  decoration: const BoxDecoration(
-                    color: AppTheme.primarySurface,
-                    shape: BoxShape.circle,
-                  ),
-                  child: const Icon(Icons.event,
-                      color: AppTheme.primaryColor, size: 22),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        cita.fechaFormateada,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          color: AppTheme.gray900,
-                        ),
-                      ),
-                      Text(cita.horaFormateada,
-                          style: const TextStyle(color: AppTheme.gray600)),
-                    ],
-                  ),
-                ),
-                EstatusChip(estatus: cita.estatus),
-              ],
-            ),
-            if (cita.motivo.isNotEmpty) ...[
-              const Divider(height: 20),
-              Text(cita.motivo,
-                  style:
-                      const TextStyle(color: AppTheme.gray700, fontSize: 14)),
-            ],
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: () async {
-                  await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => PreEvaluacionScreen(citaId: cita.id),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.psychology, size: 18),
-                label: const Text('Pre-evaluacion IA'),
+            Icon(Icons.event_available, size: 40, color: textMuted),
+            const SizedBox(height: 8),
+            Text(
+              'Sin citas próximas',
+              style: TextStyle(
+                color: textMain,
+                fontWeight: FontWeight.w600,
+                fontSize: 14,
               ),
             ),
+            const SizedBox(height: 4),
+            Text(
+              'Agenda una desde el botón de abajo',
+              style: TextStyle(color: textMuted, fontSize: 12),
+            ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniStat extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _MiniStat({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 2,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11.5,
+              color: textMuted,
+              fontWeight: FontWeight.w500,
+              letterSpacing: 0.2,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.5,
+              color: textMain,
+              height: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SeccionTitulo extends StatelessWidget {
+  final String text;
+  final Color color;
+
+  const _SeccionTitulo({required this.text, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: color,
+        letterSpacing: 0.6,
+      ),
+    );
+  }
+}
+
+class _QuickAccess extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color bg;
+  final Color bgDark;
+  final Color iconColor;
+  final VoidCallback onTap;
+
+  const _QuickAccess({
+    required this.icon,
+    required this.label,
+    required this.bg,
+    required this.bgDark,
+    required this.iconColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final color = isDark ? bgDark : bg;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+
+    return Material(
+      color: color,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Icon(icon, color: iconColor, size: 30),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: textMain,
+                  height: 1.2,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/screens/student/nueva_cita_form.dart
+++ b/mobile/lib/screens/student/nueva_cita_form.dart
@@ -1,52 +1,913 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:yoltec_mobile/services/auth_service.dart';
+import 'package:yoltec_mobile/services/cita_service.dart';
 import 'package:yoltec_mobile/utils/app_theme.dart';
 
-// Stub temporal — la implementación real (calendario + slots) llega en Bloque 4 Fase 5.
-class NuevaCitaForm extends StatelessWidget {
+// Slots fijos del consultorio: 08:00 a 16:45 cada 15 min (36 slots).
+const _horaInicio = 8;
+const _horaFin = 17;
+const _stepMinutos = 15;
+
+class _DayInfo {
+  final Set<String> ocupados;
+  final String? horaCierre;
+  final bool lleno;
+  const _DayInfo({
+    required this.ocupados,
+    required this.horaCierre,
+    required this.lleno,
+  });
+}
+
+class NuevaCitaForm extends StatefulWidget {
   const NuevaCitaForm({super.key});
 
   @override
+  State<NuevaCitaForm> createState() => _NuevaCitaFormState();
+}
+
+class _NuevaCitaFormState extends State<NuevaCitaForm> {
+  late int _year;
+  late int _month;
+  final Map<String, _DayInfo> _infoMes = {};
+  String? _fechaSel;
+  String? _horaSel;
+  bool _cargando = false;
+  String? _errorCarga;
+
+  @override
+  void initState() {
+    super.initState();
+    final hoy = DateTime.now();
+    _year = hoy.year;
+    _month = hoy.month;
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _cargarDisponibilidad());
+  }
+
+  Future<void> _cargarDisponibilidad() async {
+    setState(() {
+      _cargando = true;
+      _errorCarga = null;
+      _infoMes.clear();
+    });
+    try {
+      final token =
+          Provider.of<AuthService>(context, listen: false).token ?? '';
+      final data = await Provider.of<CitaService>(context, listen: false)
+          .obtenerDisponibilidad(token, _month, _year);
+      final days = data['days'] as List<dynamic>? ?? [];
+      for (final raw in days) {
+        final map = raw as Map<String, dynamic>;
+        final fecha = (map['date'] as String? ?? '').split('T').first;
+        if (fecha.isEmpty) continue;
+        final ocupados = (map['taken_slots'] as List<dynamic>? ?? [])
+            .map((e) => e.toString())
+            .toSet();
+        final special = map['special'] as Map<String, dynamic>?;
+        final lleno = special?['status'] == 'full';
+        final horaCierre = special?['hora_cierre'] as String?;
+        _infoMes[fecha] = _DayInfo(
+          ocupados: ocupados,
+          horaCierre: horaCierre,
+          lleno: lleno,
+        );
+      }
+    } catch (e) {
+      _errorCarga = 'No se pudo cargar la disponibilidad';
+    } finally {
+      if (mounted) setState(() => _cargando = false);
+    }
+  }
+
+  List<String> get _allSlots {
+    final slots = <String>[];
+    for (var h = _horaInicio; h < _horaFin; h++) {
+      for (var m = 0; m < 60; m += _stepMinutos) {
+        if (h == _horaFin - 1 && m > 45) break;
+        slots.add(
+            '${h.toString().padLeft(2, '0')}:${m.toString().padLeft(2, '0')}');
+      }
+    }
+    return slots;
+  }
+
+  List<String> _slotsLibres(String fecha) {
+    final info = _infoMes[fecha];
+    if (info != null && info.lleno) return const [];
+
+    final hoy = DateTime.now();
+    final fechaHoy =
+        DateFormat('yyyy-MM-dd').format(hoy);
+    final ahora =
+        '${hoy.hour.toString().padLeft(2, '0')}:${hoy.minute.toString().padLeft(2, '0')}';
+
+    return _allSlots.where((h) {
+      if (info != null && info.ocupados.contains(h)) return false;
+      if (info?.horaCierre != null && h.compareTo(info!.horaCierre!) >= 0) {
+        return false;
+      }
+      if (fecha == fechaHoy && h.compareTo(ahora) <= 0) return false;
+      return true;
+    }).toList();
+  }
+
+  void _mesAnterior() {
+    setState(() {
+      if (_month == 1) {
+        _month = 12;
+        _year--;
+      } else {
+        _month--;
+      }
+      _fechaSel = null;
+      _horaSel = null;
+    });
+    _cargarDisponibilidad();
+  }
+
+  void _mesSiguiente() {
+    setState(() {
+      if (_month == 12) {
+        _month = 1;
+        _year++;
+      } else {
+        _month++;
+      }
+      _fechaSel = null;
+      _horaSel = null;
+    });
+    _cargarDisponibilidad();
+  }
+
+  void _seleccionarDia(String fecha) {
+    setState(() {
+      _fechaSel = fecha;
+      _horaSel = null;
+    });
+  }
+
+  void _seleccionarHora(String hora) {
+    setState(() => _horaSel = hora);
+    _mostrarConfirmacion();
+  }
+
+  void _mostrarConfirmacion() {
+    if (_fechaSel == null || _horaSel == null) return;
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _ConfirmacionSheet(
+        fecha: _fechaSel!,
+        hora: _horaSel!,
+        onConfirmar: _confirmarCita,
+      ),
+    );
+  }
+
+  Future<bool> _confirmarCita(String motivo) async {
+    final token = Provider.of<AuthService>(context, listen: false).token ?? '';
+    final servicio = Provider.of<CitaService>(context, listen: false);
+    final cita = await servicio.crearCita(
+      token,
+      fechaCita: _fechaSel!,
+      horaCita: '$_horaSel:00',
+      motivo: motivo,
+    );
+    if (cita == null) return false;
+    await servicio.cargarCitas(token);
+    if (mounted) Navigator.of(context).pop(true);
+    return true;
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? AppTheme.bgDark : AppTheme.surface;
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+        backgroundColor: AppTheme.primaryColor,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+        title: const Text(
+          'Agendar cita',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 18, 16, 24),
+          children: [
+            _seccionTitulo('Selecciona un día'),
+            const SizedBox(height: 12),
+            _navegadorMes(),
+            const SizedBox(height: 10),
+            if (_cargando)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(
+                  child: CircularProgressIndicator(
+                      color: AppTheme.primaryColor),
+                ),
+              )
+            else if (_errorCarga != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Center(
+                  child: Text(_errorCarga!,
+                      style: const TextStyle(color: AppTheme.error)),
+                ),
+              )
+            else
+              _Calendario(
+                year: _year,
+                month: _month,
+                fechaSel: _fechaSel,
+                librePorFecha: _calcularLibresPorFecha(),
+                onSelect: _seleccionarDia,
+              ),
+            const SizedBox(height: 12),
+            const _LeyendaCalendario(),
+            if (_fechaSel != null) ...[
+              const SizedBox(height: 28),
+              _CabeceraSlots(fecha: _fechaSel!),
+              const SizedBox(height: 4),
+              const Text(
+                'Solo se muestran horarios libres',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppTheme.textMuted,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const SizedBox(height: 10),
+              _GridSlots(
+                slots: _slotsLibres(_fechaSel!),
+                slotSel: _horaSel,
+                onSelect: _seleccionarHora,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Map<String, int> _calcularLibresPorFecha() {
+    final mapa = <String, int>{};
+    final diasMes = DateTime(_year, _month + 1, 0).day;
+    for (var d = 1; d <= diasMes; d++) {
+      final fecha = DateFormat('yyyy-MM-dd')
+          .format(DateTime(_year, _month, d));
+      mapa[fecha] = _slotsLibres(fecha).length;
+    }
+    return mapa;
+  }
+
+  Widget _seccionTitulo(String texto) => Text(
+        texto,
+        style: TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w600,
+          color: Theme.of(context).brightness == Brightness.dark
+              ? AppTheme.textPrimaryDark
+              : AppTheme.textPrimary,
+        ),
+      );
+
+  Widget _navegadorMes() {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final fecha = DateTime(_year, _month);
+    final etiqueta = DateFormat('MMMM y', 'es_MX').format(fecha);
+    final capital = etiqueta[0].toUpperCase() + etiqueta.substring(1);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left, size: 22),
+          onPressed: _mesAnterior,
+          color: isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary,
+          visualDensity: VisualDensity.compact,
+        ),
+        Text(
+          capital,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            letterSpacing: -0.2,
+            color: isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary,
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.chevron_right, size: 22),
+          onPressed: _mesSiguiente,
+          color: isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary,
+          visualDensity: VisualDensity.compact,
+        ),
+      ],
+    );
+  }
+}
+
+class _Calendario extends StatelessWidget {
+  final int year;
+  final int month;
+  final String? fechaSel;
+  final Map<String, int> librePorFecha;
+  final ValueChanged<String> onSelect;
+
+  const _Calendario({
+    required this.year,
+    required this.month,
+    required this.fechaSel,
+    required this.librePorFecha,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const cabeceras = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
+    final cells = <Widget>[];
+    for (final h in cabeceras) {
+      cells.add(_HeaderCelda(label: h));
+    }
+
+    final diasMes = DateTime(year, month + 1, 0).day;
+    final dowPrimero = DateTime(year, month, 1).weekday;
+    for (var i = 1; i < dowPrimero; i++) {
+      cells.add(const SizedBox());
+    }
+
+    final hoy = DateTime.now();
+    final hoyStr = DateFormat('yyyy-MM-dd').format(hoy);
+
+    for (var d = 1; d <= diasMes; d++) {
+      final fecha = DateTime(year, month, d);
+      final fechaStr = DateFormat('yyyy-MM-dd').format(fecha);
+      final dow = fecha.weekday;
+      if (dow == 7) {
+        cells.add(const SizedBox());
+        continue;
+      }
+      final esPasado = fechaStr.compareTo(hoyStr) < 0;
+      final libres = librePorFecha[fechaStr] ?? 0;
+      _EstadoDia estado;
+      if (esPasado) {
+        estado = _EstadoDia.pasado;
+      } else if (libres == 0) {
+        estado = _EstadoDia.lleno;
+      } else if (libres < 12) {
+        estado = _EstadoDia.poco;
+      } else {
+        estado = _EstadoDia.disponible;
+      }
+      cells.add(
+        _CeldaDia(
+          dia: d,
+          estado: estado,
+          libres: libres,
+          seleccionada: fechaStr == fechaSel,
+          onTap: estado == _EstadoDia.pasado || estado == _EstadoDia.lleno
+              ? null
+              : () => onSelect(fechaStr),
+        ),
+      );
+    }
+
+    return GridView.count(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      crossAxisCount: 7,
+      mainAxisSpacing: 6,
+      crossAxisSpacing: 6,
+      childAspectRatio: 0.85,
+      children: cells,
+    );
+  }
+}
+
+enum _EstadoDia { disponible, poco, lleno, pasado }
+
+class _HeaderCelda extends StatelessWidget {
+  final String label;
+  const _HeaderCelda({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Center(
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+          color: isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle,
+        ),
+      ),
+    );
+  }
+}
+
+class _CeldaDia extends StatelessWidget {
+  final int dia;
+  final _EstadoDia estado;
+  final int libres;
+  final bool seleccionada;
+  final VoidCallback? onTap;
+
+  const _CeldaDia({
+    required this.dia,
+    required this.estado,
+    required this.libres,
+    required this.seleccionada,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    Color bg = Colors.transparent;
+    Color colorNum =
+        isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    Color colorDs = AppTheme.textSubtle;
+    String? sub;
+
+    switch (estado) {
+      case _EstadoDia.pasado:
+        colorNum = isDark ? AppTheme.textSubtleDark : const Color(0xFFD1D5DB);
+        break;
+      case _EstadoDia.lleno:
+        bg = AppTheme.errorSurface;
+        colorNum = AppTheme.error;
+        colorDs = AppTheme.error;
+        sub = 'Sin disp';
+        break;
+      case _EstadoDia.poco:
+        colorDs = AppTheme.warning;
+        sub = '$libres disp';
+        break;
+      case _EstadoDia.disponible:
+        colorDs = AppTheme.primaryColor;
+        sub = '$libres disp';
+        break;
+    }
+
+    if (seleccionada) {
+      bg = AppTheme.primaryColor;
+      colorNum = Colors.white;
+      colorDs = Colors.white.withValues(alpha: 0.85);
+    }
+
+    return Material(
+      color: bg,
+      borderRadius: BorderRadius.circular(8),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '$dia',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight:
+                      seleccionada ? FontWeight.w700 : FontWeight.w600,
+                  color: colorNum,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                  height: 1,
+                ),
+              ),
+              if (sub != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  sub,
+                  style: TextStyle(
+                    fontSize: 9.5,
+                    fontWeight: FontWeight.w600,
+                    color: colorDs,
+                    height: 1,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LeyendaCalendario extends StatelessWidget {
+  const _LeyendaCalendario();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final muted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    final subtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _LegendItem(color: AppTheme.primaryColor, label: 'Disponible', muted: muted),
+        Text(' · ', style: TextStyle(color: subtle, fontSize: 11)),
+        _LegendItem(color: AppTheme.warning, label: 'Poca', muted: muted),
+        Text(' · ', style: TextStyle(color: subtle, fontSize: 11)),
+        _LegendItem(color: AppTheme.error, label: 'Lleno', muted: muted),
+      ],
+    );
+  }
+}
+
+class _LegendItem extends StatelessWidget {
+  final Color color;
+  final String label;
+  final Color muted;
+  const _LegendItem({
+    required this.color,
+    required this.label,
+    required this.muted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 6,
+          height: 6,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 5),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            color: muted,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CabeceraSlots extends StatelessWidget {
+  final String fecha;
+  const _CabeceraSlots({required this.fecha});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final partes = fecha.split('-');
+    final dt = DateTime(
+      int.parse(partes[0]),
+      int.parse(partes[1]),
+      int.parse(partes[2]),
+    );
+    final etiqueta = DateFormat('EEEE, d \'de\' MMMM', 'es_MX').format(dt);
+    final capital = etiqueta[0].toUpperCase() + etiqueta.substring(1);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Text(
+          'Horarios disponibles',
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary,
+          ),
+        ),
+        Flexible(
+          child: Text(
+            capital,
+            textAlign: TextAlign.end,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 13,
+              color: AppTheme.primaryColor,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GridSlots extends StatelessWidget {
+  final List<String> slots;
+  final String? slotSel;
+  final ValueChanged<String> onSelect;
+
+  const _GridSlots({
+    required this.slots,
+    required this.slotSel,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (slots.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 18),
+        child: Center(
+          child: Text(
+            'Sin horarios disponibles este día',
+            style: TextStyle(color: AppTheme.textMuted, fontSize: 13),
+          ),
+        ),
+      );
+    }
+    return GridView.count(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      crossAxisCount: 3,
+      mainAxisSpacing: 8,
+      crossAxisSpacing: 8,
+      childAspectRatio: 1.8,
+      children: slots
+          .map(
+            (h) => _SlotChip(
+              hora: h,
+              seleccionado: slotSel == h,
+              onTap: () => onSelect(h),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _SlotChip extends StatelessWidget {
+  final String hora;
+  final bool seleccionado;
+  final VoidCallback onTap;
+
+  const _SlotChip({
+    required this.hora,
+    required this.seleccionado,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final border = isDark ? AppTheme.borderDark : AppTheme.border;
+    final colorHora = seleccionado
+        ? Colors.white
+        : (isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary);
+    final colorFin = seleccionado
+        ? Colors.white.withValues(alpha: 0.8)
+        : (isDark ? AppTheme.textMutedDark : AppTheme.textMuted);
+
+    final partes = hora.split(':');
+    final hh = int.parse(partes[0]);
+    final mm = int.parse(partes[1]);
+    final totalMin = hh * 60 + mm + _stepMinutos;
+    final horaFin =
+        '${(totalMin ~/ 60).toString().padLeft(2, '0')}:${(totalMin % 60).toString().padLeft(2, '0')}';
+
+    return Material(
+      color: seleccionado ? AppTheme.primaryColor : Colors.transparent,
+      borderRadius: BorderRadius.circular(8),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: seleccionado ? AppTheme.primaryColor : border,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                hora,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: colorHora,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                  height: 1.1,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                '– $horaFin',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: colorFin,
+                  fontWeight: FontWeight.w500,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ConfirmacionSheet extends StatefulWidget {
+  final String fecha;
+  final String hora;
+  final Future<bool> Function(String motivo) onConfirmar;
+
+  const _ConfirmacionSheet({
+    required this.fecha,
+    required this.hora,
+    required this.onConfirmar,
+  });
+
+  @override
+  State<_ConfirmacionSheet> createState() => _ConfirmacionSheetState();
+}
+
+class _ConfirmacionSheetState extends State<_ConfirmacionSheet> {
+  final _motivoCtrl = TextEditingController();
+  String? _errorMotivo;
+  bool _enviando = false;
+
+  @override
+  void dispose() {
+    _motivoCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _confirmar() async {
+    final motivo = _motivoCtrl.text.trim();
+    if (motivo.isEmpty) {
+      setState(() => _errorMotivo = '* El motivo es obligatorio');
+      return;
+    }
+    setState(() {
+      _enviando = true;
+      _errorMotivo = null;
+    });
+    final ok = await widget.onConfirmar(motivo);
+    if (!mounted) return;
+    setState(() => _enviando = false);
+    if (!ok) {
+      setState(() => _errorMotivo = 'No se pudo agendar. Intenta de nuevo.');
+    } else {
+      Navigator.pop(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Cita agendada exitosamente')),
+      );
+    }
+  }
+
+  String _resumen() {
+    final partes = widget.fecha.split('-');
+    final dt = DateTime(
+      int.parse(partes[0]),
+      int.parse(partes[1]),
+      int.parse(partes[2]),
+    );
+    final etiqueta = DateFormat('EEEE d \'de\' MMMM', 'es_MX').format(dt);
+    final capital = etiqueta[0].toUpperCase() + etiqueta.substring(1);
+    final partesH = widget.hora.split(':');
+    final hh = int.parse(partesH[0]);
+    final mm = int.parse(partesH[1]);
+    final fin = hh * 60 + mm + _stepMinutos;
+    final horaFin =
+        '${(fin ~/ 60).toString().padLeft(2, '0')}:${(fin % 60).toString().padLeft(2, '0')}';
+    return '$capital · ${widget.hora} – $horaFin';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
     return Padding(
       padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
-        top: 24,
-        left: 24,
-        right: 24,
+        bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 40,
-            height: 4,
-            margin: const EdgeInsets.only(bottom: 16),
-            decoration: BoxDecoration(
-              color: AppTheme.gray400,
-              borderRadius: BorderRadius.circular(2),
+      child: Container(
+        decoration: BoxDecoration(
+          color: surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
+        ),
+        padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFD1D5DB),
+                  borderRadius: BorderRadius.circular(99),
+                ),
+              ),
             ),
-          ),
-          const Icon(Icons.event_available, size: 48, color: AppTheme.primaryColor),
-          const SizedBox(height: 12),
-          const Text(
-            'Agendar cita',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-          ),
-          const SizedBox(height: 8),
-          const Text(
-            'Esta función estará disponible pronto. Por ahora puedes agendar desde la versión web.',
-            textAlign: TextAlign.center,
-            style: TextStyle(color: AppTheme.gray600, fontSize: 14),
-          ),
-          const SizedBox(height: 20),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Entendido'),
+            Text(
+              'Confirmar cita',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+                letterSpacing: -0.3,
+                color: textMain,
+              ),
             ),
-          ),
-        ],
+            const SizedBox(height: 6),
+            Text(
+              _resumen(),
+              style: const TextStyle(
+                fontSize: 13.5,
+                color: AppTheme.primaryColor,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Divider(
+              height: 1,
+              color: isDark ? AppTheme.borderDark : AppTheme.borderSoft,
+            ),
+            const SizedBox(height: 14),
+            Text(
+              'Motivo de la cita',
+              style: TextStyle(
+                fontSize: 12.5,
+                color: textMuted,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(height: 6),
+            TextField(
+              controller: _motivoCtrl,
+              maxLines: 3,
+              minLines: 3,
+              decoration: const InputDecoration(
+                hintText: 'Describe brevemente el motivo...',
+              ),
+            ),
+            if (_errorMotivo != null) ...[
+              const SizedBox(height: 6),
+              Text(
+                _errorMotivo!,
+                style: const TextStyle(
+                  fontSize: 11,
+                  color: AppTheme.error,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 52,
+              child: ElevatedButton(
+                onPressed: _enviando ? null : _confirmar,
+                child: _enviando
+                    ? const SizedBox(
+                        width: 22,
+                        height: 22,
+                        child: CircularProgressIndicator(
+                            strokeWidth: 2.5, color: Colors.white),
+                      )
+                    : const Text('Confirmar cita'),
+              ),
+            ),
+            TextButton(
+              onPressed:
+                  _enviando ? null : () => Navigator.pop(context),
+              child: Text(
+                'Cancelar',
+                style: TextStyle(
+                  color: textMuted,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/student/perfil_tab.dart
+++ b/mobile/lib/screens/student/perfil_tab.dart
@@ -23,9 +23,14 @@ class _PerfilTabState extends State<PerfilTab> {
   String _numeroControl = '';
   String _telefono = '';
   String? _fotoPerfil;
+  String _carrera = '';
   String _tipoSangre = '';
+  String _peso = '';
+  String _estatura = '';
   String _alergias = '';
   String _enfermedadesCronicas = '';
+  String _contactoNombre = '';
+  String _contactoTelefono = '';
 
   @override
   void initState() {
@@ -34,9 +39,13 @@ class _PerfilTabState extends State<PerfilTab> {
   }
 
   Future<void> _cargarPerfil() async {
-    setState(() { _cargando = true; _error = null; });
+    setState(() {
+      _cargando = true;
+      _error = null;
+    });
     try {
-      final token = Provider.of<AuthService>(context, listen: false).token ?? '';
+      final token =
+          Provider.of<AuthService>(context, listen: false).token ?? '';
       final data = await ApiService.get('/perfil-medico', token: token);
       final perfil = data['data'] ?? data;
       if (mounted) {
@@ -47,31 +56,84 @@ class _PerfilTabState extends State<PerfilTab> {
           _numeroControl = (perfil['numero_control'] ?? '').toString();
           _telefono = (perfil['telefono'] ?? '').toString();
           _fotoPerfil = perfil['foto_perfil']?.toString();
+          _carrera = (perfil['carrera'] ?? '').toString();
           _tipoSangre = (perfil['tipo_sangre'] ?? '').toString();
+          _peso = (perfil['peso'] ?? '').toString();
+          _estatura = (perfil['estatura'] ?? '').toString();
           _alergias = (perfil['alergias'] ?? '').toString();
-          _enfermedadesCronicas = (perfil['enfermedades_cronicas'] ?? '').toString();
+          _enfermedadesCronicas =
+              (perfil['enfermedades_cronicas'] ?? '').toString();
+          _contactoNombre =
+              (perfil['contacto_emergencia_nombre'] ?? '').toString();
+          _contactoTelefono =
+              (perfil['contacto_emergencia_telefono'] ?? '').toString();
           _cargando = false;
         });
       }
     } on ApiException catch (e) {
-      if (mounted) setState(() { _error = e.message; _cargando = false; });
+      if (mounted) {
+        setState(() {
+          _error = e.message;
+          _cargando = false;
+        });
+      }
     } catch (_) {
-      if (mounted) setState(() { _error = 'Error al cargar perfil'; _cargando = false; });
+      if (mounted) {
+        setState(() {
+          _error = 'Error al cargar perfil';
+          _cargando = false;
+        });
+      }
     }
   }
 
   Future<void> _cambiarFoto() async {
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_camera_outlined),
+              title: const Text('Cámara'),
+              onTap: () => Navigator.pop(ctx, ImageSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library_outlined),
+              title: const Text('Galería'),
+              onTap: () => Navigator.pop(ctx, ImageSource.gallery),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (source == null) return;
+
     final picker = ImagePicker();
-    final picked = await picker.pickImage(source: ImageSource.gallery, maxWidth: 800, imageQuality: 80);
+    final picked = await picker.pickImage(
+      source: source,
+      maxWidth: 800,
+      imageQuality: 80,
+    );
     if (picked == null || !mounted) return;
     try {
-      final token = Provider.of<AuthService>(context, listen: false).token ?? '';
-      final result = await ApiService.postMultipart('/perfil/foto', File(picked.path), 'foto', token: token);
-      final nuevaFoto = (result['data'] ?? result)['foto_perfil']?.toString();
+      final token =
+          Provider.of<AuthService>(context, listen: false).token ?? '';
+      final result = await ApiService.postMultipart(
+        '/perfil/foto',
+        File(picked.path),
+        'foto',
+        token: token,
+      );
+      final nuevaFoto =
+          (result['data'] ?? result)['foto_perfil']?.toString();
       if (mounted) {
         setState(() => _fotoPerfil = nuevaFoto);
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Foto actualizada'), backgroundColor: AppTheme.primaryColor),
+          const SnackBar(
+            content: Text('Foto actualizada'),
+            backgroundColor: AppTheme.primaryColor,
+          ),
         );
       }
     } on ApiException catch (e) {
@@ -92,157 +154,406 @@ class _PerfilTabState extends State<PerfilTab> {
 
   @override
   Widget build(BuildContext context) {
-    if (_cargando) return const Center(child: CircularProgressIndicator(color: AppTheme.primaryColor));
+    if (_cargando) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppTheme.primaryColor),
+      );
+    }
     if (_error != null) return _buildError();
 
-    return RefreshIndicator(
-      color: AppTheme.primaryColor,
-      onRefresh: _cargarPerfil,
-      child: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          _buildAvatar(),
-          const SizedBox(height: 10),
-          Center(child: Text('$_nombre $_apellido'.trim(),
-            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: AppTheme.gray900))),
-          if (_email.isNotEmpty) Center(child: Text(_email,
-            style: const TextStyle(color: AppTheme.gray600, fontSize: 13))),
-          const SizedBox(height: 20),
-          _SeccionCard(titulo: 'Datos Personales', icono: Icons.badge_outlined, children: [
-            _CampoInfo(label: 'Numero de control', valor: _numeroControl),
-            _CampoInfo(label: 'Nombre', valor: '$_nombre $_apellido'.trim()),
-            _CampoInfo(label: 'Email', valor: _email),
-            if (_telefono.isNotEmpty) _CampoInfo(label: 'Telefono', valor: _telefono),
-          ]),
-          const SizedBox(height: 14),
-          _SeccionCard(
-            titulo: 'Información Médica',
-            icono: Icons.medical_information_outlined,
-            accion: TextButton.icon(
-              onPressed: () => _mostrarEditarInfoMedica(),
-              icon: const Icon(Icons.edit_outlined, size: 16),
-              label: const Text('Editar', style: TextStyle(fontSize: 13)),
-              style: TextButton.styleFrom(foregroundColor: AppTheme.primaryColor,
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4)),
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? AppTheme.bgDark : AppTheme.bg;
+
+    return Container(
+      color: bg,
+      child: RefreshIndicator(
+        color: AppTheme.primaryColor,
+        onRefresh: _cargarPerfil,
+        child: ListView(
+          padding: const EdgeInsets.only(bottom: 24),
+          children: [
+            _Cabecera(
+              iniciales: _iniciales,
+              nombre: '$_nombre $_apellido'.trim(),
+              numeroControl: _numeroControl,
+              carrera: _carrera,
+              fotoUrl: _fotoPerfil,
+              onCambiarFoto: _cambiarFoto,
             ),
-            children: [
-              _CampoInfo(label: 'Tipo de sangre', valor: _tipoSangre.isEmpty ? 'No registrado' : _tipoSangre),
-              _CampoInfo(label: 'Alergias', valor: _alergias.isEmpty ? 'Ninguna' : _alergias),
-              _CampoInfo(label: 'Enfermedades cronicas', valor: _enfermedadesCronicas.isEmpty ? 'Ninguna' : _enfermedadesCronicas),
-            ],
-          ),
-          const SizedBox(height: 14),
-          _SeccionCard(titulo: 'Seguridad', icono: Icons.lock_outline, children: [
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: () => showDialog(context: context, builder: (_) => const _CambiarPasswordDialog()),
-                icon: const Icon(Icons.key_outlined, size: 18),
-                label: const Text('Cambiar contraseña'),
-                style: OutlinedButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 12)),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  onPressed: _mostrarEditarInfoMedica,
+                  icon: const Icon(Icons.edit_outlined, size: 14),
+                  label: const Text(
+                    'Editar',
+                    style:
+                        TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                  ),
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppTheme.primaryColor,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                    minimumSize: const Size(0, 28),
+                  ),
+                ),
               ),
             ),
-          ]),
-          const SizedBox(height: 24),
-        ],
+            const _SeccionTitulo('Datos físicos'),
+            _Tarjeta(filas: [
+              _Fila(label: 'Tipo de sangre',
+                  valor: _tipoSangre.isEmpty ? 'No registrado' : _tipoSangre),
+              if (_peso.isNotEmpty)
+                _Fila(label: 'Peso', valor: '$_peso kg'),
+              if (_estatura.isNotEmpty)
+                _Fila(label: 'Estatura', valor: '$_estatura cm'),
+            ]),
+            const SizedBox(height: 12),
+            const _SeccionTitulo('Información médica'),
+            _Tarjeta(filas: [
+              _Fila(
+                label: 'Alergias',
+                valor: _alergias.isEmpty ? 'Ninguna conocida' : _alergias,
+              ),
+              _Fila(
+                label: 'Enfermedades crónicas',
+                valor: _enfermedadesCronicas.isEmpty
+                    ? 'Ninguna'
+                    : _enfermedadesCronicas,
+              ),
+            ]),
+            if (_contactoNombre.isNotEmpty || _contactoTelefono.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              const _SeccionTitulo('Contacto de emergencia'),
+              _Tarjeta(filas: [
+                if (_contactoNombre.isNotEmpty)
+                  _Fila(label: 'Nombre', valor: _contactoNombre),
+                if (_contactoTelefono.isNotEmpty)
+                  _Fila(label: 'Teléfono', valor: _contactoTelefono),
+              ]),
+            ],
+            const SizedBox(height: 12),
+            const _SeccionTitulo('Cuenta'),
+            _Tarjeta(filas: [
+              if (_email.isNotEmpty)
+                _Fila(label: 'Email', valor: _email),
+              if (_telefono.isNotEmpty)
+                _Fila(label: 'Teléfono', valor: _telefono),
+            ]),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 18, 16, 0),
+              child: OutlinedButton.icon(
+                onPressed: () => showDialog(
+                  context: context,
+                  builder: (_) => const _CambiarPasswordDialog(),
+                ),
+                icon: const Icon(Icons.key_outlined, size: 18),
+                label: const Text('Cambiar contraseña'),
+                style: OutlinedButton.styleFrom(
+                  minimumSize: const Size(double.infinity, 46),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  Widget _buildAvatar() {
-    return Center(
-      child: Stack(children: [
-        CircleAvatar(
-          radius: 52,
-          backgroundColor: AppTheme.primarySurface,
-          backgroundImage: (_fotoPerfil != null && _fotoPerfil!.isNotEmpty) ? NetworkImage(_fotoPerfil!) : null,
-          child: (_fotoPerfil == null || _fotoPerfil!.isEmpty)
-            ? Text(_iniciales, style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: AppTheme.primaryColor))
-            : null,
-        ),
-        Positioned(
-          bottom: 0, right: 0,
-          child: GestureDetector(
-            onTap: _cambiarFoto,
-            child: Container(
-              padding: const EdgeInsets.all(6),
-              decoration: BoxDecoration(color: AppTheme.primaryColor, shape: BoxShape.circle,
-                border: Border.all(color: Colors.white, width: 2)),
-              child: const Icon(Icons.camera_alt, size: 16, color: Colors.white),
-            ),
-          ),
-        ),
-      ]),
-    );
-  }
-
   Widget _buildError() {
-    return Center(child: Padding(
-      padding: const EdgeInsets.all(24),
-      child: Column(mainAxisSize: MainAxisSize.min, children: [
-        const Icon(Icons.error_outline, size: 48, color: AppTheme.error),
-        const SizedBox(height: 12),
-        Text(_error!, textAlign: TextAlign.center, style: const TextStyle(color: AppTheme.gray700)),
-        const SizedBox(height: 16),
-        ElevatedButton.icon(onPressed: _cargarPerfil, icon: const Icon(Icons.refresh, size: 18), label: const Text('Reintentar')),
-      ]),
-    ));
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: AppTheme.error),
+            const SizedBox(height: 12),
+            Text(
+              _error!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: AppTheme.textMuted),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: _cargarPerfil,
+              icon: const Icon(Icons.refresh, size: 18),
+              label: const Text('Reintentar'),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   void _mostrarEditarInfoMedica() {
     showDialog(
       context: context,
       builder: (_) => _EditarInfoMedicaDialog(
-        tipoSangre: _tipoSangre, alergias: _alergias, enfermedadesCronicas: _enfermedadesCronicas,
-        onGuardado: (ts, al, ec) => setState(() { _tipoSangre = ts; _alergias = al; _enfermedadesCronicas = ec; }),
+        tipoSangre: _tipoSangre,
+        alergias: _alergias,
+        enfermedadesCronicas: _enfermedadesCronicas,
+        onGuardado: (ts, al, ec) => setState(() {
+          _tipoSangre = ts;
+          _alergias = al;
+          _enfermedadesCronicas = ec;
+        }),
       ),
     );
   }
 }
 
-class _SeccionCard extends StatelessWidget {
-  final String titulo;
-  final IconData icono;
-  final List<Widget> children;
-  final Widget? accion;
+class _Cabecera extends StatelessWidget {
+  final String iniciales;
+  final String nombre;
+  final String numeroControl;
+  final String carrera;
+  final String? fotoUrl;
+  final VoidCallback onCambiarFoto;
 
-  const _SeccionCard({required this.titulo, required this.icono, required this.children, this.accion});
+  const _Cabecera({
+    required this.iniciales,
+    required this.nombre,
+    required this.numeroControl,
+    required this.carrera,
+    required this.fotoUrl,
+    required this.onCambiarFoto,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Row(children: [
-            Icon(icono, color: AppTheme.primaryColor, size: 18),
-            const SizedBox(width: 8),
-            Text(titulo, style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 15, color: AppTheme.gray800)),
-            if (accion != null) ...[const Spacer(), accion!],
-          ]),
-          const Divider(height: 20),
-          ...children,
-        ]),
+    final meta = [
+      if (numeroControl.isNotEmpty) numeroControl,
+      if (carrera.isNotEmpty) carrera,
+    ].join(' · ');
+
+    return Container(
+      width: double.infinity,
+      color: AppTheme.primaryColor,
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 22),
+      child: Column(
+        children: [
+          Stack(
+            children: [
+              Container(
+                width: 72,
+                height: 72,
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.15),
+                  shape: BoxShape.circle,
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: (fotoUrl != null && fotoUrl!.isNotEmpty)
+                    ? Image.network(
+                        fotoUrl!,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) => _avatarTexto(),
+                      )
+                    : _avatarTexto(),
+              ),
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: GestureDetector(
+                  onTap: onCambiarFoto,
+                  child: Container(
+                    padding: const EdgeInsets.all(5),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: AppTheme.primaryColor,
+                        width: 2,
+                      ),
+                    ),
+                    child: const Icon(
+                      Icons.camera_alt,
+                      size: 12,
+                      color: AppTheme.primaryColor,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            nombre.isEmpty ? 'Sin nombre' : nombre,
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+              letterSpacing: -0.2,
+            ),
+          ),
+          if (meta.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              meta,
+              style: const TextStyle(
+                fontSize: 13,
+                color: Colors.white70,
+                fontWeight: FontWeight.w400,
+              ),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _PuntoActivo(),
+                SizedBox(width: 5),
+                Text(
+                  'Activo',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _avatarTexto() {
+    return Center(
+      child: Text(
+        iniciales,
+        style: const TextStyle(
+          fontWeight: FontWeight.w700,
+          fontSize: 24,
+          color: Colors.white,
+          letterSpacing: 0.5,
+        ),
       ),
     );
   }
 }
 
-class _CampoInfo extends StatelessWidget {
+class _PuntoActivo extends StatelessWidget {
+  const _PuntoActivo();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 6,
+      height: 6,
+      decoration: const BoxDecoration(
+        color: Color(0xFF86EFAC),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}
+
+class _SeccionTitulo extends StatelessWidget {
+  final String texto;
+  const _SeccionTitulo(this.texto);
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final subtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(22, 6, 22, 8),
+      child: Text(
+        texto.toUpperCase(),
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: subtle,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _Tarjeta extends StatelessWidget {
+  final List<_Fila> filas;
+  const _Tarjeta({required this.filas});
+
+  @override
+  Widget build(BuildContext context) {
+    if (filas.isEmpty) return const SizedBox.shrink();
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final divider = isDark ? AppTheme.borderDark : AppTheme.borderSoft;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          for (var i = 0; i < filas.length; i++) ...[
+            filas[i],
+            if (i < filas.length - 1)
+              Divider(height: 1, color: divider, indent: 16, endIndent: 16),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _Fila extends StatelessWidget {
   final String label;
   final String valor;
-
-  const _CampoInfo({required this.label, required this.valor});
+  const _Fila({required this.label, required this.valor});
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final subtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+
     return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Text(label, style: const TextStyle(fontSize: 11, color: AppTheme.gray500, fontWeight: FontWeight.w500)),
-        const SizedBox(height: 2),
-        Text(valor, style: const TextStyle(fontSize: 14, color: AppTheme.gray800)),
-      ]),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label.toUpperCase(),
+            style: TextStyle(
+              fontSize: 11,
+              color: subtle,
+              fontWeight: FontWeight.w400,
+              letterSpacing: 0.4,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            valor,
+            style: TextStyle(
+              fontSize: 15,
+              color: textMain,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -253,10 +564,16 @@ class _EditarInfoMedicaDialog extends StatefulWidget {
   final String enfermedadesCronicas;
   final void Function(String, String, String) onGuardado;
 
-  const _EditarInfoMedicaDialog({required this.tipoSangre, required this.alergias, required this.enfermedadesCronicas, required this.onGuardado});
+  const _EditarInfoMedicaDialog({
+    required this.tipoSangre,
+    required this.alergias,
+    required this.enfermedadesCronicas,
+    required this.onGuardado,
+  });
 
   @override
-  State<_EditarInfoMedicaDialog> createState() => _EditarInfoMedicaDialogState();
+  State<_EditarInfoMedicaDialog> createState() =>
+      _EditarInfoMedicaDialogState();
 }
 
 class _EditarInfoMedicaDialogState extends State<_EditarInfoMedicaDialog> {
@@ -266,31 +583,60 @@ class _EditarInfoMedicaDialogState extends State<_EditarInfoMedicaDialog> {
   late final TextEditingController _enfermedadesCtrl;
   bool _guardando = false;
 
-  static const _tiposSangre = ['', 'A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-'];
+  static const _tiposSangre = [
+    '', 'A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-'
+  ];
 
   @override
   void initState() {
     super.initState();
     _tipoSangre = widget.tipoSangre;
     _alergiasCtrl = TextEditingController(text: widget.alergias);
-    _enfermedadesCtrl = TextEditingController(text: widget.enfermedadesCronicas);
+    _enfermedadesCtrl =
+        TextEditingController(text: widget.enfermedadesCronicas);
   }
 
   @override
-  void dispose() { _alergiasCtrl.dispose(); _enfermedadesCtrl.dispose(); super.dispose(); }
+  void dispose() {
+    _alergiasCtrl.dispose();
+    _enfermedadesCtrl.dispose();
+    super.dispose();
+  }
 
   Future<void> _guardar() async {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _guardando = true);
     try {
-      final token = Provider.of<AuthService>(context, listen: false).token ?? '';
-      await ApiService.put('/perfil-medico', {'tipo_sangre': _tipoSangre, 'alergias': _alergiasCtrl.text.trim(), 'enfermedades_cronicas': _enfermedadesCtrl.text.trim()}, token: token);
+      final token =
+          Provider.of<AuthService>(context, listen: false).token ?? '';
+      await ApiService.put(
+        '/perfil-medico',
+        {
+          'tipo_sangre': _tipoSangre,
+          'alergias': _alergiasCtrl.text.trim(),
+          'enfermedades_cronicas': _enfermedadesCtrl.text.trim(),
+        },
+        token: token,
+      );
       if (!mounted) return;
-      widget.onGuardado(_tipoSangre, _alergiasCtrl.text.trim(), _enfermedadesCtrl.text.trim());
+      widget.onGuardado(
+        _tipoSangre,
+        _alergiasCtrl.text.trim(),
+        _enfermedadesCtrl.text.trim(),
+      );
       Navigator.pop(context);
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Información médica actualizada'), backgroundColor: AppTheme.primaryColor));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Información médica actualizada'),
+          backgroundColor: AppTheme.primaryColor,
+        ),
+      );
     } on ApiException catch (e) {
-      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(e.message), backgroundColor: AppTheme.error));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.message), backgroundColor: AppTheme.error),
+        );
+      }
     } finally {
       if (mounted) setState(() => _guardando = false);
     }
@@ -299,22 +645,68 @@ class _EditarInfoMedicaDialogState extends State<_EditarInfoMedicaDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Row(children: [Icon(Icons.medical_information_outlined, color: AppTheme.primaryColor, size: 22), SizedBox(width: 8), Text('Info. Médica', style: TextStyle(fontSize: 17))]),
-      content: SingleChildScrollView(child: Form(key: _formKey, child: Column(mainAxisSize: MainAxisSize.min, children: [
-        DropdownButtonFormField<String>(
-          initialValue: _tiposSangre.contains(_tipoSangre) ? _tipoSangre : '',
-          decoration: const InputDecoration(labelText: 'Tipo de sangre', prefixIcon: Icon(Icons.bloodtype_outlined)),
-          items: _tiposSangre.map((t) => DropdownMenuItem(value: t, child: Text(t.isEmpty ? 'No especificado' : t))).toList(),
-          onChanged: (v) => setState(() => _tipoSangre = v ?? ''),
+      title: const Text('Información médica',
+          style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600)),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              DropdownButtonFormField<String>(
+                initialValue:
+                    _tiposSangre.contains(_tipoSangre) ? _tipoSangre : '',
+                decoration: const InputDecoration(
+                  labelText: 'Tipo de sangre',
+                  prefixIcon: Icon(Icons.bloodtype_outlined),
+                ),
+                items: _tiposSangre
+                    .map((t) => DropdownMenuItem(
+                        value: t,
+                        child: Text(t.isEmpty ? 'No especificado' : t)))
+                    .toList(),
+                onChanged: (v) => setState(() => _tipoSangre = v ?? ''),
+              ),
+              const SizedBox(height: 14),
+              TextFormField(
+                controller: _alergiasCtrl,
+                maxLines: 2,
+                decoration: const InputDecoration(
+                  labelText: 'Alergias',
+                  hintText: 'Ej: Penicilina, polvo...',
+                  prefixIcon: Icon(Icons.warning_amber_outlined),
+                ),
+              ),
+              const SizedBox(height: 14),
+              TextFormField(
+                controller: _enfermedadesCtrl,
+                maxLines: 2,
+                decoration: const InputDecoration(
+                  labelText: 'Enfermedades crónicas',
+                  hintText: 'Ej: Diabetes, hipertensión...',
+                  prefixIcon: Icon(Icons.monitor_heart_outlined),
+                ),
+              ),
+            ],
+          ),
         ),
-        const SizedBox(height: 14),
-        TextFormField(controller: _alergiasCtrl, maxLines: 2, decoration: const InputDecoration(labelText: 'Alergias', hintText: 'Ej: Penicilina, polvo...', prefixIcon: Icon(Icons.warning_amber_outlined))),
-        const SizedBox(height: 14),
-        TextFormField(controller: _enfermedadesCtrl, maxLines: 2, decoration: const InputDecoration(labelText: 'Enfermedades cronicas', hintText: 'Ej: Diabetes, hipertension...', prefixIcon: Icon(Icons.monitor_heart_outlined))),
-      ]))),
+      ),
       actions: [
-        TextButton(onPressed: _guardando ? null : () => Navigator.pop(context), child: const Text('Cancelar')),
-        ElevatedButton(onPressed: _guardando ? null : _guardar, child: _guardando ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white)) : const Text('Guardar')),
+        TextButton(
+          onPressed: _guardando ? null : () => Navigator.pop(context),
+          child: const Text('Cancelar'),
+        ),
+        ElevatedButton(
+          onPressed: _guardando ? null : _guardar,
+          child: _guardando
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2, color: Colors.white),
+                )
+              : const Text('Guardar'),
+        ),
       ],
     );
   }
@@ -337,47 +729,110 @@ class _CambiarPasswordDialogState extends State<_CambiarPasswordDialog> {
   bool _verConfirm = false;
 
   @override
-  void dispose() { _actualCtrl.dispose(); _nuevoCtrl.dispose(); _confirmCtrl.dispose(); super.dispose(); }
+  void dispose() {
+    _actualCtrl.dispose();
+    _nuevoCtrl.dispose();
+    _confirmCtrl.dispose();
+    super.dispose();
+  }
 
   Future<void> _guardar() async {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _guardando = true);
     try {
-      final token = Provider.of<AuthService>(context, listen: false).token ?? '';
-      await ApiService.post('/perfil/cambiar-password', {'password_actual': _actualCtrl.text, 'password_nuevo': _nuevoCtrl.text, 'password_nuevo_confirmation': _confirmCtrl.text}, token: token);
+      final token =
+          Provider.of<AuthService>(context, listen: false).token ?? '';
+      await ApiService.post(
+        '/perfil/cambiar-password',
+        {
+          'password_actual': _actualCtrl.text,
+          'password_nuevo': _nuevoCtrl.text,
+          'password_nuevo_confirmation': _confirmCtrl.text,
+        },
+        token: token,
+      );
       if (!mounted) return;
       Navigator.pop(context);
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Contraseña actualizada'), backgroundColor: AppTheme.primaryColor));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Contraseña actualizada'),
+          backgroundColor: AppTheme.primaryColor,
+        ),
+      );
     } on ApiException catch (e) {
-      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(e.message), backgroundColor: AppTheme.error));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.message), backgroundColor: AppTheme.error),
+        );
+      }
     } finally {
       if (mounted) setState(() => _guardando = false);
     }
   }
 
-  Widget _passField(TextEditingController ctrl, String label, bool ver, VoidCallback toggle) {
+  Widget _passField(
+    TextEditingController ctrl,
+    String label,
+    bool ver,
+    VoidCallback toggle,
+  ) {
     return TextFormField(
-      controller: ctrl, obscureText: !ver,
-      decoration: InputDecoration(labelText: label, prefixIcon: const Icon(Icons.lock_outline),
-        suffixIcon: IconButton(icon: Icon(ver ? Icons.visibility_off_outlined : Icons.visibility_outlined), onPressed: toggle)),
-      validator: (v) => (v == null || v.isEmpty) ? 'Campo requerido' : null,
+      controller: ctrl,
+      obscureText: !ver,
+      decoration: InputDecoration(
+        labelText: label,
+        prefixIcon: const Icon(Icons.lock_outline),
+        suffixIcon: IconButton(
+          icon: Icon(ver
+              ? Icons.visibility_off_outlined
+              : Icons.visibility_outlined),
+          onPressed: toggle,
+        ),
+      ),
+      validator: (v) =>
+          (v == null || v.isEmpty) ? 'Campo requerido' : null,
     );
   }
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Row(children: [Icon(Icons.lock_outline, color: AppTheme.primaryColor, size: 22), SizedBox(width: 8), Text('Cambiar contraseña', style: TextStyle(fontSize: 17))]),
-      content: SingleChildScrollView(child: Form(key: _formKey, child: Column(mainAxisSize: MainAxisSize.min, children: [
-        _passField(_actualCtrl, 'Contraseña actual', _verActual, () => setState(() => _verActual = !_verActual)),
-        const SizedBox(height: 14),
-        _passField(_nuevoCtrl, 'Nueva contraseña', _verNuevo, () => setState(() => _verNuevo = !_verNuevo)),
-        const SizedBox(height: 14),
-        _passField(_confirmCtrl, 'Confirmar contraseña', _verConfirm, () => setState(() => _verConfirm = !_verConfirm)),
-      ]))),
+      title: const Text('Cambiar contraseña',
+          style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600)),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _passField(_actualCtrl, 'Contraseña actual', _verActual,
+                  () => setState(() => _verActual = !_verActual)),
+              const SizedBox(height: 14),
+              _passField(_nuevoCtrl, 'Nueva contraseña', _verNuevo,
+                  () => setState(() => _verNuevo = !_verNuevo)),
+              const SizedBox(height: 14),
+              _passField(_confirmCtrl, 'Confirmar contraseña', _verConfirm,
+                  () => setState(() => _verConfirm = !_verConfirm)),
+            ],
+          ),
+        ),
+      ),
       actions: [
-        TextButton(onPressed: _guardando ? null : () => Navigator.pop(context), child: const Text('Cancelar')),
-        ElevatedButton(onPressed: _guardando ? null : _guardar, child: _guardando ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white)) : const Text('Guardar')),
+        TextButton(
+          onPressed: _guardando ? null : () => Navigator.pop(context),
+          child: const Text('Cancelar'),
+        ),
+        ElevatedButton(
+          onPressed: _guardando ? null : _guardar,
+          child: _guardando
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2, color: Colors.white),
+                )
+              : const Text('Guardar'),
+        ),
       ],
     );
   }

--- a/mobile/lib/screens/student/recetas_tab.dart
+++ b/mobile/lib/screens/student/recetas_tab.dart
@@ -1,48 +1,169 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:yoltec_mobile/models/receta.dart';
-import 'package:yoltec_mobile/screens/student/widgets/student_widgets.dart';
 import 'package:yoltec_mobile/services/auth_service.dart';
 import 'package:yoltec_mobile/services/receta_service.dart';
 import 'package:yoltec_mobile/utils/app_theme.dart';
 
-class RecetasTab extends StatelessWidget {
+class RecetasTab extends StatefulWidget {
   const RecetasTab({super.key});
 
   @override
+  State<RecetasTab> createState() => _RecetasTabState();
+}
+
+class _RecetasTabState extends State<RecetasTab> {
+  final _searchCtrl = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  bool _coincide(Receta receta) {
+    if (_query.isEmpty) return true;
+    final q = _query.toLowerCase();
+    if (receta.indicaciones.toLowerCase().contains(q)) return true;
+    if ((receta.doctorNombre ?? '').toLowerCase().contains(q)) return true;
+    for (final m in receta.medicamentos) {
+      if (m.nombre.toLowerCase().contains(q)) return true;
+    }
+    return false;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return RefreshIndicator(
-      color: AppTheme.primaryColor,
-      onRefresh: () async {
-        final token =
-            Provider.of<AuthService>(context, listen: false).token ?? '';
-        await Provider.of<RecetaService>(context, listen: false)
-            .cargarRecetas(token);
-      },
-      child: Consumer<RecetaService>(
-        builder: (context, service, _) {
-          if (service.isLoading) {
-            return const Center(
-                child: CircularProgressIndicator(
-                    color: AppTheme.primaryColor));
-          }
-          if (service.recetas.isEmpty) {
-            return ListView(
-              children: const [
-                SizedBox(height: 80),
-                Center(child: Text('No tienes recetas registradas.')),
-              ],
-            );
-          }
-          return ListView.separated(
-            padding: const EdgeInsets.all(16),
-            itemCount: service.recetas.length,
-            separatorBuilder: (_, __) => const SizedBox(height: 10),
-            itemBuilder: (context, i) =>
-                _RecetaCard(receta: service.recetas[i]),
-          );
-        },
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark ? AppTheme.bgDark : AppTheme.bg;
+
+    return Container(
+      color: bg,
+      child: Column(
+        children: [
+          _BarraBusqueda(
+            controller: _searchCtrl,
+            onChanged: (v) => setState(() => _query = v.trim()),
+          ),
+          Expanded(
+            child: RefreshIndicator(
+              color: AppTheme.primaryColor,
+              onRefresh: () async {
+                final token = Provider.of<AuthService>(context, listen: false)
+                        .token ??
+                    '';
+                await Provider.of<RecetaService>(context, listen: false)
+                    .cargarRecetas(token);
+              },
+              child: Consumer<RecetaService>(
+                builder: (context, service, _) {
+                  if (service.isLoading && service.recetas.isEmpty) {
+                    return const Center(
+                      child: CircularProgressIndicator(
+                          color: AppTheme.primaryColor),
+                    );
+                  }
+                  final filtradas =
+                      service.recetas.where(_coincide).toList();
+                  if (filtradas.isEmpty) {
+                    return ListView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      padding: const EdgeInsets.all(16),
+                      children: [
+                        const SizedBox(height: 60),
+                        Center(
+                          child: _Vacio(
+                            mensaje: service.recetas.isEmpty
+                                ? 'No tienes recetas registradas'
+                                : 'Sin resultados',
+                          ),
+                        ),
+                      ],
+                    );
+                  }
+                  return ListView.separated(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                    itemCount: filtradas.length,
+                    separatorBuilder: (_, __) => const SizedBox(height: 12),
+                    itemBuilder: (_, i) => _RecetaCard(receta: filtradas[i]),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
       ),
+    );
+  }
+}
+
+class _BarraBusqueda extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  const _BarraBusqueda({required this.controller, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final fill = isDark
+        ? Colors.white.withValues(alpha: 0.06)
+        : const Color(0xFFF3F4F6);
+    final subtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+
+    return Container(
+      color: surface,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      child: TextField(
+        controller: controller,
+        onChanged: onChanged,
+        decoration: InputDecoration(
+          hintText: 'Buscar receta o medicamento...',
+          hintStyle: TextStyle(color: subtle, fontSize: 13.5),
+          prefixIcon: Icon(Icons.search, color: subtle, size: 18),
+          filled: true,
+          fillColor: fill,
+          contentPadding:
+              const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide.none,
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide.none,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Vacio extends StatelessWidget {
+  final String mensaje;
+  const _Vacio({required this.mensaje});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final muted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.medication_outlined, size: 44, color: muted),
+        const SizedBox(height: 10),
+        Text(
+          mensaje,
+          style: TextStyle(color: muted, fontSize: 14),
+        ),
+      ],
     );
   }
 }
@@ -53,59 +174,366 @@ class _RecetaCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(14),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.receipt_long,
-                    color: AppTheme.primaryColor, size: 18),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text('Receta ${receta.id}',
-                      style:
-                          const TextStyle(fontWeight: FontWeight.w600)),
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+    final textSubtle = isDark ? AppTheme.textSubtleDark : AppTheme.textSubtle;
+    final divider = isDark ? AppTheme.borderDark : AppTheme.borderSoft;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _ChipFecha(fecha: receta.fechaEmision),
+              if ((receta.doctorNombre ?? '').isNotEmpty)
+                Flexible(
+                  child: Text(
+                    receta.doctorNombre!,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: textMuted,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
                 ),
-                Text(receta.fechaFormateada,
-                    style: const TextStyle(
-                        color: AppTheme.gray600, fontSize: 12)),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Divider(height: 1, color: divider),
+          const SizedBox(height: 12),
+          if (receta.medicamentos.isNotEmpty)
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final m in receta.medicamentos)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: _MedRow(med: m, textMain: textMain, textMuted: textMuted),
+                  ),
               ],
             ),
-            if (receta.indicaciones.isNotEmpty) ...[
-              const SizedBox(height: 8),
-              InfoRow(label: 'Indicaciones', value: receta.indicaciones),
-            ],
-            if (receta.medicamentos.isNotEmpty) ...[
-              const Divider(height: 16),
-              const Text('Medicamentos:',
+          if (receta.indicaciones.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              receta.indicaciones,
+              style: TextStyle(
+                fontSize: 12,
+                color: textSubtle,
+                fontStyle: FontStyle.italic,
+                height: 1.4,
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Divider(height: 1, color: divider),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton(
+              onPressed: () => _mostrarDetalle(context, receta),
+              style: TextButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                minimumSize: const Size(0, 28),
+              ),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Ver detalle completo',
+                    style:
+                        TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                  ),
+                  SizedBox(width: 4),
+                  Icon(Icons.chevron_right, size: 16),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _mostrarDetalle(BuildContext context, Receta receta) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _DetalleSheet(receta: receta),
+    );
+  }
+}
+
+class _ChipFecha extends StatelessWidget {
+  final String fecha;
+  const _ChipFecha({required this.fecha});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final fill = isDark
+        ? Colors.white.withValues(alpha: 0.08)
+        : const Color(0xFFF3F4F6);
+    final color = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: fill,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        _formatear(fecha),
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: color,
+          letterSpacing: 0.3,
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
+      ),
+    );
+  }
+
+  String _formatear(String fechaIso) {
+    final partes = fechaIso.split('-');
+    if (partes.length != 3) return fechaIso;
+    try {
+      final fecha = DateTime(
+        int.parse(partes[0]),
+        int.parse(partes[1]),
+        int.parse(partes[2]),
+      );
+      final texto = DateFormat('d MMM y', 'es_MX').format(fecha).toUpperCase();
+      return texto.replaceAll('.', '');
+    } catch (_) {
+      return fechaIso;
+    }
+  }
+}
+
+class _MedRow extends StatelessWidget {
+  final Medicamento med;
+  final Color textMain;
+  final Color textMuted;
+  const _MedRow({
+    required this.med,
+    required this.textMain,
+    required this.textMuted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final extras = <String>[];
+    if (med.dosis.isNotEmpty) extras.add(med.dosis);
+    if (med.frecuencia.isNotEmpty) extras.add(med.frecuencia);
+    final dosisTexto = extras.join(' · ');
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: Icon(Icons.medication_outlined,
+              size: 16, color: textMuted),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: med.nombre,
                   style: TextStyle(
-                      fontWeight: FontWeight.w600, fontSize: 13)),
-              const SizedBox(height: 6),
-              ...receta.medicamentos.map((m) => Padding(
-                    padding: const EdgeInsets.only(bottom: 4),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Icon(Icons.medication_outlined,
-                            size: 14, color: AppTheme.primaryColor),
-                        const SizedBox(width: 6),
-                        Expanded(
-                          child: Text(
-                            '${m.nombre}'
-                            '${m.dosis.isNotEmpty ? ' - ${m.dosis}' : ''}'
-                            '${m.frecuencia.isNotEmpty ? '\n${m.frecuencia}' : ''}',
-                            style: const TextStyle(fontSize: 13),
-                          ),
-                        ),
-                      ],
+                    fontSize: 13.5,
+                    color: textMain,
+                    fontWeight: FontWeight.w500,
+                    height: 1.4,
+                  ),
+                ),
+                if (dosisTexto.isNotEmpty)
+                  TextSpan(
+                    text: ' — $dosisTexto',
+                    style: TextStyle(
+                      fontSize: 13.5,
+                      color: textMuted,
+                      height: 1.4,
                     ),
-                  )),
-            ],
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DetalleSheet extends StatelessWidget {
+  final Receta receta;
+  const _DetalleSheet({required this.receta});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark ? AppTheme.surfaceDark : AppTheme.surface;
+    final textMain = isDark ? AppTheme.textPrimaryDark : AppTheme.textPrimary;
+    final textMuted = isDark ? AppTheme.textMutedDark : AppTheme.textMuted;
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.4,
+      maxChildSize: 0.92,
+      expand: false,
+      builder: (_, scrollCtrl) => Container(
+        decoration: BoxDecoration(
+          color: surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
+        ),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 10),
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFD1D5DB),
+                  borderRadius: BorderRadius.circular(99),
+                ),
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                controller: scrollCtrl,
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+                children: [
+                  Text(
+                    'Receta #${receta.id}',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                      color: textMain,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Emitida el ${receta.fechaFormateada}'
+                    '${(receta.doctorNombre ?? '').isNotEmpty ? ' · ${receta.doctorNombre}' : ''}',
+                    style: TextStyle(fontSize: 13, color: textMuted),
+                  ),
+                  const SizedBox(height: 20),
+                  Text(
+                    'Medicamentos',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: textMuted,
+                      letterSpacing: 0.4,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  for (final m in receta.medicamentos) ...[
+                    _MedDetalle(med: m, textMain: textMain, textMuted: textMuted),
+                    const SizedBox(height: 8),
+                  ],
+                  if (receta.indicaciones.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      'Indicaciones',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: textMuted,
+                        letterSpacing: 0.4,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      receta.indicaciones,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: textMain,
+                        height: 1.5,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _MedDetalle extends StatelessWidget {
+  final Medicamento med;
+  final Color textMain;
+  final Color textMuted;
+  const _MedDetalle({
+    required this.med,
+    required this.textMain,
+    required this.textMuted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppTheme.primarySurface,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            med.nombre,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: textMain,
+            ),
+          ),
+          if (med.dosis.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text('Dosis: ${med.dosis}',
+                  style: TextStyle(fontSize: 13, color: textMuted)),
+            ),
+          if (med.frecuencia.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text('Frecuencia: ${med.frecuencia}',
+                  style: TextStyle(fontSize: 13, color: textMuted)),
+            ),
+          if (med.duracion.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text('Duración: ${med.duracion}',
+                  style: TextStyle(fontSize: 13, color: textMuted)),
+            ),
+        ],
       ),
     );
   }

--- a/mobile/lib/screens/student/student_home_screen.dart
+++ b/mobile/lib/screens/student/student_home_screen.dart
@@ -37,7 +37,11 @@ class _StudentHomeScreenState extends State<StudentHomeScreen> {
   @override
   Widget build(BuildContext context) {
     final tabs = [
-      InicioTab(onNuevaCita: () => setState(() => _tabIndex = 1)),
+      InicioTab(
+        onNuevaCita: () => setState(() => _tabIndex = 1),
+        onIrRecetas: () => setState(() => _tabIndex = 2),
+        onIrPerfil: () => setState(() => _tabIndex = 3),
+      ),
       const CitasTab(),
       const RecetasTab(),
       const PerfilTab(),


### PR DESCRIPTION
## Resumen

Bloque 3 de Fase 5 — rediseño visual completo de las 7 pantallas del alumno alineadas a `mobile/design-reference/*.html` (light) y `mobile/design-reference-dark/*.html` usando los tokens nuevos del Bloque 2.

## Pantallas rediseñadas

| # | Pantalla | Cambios principales |
|---|----------|--------------------|
| 3.1 | Login | Zona verde 35% con logo \"Y\", zona blanca 65% con form. Eye toggle, link \"¿Olvidaste tu NIP?\". |
| 3.2 | Inicio | Card próxima cita con badge CONFIRMADA + hora destacada + botón cancelar. Mini stats. Grid 2×2 acceso rápido. |
| 3.3 | Mis Citas | 3 tabs (Próximas + badge / Pasadas / Canceladas). Cards con badge de estatus, hora destacada y diagnóstico cuando aplica. |
| 3.4 | Agendar Cita | Calendario mensual con disponibilidad real del backend (`/citas/disponibilidad`), grid de slots 3 col, bottom sheet de confirmación. |
| 3.5 | Pre-evaluación IA | Avatares IA con `iaColor`, burbujas estilo asistente, header con subtítulo \"No reemplaza una consulta médica\". Card de resultados con barras por diagnóstico. |
| 3.6 | Mis Recetas | Buscador filtra por med/doctor/indicaciones. Cards con chip de fecha + doctor, lista de meds y bottom sheet de detalle completo. |
| 3.7 | Perfil | Header verde con avatar + nombre + control · carrera + badge \"Activo\". Cards por sección. Foto editable con cámara/galería. |

## Notas técnicas

- Todos los archivos compilan con `flutter analyze` → **0 issues**.
- Soporte dark mode en cada pantalla usando los tokens nuevos.
- `nueva_cita_form.dart` pasó de stub a pantalla completa con lógica de disponibilidad portada del Angular.
- `intl: ^0.20.2` (ya estaba en `pubspec.yaml`) usado para `DateFormat` con locale `es_MX`.
- Mantengo 4 tabs en bottom nav (Inicio · Citas · Recetas · Perfil) — IA accesible desde grid de acceso rápido y card de próxima cita.

## Test plan

- [ ] `flutter analyze` ok
- [ ] Login: ingresa con 22690495 / NIP
- [ ] Inicio: próxima cita visible, mini stats actualizadas, grid navega
- [ ] Mis Citas: 3 tabs cambian, badge en Próximas, cancelar funciona
- [ ] Agendar: calendario navega meses, slots cargan, confirm crea cita
- [ ] IA: chat funciona, resultado muestra barras de diagnóstico
- [ ] Recetas: buscador filtra, detalle abre bottom sheet
- [ ] Perfil: carga datos, cambia foto (cámara/galería), edita info médica, cambia password
- [ ] Dark mode: probar cada pantalla