### PR TITLE
chore: actualizar dominio Vercel a yoltec.vercel.app

### DIFF
--- a/IA/app.py
+++ b/IA/app.py
@@ -45,6 +45,7 @@ app.add_middleware(
         "http://127.0.0.1:4200",
         "http://localhost:8000",
         "http://127.0.0.1:8000",
+        "https://yoltec.vercel.app",
         "https://frontend-nu-weld-77.vercel.app",
         "https://yoltec-backend.onrender.com",
     ],

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Cada subcarpeta tiene su propio `CLAUDE.md` (gitignored) con convenciones intern
 
 | Servicio | Plataforma | URL |
 |----------|------------|-----|
-| Frontend | Vercel | https://frontend-nu-weld-77.vercel.app |
+| Frontend | Vercel | https://yoltec.vercel.app |
 | Backend | Render | https://yoltec-backend.onrender.com |
 | IA | Render | https://yoltec-ia.onrender.com |
 | BD | Neon | privada |

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -6,6 +6,7 @@ return [
     'allowed_origins' => [
         'http://localhost:4200',
         'http://127.0.0.1:4200',
+        'https://yoltec.vercel.app',
         'https://frontend-nu-weld-77.vercel.app',
     ],
     'allowed_origins_patterns' => [],


### PR DESCRIPTION
## Resumen
- Renombrar dominio de produccion: `frontend-nu-weld-77.vercel.app` -> `yoltec.vercel.app`
- CORS backend (Laravel) y CORS IA (FastAPI): agregar dominio nuevo, mantener viejo durante transicion
- README: actualizar tabla de despliegue

## Cambios manuales fuera del repo (hacer despues del merge)
- [ ] Renombrar proyecto en dashboard de Vercel: Settings -> General -> Project Name -> `yoltec`
- [ ] Actualizar variable `FRONTEND_URL` en Render (backend) a `https://yoltec.vercel.app`
- [ ] Cuando el dominio viejo deje de redirigir (Vercel mantiene alias ~unos dias), quitar `frontend-nu-weld-77.vercel.app` de `backend/config/cors.php` e `IA/app.py`

## Test plan
- [ ] Despues del rename en Vercel, abrir `https://yoltec.vercel.app` y verificar login alumno
- [ ] Verificar peticion `/api/login` desde frontend nuevo (CORS debe pasar)
- [ ] Verificar peticion al microservicio IA (CORS debe pasar)