### PR TITLE
feat: responsive movil rol Doctor

### DIFF
--- a/frontend/src/app/components/doctor/components-doctor/doctor-bitacoras/doctor-bitacoras.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-bitacoras/doctor-bitacoras.component.css
@@ -494,3 +494,11 @@
   .kpis { grid-template-columns: 1fr 1fr; }
   .drawer { width: 100vw; }
 }
+
+@media (max-width: 480px) {
+  .kpis { grid-template-columns: 1fr; gap: 10px; }
+  .bita-search { min-width: unset; width: 100%; }
+  .filtros-bar { flex-wrap: wrap; }
+  .bita-row { padding: 10px 12px; }
+  .header-actions { flex-wrap: wrap; gap: 8px; }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.css
@@ -1456,3 +1456,13 @@
   .citas-search-bar { flex-direction: column; align-items: stretch; }
   .filtros-inline { flex-wrap: wrap; }
 }
+
+@media (max-width: 480px) {
+  .kpis { grid-template-columns: 1fr; gap: 10px; }
+  .kpi-card { padding: 14px; }
+  .citas-actions-bar { flex-wrap: wrap; gap: 8px; }
+  .week-grid-table { font-size: 12px; }
+  .cita-row { padding: 10px 12px; gap: 8px; }
+  .badge-prioridad { font-size: 10px; padding: 2px 6px; }
+  .proxima-hero { padding: 14px; }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-estadisticas/doctor-estadisticas.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-estadisticas/doctor-estadisticas.component.css
@@ -239,3 +239,12 @@
   .skeleton-charts { grid-template-columns: 1fr; }
   .rank-bar-wrap { width: 90px; }
 }
+
+@media (max-width: 480px) {
+  .kpis         { grid-template-columns: 1fr; gap: 10px; }
+  .skeleton-kpis { grid-template-columns: 1fr; }
+  .chart-card   { padding: 14px; }
+  .chart-card h3 { font-size: 14px; }
+  .rank-bar-wrap { width: 60px; }
+  .skeleton-chart { height: 220px; }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-ficha-paciente/doctor-ficha-paciente.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-ficha-paciente/doctor-ficha-paciente.component.css
@@ -337,3 +337,9 @@
     grid-column: span 1;
   }
 }
