### PR TITLE
fix(mobile): Bloque 4 — logging y hardening Fase 5

### DIFF
--- a/mobile/lib/services/pre_evaluacion_service.dart
+++ b/mobile/lib/services/pre_evaluacion_service.dart
@@ -82,7 +82,8 @@ class PreEvaluacionService extends ChangeNotifier {
         if (map['cita_id'] == citaId) return map;
       }
       return null;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('Error buscando pre-evaluación de cita $citaId: $e');
       return null;
     }
   }


### PR DESCRIPTION
## Resumen

Bloque 4 de Fase 5 — endurecimiento del cliente mobile. Resulta mínimo porque la mayoría de los pendientes históricos del CLAUDE.md ya estaban resueltos en código:

- ✅ `Receta` ya está tipada con clase Dart (no `Map<String, dynamic>`)
- ✅ Estatus `'no_asistio'` ya manejado en `Cita.estatusTexto`
- ✅ Offline cache ya tiene TTL 24h (`OfflineCacheService._ttlHours`)
- ✅ `PreEvaluacionService.cargarHistorial()` ya tiene `debugPrint`

Único catch silencioso real pendiente: `buscarPreEvaluacionDeCita` — agregado log.

## Cambios

- `lib/services/pre_evaluacion_service.dart`: `catch (_)` → `catch (e) { debugPrint(...) }` en `buscarPreEvaluacionDeCita`.

`mobile/CLAUDE.md` también actualizado localmente (estructura real + bugs activos) pero está en `.gitignore`, no se commitea.

## Test plan

- [x] `flutter analyze` → 0 issues
- [ ] Abrir pre-evaluación de una cita inexistente — debe loggear sin crashear