+
+@media (max-width: 480px) {
+  .ficha-header { flex-wrap: wrap; gap: 12px; }
+  .ficha-header h2 { font-size: 18px; }
+  .info-card { padding: var(--yol-s-4); }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-header/doctor-header.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-header/doctor-header.component.css
@@ -125,10 +125,43 @@ nav a.active {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   margin-left: 220px;
   position: sticky;
   top: 0;
   z-index: 50;
+}
+.topbar-title { min-width: 0; flex: 1; }
+
+/* Hamburguesa (solo móvil pequeño) */
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+  color: var(--yol-text);
+  border-radius: var(--yol-r);
+  align-items: center;
+  justify-content: center;
+  transition: background var(--yol-duration-fast) var(--yol-ease);
+}
+.hamburger:hover { background: var(--yol-bg); }
+.hamburger svg { width: 22px; height: 22px; }
+
+/* Backdrop sidebar móvil */
+.sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, .45);
+  z-index: 199;
+  opacity: 0;
+  transition: opacity .2s;
+}
+.sidebar-backdrop.show {
+  display: block;
+  opacity: 1;
 }
 .crumb {
   font-size: 12px;
@@ -338,8 +371,12 @@ nav a.active {
   background: var(--yol-text-subtle);
 }
 
+/* Dark mode adicional */
+:host-context(.dark) .hamburger { color: var(--yol-text); }
+:host-context(.dark) .hamburger:hover { background: #1a2e1a; }
+
 /* ===== RESPONSIVE ===== */
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .sidebar {
     width: 60px;
   }
@@ -369,10 +406,72 @@ nav a.active {
   }
   .topbar {
     margin-left: 60px;
+    padding: 12px 20px;
   }
   .topbar-search {
     display: none;
   }
+  .user-trigger-name {
+    display: none;
+  }
+}
+
+/* En móvil pequeño: drawer con hamburguesa */
+@media (max-width: 600px) {
+  .hamburger {
+    display: inline-flex;
+  }
+  .sidebar {
+    width: 240px;
+    transform: translateX(-100%);
+    transition: transform .25s ease;
+    z-index: 250;
+    box-shadow: 4px 0 24px rgba(0, 0, 0, .25);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  /* En modo drawer, mostrar textos completos */
+  .sidebar .brand span,
+  .sidebar nav a,
+  .sidebar .sidebar-user b,
+  .sidebar .sidebar-user span,
+  .sidebar .sidebar-user div:last-child {
+    display: revert;
+  }
+  .sidebar .brand {
+    justify-content: flex-start;
+    padding: 18px 20px;
+  }
+  .sidebar nav a {
+    justify-content: flex-start;
+    padding: 10px 20px;
+    border-left: 3px solid transparent;
+    border-bottom: none;
+  }
+  .sidebar nav a.active {
+    border-left-color: var(--yol-accent);
+    border-bottom: none;
+  }
+  .sidebar .sidebar-user {
+    justify-content: flex-start;
+  }
+  .topbar {
+    margin-left: 0;
+    padding: 12px 14px;
+    gap: 10px;
+  }
+  .topbar h1 {
+    font-size: 17px;
+  }
+  .crumb { font-size: 11px; }
+  .btn-action {
+    padding: 7px 10px;
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 380px) {
   .btn-action {
     display: none;
   }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-header/doctor-header.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-header/doctor-header.component.html
@@ -1,31 +1,33 @@
-<aside class="sidebar">
+<div class="sidebar-backdrop" [class.show]="sidebarOpen" (click)="closeSidebar()"></div>
+
+<aside class="sidebar" [class.open]="sidebarOpen">
   <div class="brand">
     <div class="brand-mark">Y</div>
     <span>Yoltec</span>
   </div>
   <nav>
-    <a [class.active]="activeSection === 'inicio'" (click)="sectionChange.emit('inicio')">
+    <a [class.active]="activeSection === 'inicio'" (click)="onNavigate('inicio')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Panel
     </a>
-    <a [class.active]="activeSection === 'citas'" (click)="sectionChange.emit('citas')">
+    <a [class.active]="activeSection === 'citas'" (click)="onNavigate('citas')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>Citas
     </a>
-    <a [class.active]="activeSection === 'bitacoras'" (click)="sectionChange.emit('bitacoras')">
+    <a [class.active]="activeSection === 'bitacoras'" (click)="onNavigate('bitacoras')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="9" y1="13" x2="15" y2="13"/><line x1="9" y1="17" x2="15" y2="17"/></svg>Bitácoras
     </a>
-    <a [class.active]="activeSection === 'recetas'" (click)="sectionChange.emit('recetas')">
+    <a [class.active]="activeSection === 'recetas'" (click)="onNavigate('recetas')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="14" height="18" rx="2"/><line x1="7" y1="8" x2="13" y2="8"/><line x1="7" y1="12" x2="13" y2="12"/><path d="M17 14l4 4M21 14l-4 4"/></svg>Recetas
     </a>
-    <a [class.active]="activeSection === 'pre-evaluaciones'" (click)="sectionChange.emit('pre-evaluaciones')">
+    <a [class.active]="activeSection === 'pre-evaluaciones'" (click)="onNavigate('pre-evaluaciones')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="4" width="14" height="17" rx="2"/><path d="M9 4h6v3H9z"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="13" y2="16"/></svg>Pre-evaluaciones
       @if (totalPendientes > 0) {
         <span class="badge">{{ totalPendientes }}</span>
       }
     </a>
-    <a [class.active]="activeSection === 'ia-prioridad'" (click)="sectionChange.emit('ia-prioridad')">
+    <a [class.active]="activeSection === 'ia-prioridad'" (click)="onNavigate('ia-prioridad')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.5 6.5L21 11l-5.5 4 1.5 7-5-3.5L7 22l1.5-7L3 11l6.5-2.5z"/></svg>Prioridad IA
     </a>
-    <a [class.active]="activeSection === 'estadisticas'" (click)="sectionChange.emit('estadisticas')">
+    <a [class.active]="activeSection === 'estadisticas'" (click)="onNavigate('estadisticas')">
       <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="20" x2="21" y2="20"/><rect x="6" y="10" width="3" height="10"/><rect x="11" y="6" width="3" height="14"/><rect x="16" y="13" width="3" height="7"/></svg>Estadísticas
     </a>
   </nav>
@@ -39,7 +41,10 @@
 </aside>
 
 <div class="topbar">
-  <div>
+  <button class="hamburger" (click)="toggleSidebar()" aria-label="Abrir menú">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+  </button>
+  <div class="topbar-title">
     <div class="crumb">{{ sectionCrumb }}</div>
     <h1>{{ sectionTitle }}</h1>
   </div>
@@ -48,7 +53,7 @@
       <button class="btn-action secondary" (click)="exportEvent.emit()">Exportar</button>
     }
     @if (primaryAction) {
-      <button class="btn-action primary" (click)="sectionChange.emit('citas')">{{ primaryAction }}</button>
+      <button class="btn-action primary" (click)="onNavigate('citas')">{{ primaryAction }}</button>
     }
     <div class="user-menu-wrap">
       <button class="user-trigger" (click)="toggleUserMenu()">

--- a/frontend/src/app/components/doctor/components-doctor/doctor-header/doctor-header.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-header/doctor-header.component.ts
@@ -18,10 +18,20 @@ export class DoctorHeaderComponent {
   @Output() exportEvent = new EventEmitter<void>();
 
   userMenuOpen = false;
+  sidebarOpen = false;
 
   constructor(public themeService: ThemeService) {}
 
   toggleUserMenu(): void { this.userMenuOpen = !this.userMenuOpen; }
+
+  toggleSidebar(): void { this.sidebarOpen = !this.sidebarOpen; }
+
+  closeSidebar(): void { this.sidebarOpen = false; }
+
+  onNavigate(section: string): void {
+    this.sectionChange.emit(section);
+    this.sidebarOpen = false;
+  }
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(e: MouseEvent): void {

--- a/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-ia-prioridad/doctor-ia-prioridad.component.css
@@ -321,3 +321,9 @@
   .prioridad-badge   { min-width: 100px; padding: var(--yol-s-4) var(--yol-s-3); }
   .cita-prioridad-header { flex-direction: column; align-items: flex-start; }
 }
+
+@media (max-width: 480px) {
+  .prioridad-resumen { flex-wrap: wrap; }
+  .prioridad-badge   { flex: 1; min-width: 0; }
+  .detalle-factores ul { padding-left: 16px; }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-inicio/doctor-inicio.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-inicio/doctor-inicio.component.css
@@ -276,3 +276,10 @@ tr:hover td {
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 480px) {
+  .kpis { gap: 10px; }
+  .kpi, .card { padding: 14px; }
+  .kpi-v { font-size: 24px; }
+  .card-head h2 { font-size: 15px; }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
@@ -480,3 +480,11 @@
   .filters { flex-direction: column; align-items: stretch; }
   .ffld input, .ffld select { min-width: 0; width: 100%; }
 }
+
+@media (max-width: 480px) {
+  .pe-header, .pe-content { padding-left: 14px; padding-right: 14px; }
+  .pe-header h2 { font-size: 18px; }
+  .pc-card { padding: 14px; }
+  .pc-actions { flex-wrap: wrap; }
+  .pc-actions button { width: 100%; }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-recetas/doctor-recetas.component.css
@@ -536,3 +536,10 @@
 
   .drawer { width: 100vw; }
 }
+
+@media (max-width: 480px) {
+  .rx-search { width: 100%; }
+  .filtros-bar { flex-wrap: wrap; gap: 8px; }
+  .header-actions { flex-wrap: wrap; }
+  .rx-row { padding: 10px 12px; }
+}

--- a/frontend/src/app/components/doctor/doctor-dashboard/doctor-dashboard.component.css
+++ b/frontend/src/app/components/doctor/doctor-dashboard/doctor-dashboard.component.css
@@ -26,9 +26,16 @@
   width: 100%;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .main-content {
     margin-left: 60px;
     padding: 16px;
+  }
+}
+
+@media (max-width: 600px) {
+  .main-content {
+    margin-left: 0;
+    padding: 14px;
   }
 }

--- a/frontend/src/app/components/doctor/nueva-cita/nueva-cita-doctor.component.css
+++ b/frontend/src/app/components/doctor/nueva-cita/nueva-cita-doctor.component.css
@@ -415,3 +415,26 @@
 .nc-btn.outline:hover {
   background: var(--yol-primary-50);
 }
+
+/* ── Responsive ──────────────────────────────────── */
+@media (max-width: 768px) {
+  .nc-wrap { padding: 16px; }
+  .nc-header h2 { font-size: 20px; }
+  .nc-steps { gap: 8px; }
+  .nc-step { font-size: 12px; }
+  .nc-step-sep { display: none; }
+  .nc-body { padding: 16px; }
+  .nc-search-row { flex-direction: column; gap: 10px; }
+}
+
+@media (max-width: 480px) {
+  .nc-wrap { padding: 12px; }
+  .nc-header h2 { font-size: 17px; }
+  .nc-sub { font-size: 12px; }
+  .nc-step-n { width: 24px; height: 24px; font-size: 12px; }
+  .nc-body { padding: 12px; }
+  .nc-search-field input { font-size: 16px; }
+  .nc-student { padding: 10px 12px; gap: 10px; }
+  .nc-av { width: 36px; height: 36px; font-size: 13px; }
+  .nc-btn { width: 100%; }
+}


### PR DESCRIPTION
## Resumen
- Adapta todas las vistas del rol Doctor a navegacion movil
- Cambio mas critico: el sidebar del doctor antes solo se reducia a 60px icon-only en 768px - ahora en 600px se convierte en drawer con hamburguesa
- Build verificado: `npx ng build --configuration=development` OK (4.8s, sin errores)

## Breakpoints aplicados
- **≤900px**: sidebar icon-only (60px), oculta user-trigger-name
- **≤600px**: hamburguesa + drawer con backdrop, sidebar 240px con textos completos
- **≤480px**: KPIs 1 columna, paddings/fonts compactos en todos los sub-componentes
- **≤380px**: oculta btn-action (Nueva cita) del topbar

## Archivos modificados (13)
- doctor-dashboard (CSS): coordinacion margin-left con nuevos breakpoints
- doctor-header (TS+HTML+CSS): hamburguesa + drawer + nuevo metodo `onNavigate` que cierra drawer al cambiar seccion
- 8 sub-componentes (CSS): inicio, citas, bitacoras, recetas, pre-evaluaciones, ia-prioridad, estadisticas, ficha-paciente
- nueva-cita-doctor (CSS): responsive desde cero (no tenia media queries)

## Test plan
- [ ] DevTools modo iPhone SE (375x667) y Pixel 5 (393x851):
  - [ ] Doctor-dashboard: hamburguesa visible solo en ≤600px, drawer abre con textos completos, backdrop cierra
  - [ ] Cambio de seccion (Panel, Citas, Bitacoras, etc.) cierra el drawer automaticamente
  - [ ] Topbar h1 legible, crumb visible
  - [ ] Inicio (Panel): KPIs 1col, citas del dia legibles
  - [ ] Citas: kpis apiladas, drawer 100vw al abrir cita
  - [ ] Bitacoras: filtros apilan, drawer abre detalle
  - [ ] Estadisticas: graficas 1col, no se desbordan
  - [ ] Ficha-paciente: secciones legibles
  - [ ] Nueva-cita (`/doctor/nueva-cita`): wizard usable, busqueda alumno funciona, botones full-width
- [ ] Dark mode en hamburguesa y drawer

## Notas
- 13 archivos modificados, +217 / -12 lineas
- 2FA del doctor solo en produccion (no afecta este PR)
- Pendiente: rol Admin (PR-C)