### PR TITLE
feat: responsive movil rol Admin

### DIFF
--- a/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.css
+++ b/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.css
@@ -992,6 +992,22 @@
   .search-input { width: 100%; }
   .users-toolbar { flex-direction: column; align-items: stretch; }
   .toolbar-actions { flex-wrap: wrap; }
+  .admin-topbar { padding: 14px 20px; }
+  .admin-title { font-size: 18px; }
+}
+
+@media (max-width: 600px) {
+  /* Espacio para hamburguesa fija */
+  .admin-topbar { padding-left: 60px; }
+  .stats-grid { grid-template-columns: 1fr; }
+  .admin-main { padding: 14px; }
+  .admin-user-name { display: none; }
+}
+
+@media (max-width: 480px) {
+  .admin-topbar { padding: 14px 12px 14px 56px; }
+  .admin-title { font-size: 16px; }
+  .admin-crumb { font-size: 11px; }
 }
 
 /* Dark mode: calendario de días especiales */

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.css
@@ -429,3 +429,27 @@ tr:last-child td { border-bottom: 0; }
   margin-top: 6px;
 }
 
+/* ── Responsive ──────────────────────────────────── */
+@media (max-width: 900px) {
+  .main { padding: 24px 20px 40px; }
+  .cols { grid-template-columns: 1fr; }
+  .page-head { flex-direction: column; align-items: stretch; gap: 12px; }
+  .btn-primary { width: 100%; justify-content: center; }
+}
+
+@media (max-width: 600px) {
+  .main { padding: 20px 16px 40px 16px; }
+  .page-head h1 { padding-left: 56px; min-height: 36px; display: flex; align-items: center; font-size: 20px; }
+  .subtitle { padding-left: 0; }
+  .card-body { padding: 14px; }
+  .cal-grid { gap: 4px; }
+  .month-label { font-size: 14px; }
+  .modal-actions { flex-direction: column-reverse; }
+  .modal-actions button { width: 100%; }
+}
+
+@media (max-width: 480px) {
+  .main { padding: 16px 12px 32px; }
+  .page-head h1 { font-size: 18px; }
+}
+

--- a/frontend/src/app/components/admin/shared/admin-sidebar.component.css
+++ b/frontend/src/app/components/admin/shared/admin-sidebar.component.css
@@ -136,3 +136,66 @@ nav {
   font-family: var(--yol-font);
 }
 
+/* ── Hamburguesa (solo móvil) ─────────────────────── */
+.admin-hamburger {
+  display: none;
+  position: fixed;
+  top: 14px;
+  left: 14px;
+  z-index: 240;
+  background: var(--yol-surface);
+  border: 1px solid var(--yol-border);
+  border-radius: var(--yol-r);
+  padding: 8px;
+  cursor: pointer;
+  color: var(--yol-text);
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--yol-shadow-sm);
+  transition: background .15s;
+}
+.admin-hamburger:hover { background: var(--yol-bg); }
+.admin-hamburger svg { width: 22px; height: 22px; }
+
+/* ── Backdrop ─────────────────────────────────────── */
+.admin-sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, .45);
+  z-index: 199;
+  opacity: 0;
+  transition: opacity .2s;
+}
+.admin-sidebar-backdrop.show {
+  display: block;
+  opacity: 1;
+}
+
+/* ── Responsive: drawer ───────────────────────────── */
+@media (max-width: 768px) {
+  .sidebar { width: 200px; }
+}
+
+@media (max-width: 600px) {
+  .admin-hamburger { display: inline-flex; }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 240px;
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform .25s ease;
+    z-index: 250;
+    box-shadow: 4px 0 24px rgba(0, 0, 0, .25);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+}
+
+:host-context(.dark) .admin-hamburger { color: var(--yol-text); border-color: #2a4030; }
+:host-context(.dark) .admin-hamburger:hover { background: #1a2e1a; }
+

--- a/frontend/src/app/components/admin/shared/admin-sidebar.component.html
+++ b/frontend/src/app/components/admin/shared/admin-sidebar.component.html
@@ -1,11 +1,17 @@
-<aside class="sidebar">
+<button class="admin-hamburger" (click)="toggle()" aria-label="Abrir menú">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+</button>
+
+<div class="admin-sidebar-backdrop" [class.show]="isOpen" (click)="close()"></div>
+
+<aside class="sidebar" [class.open]="isOpen">
   <div class="brand">
     <div class="brand-icon">Y</div>
     Yoltec
   </div>
 
   <nav>
-    <a class="nav-item" [class.active]="activeSection === 'panel'" (click)="sectionChange.emit('panel')">
+    <a class="nav-item" [class.active]="activeSection === 'panel'" (click)="onNavigate('panel')">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
         <rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/>
         <rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/>
@@ -13,7 +19,7 @@
       Panel
     </a>
 
-    <a class="nav-item" [class.active]="activeSection === 'usuarios'" (click)="sectionChange.emit('usuarios')">
+    <a class="nav-item" [class.active]="activeSection === 'usuarios'" (click)="onNavigate('usuarios')">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="9" cy="8" r="3.5"/><path d="M2.5 20c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6"/>
         <circle cx="17" cy="8" r="3"/><path d="M16 14c2.7.2 5 2.5 5 5.5"/>
@@ -21,7 +27,7 @@
       Usuarios
     </a>
 
-    <a class="nav-item" [class.active]="activeSection === 'calendario'" (click)="sectionChange.emit('calendario')">
+    <a class="nav-item" [class.active]="activeSection === 'calendario'" (click)="onNavigate('calendario')">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
         <rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/>
         <circle cx="12" cy="15" r="1.5" fill="currentColor"/>

--- a/frontend/src/app/components/admin/shared/admin-sidebar.component.ts
+++ b/frontend/src/app/components/admin/shared/admin-sidebar.component.ts
@@ -12,6 +12,16 @@ export class AdminSidebarComponent {
   @Input() adminName = 'Administrador';
   @Output() sectionChange = new EventEmitter<string>();
 
+  isOpen = false;
+
+  toggle(): void { this.isOpen = !this.isOpen; }
+  close(): void { this.isOpen = false; }
+
+  onNavigate(section: string): void {
+    this.sectionChange.emit(section);
+    this.isOpen = false;
+  }
+
   get initials(): string {
     return this.adminName.split(' ').slice(0, 2).map(p => p[0]).join('').toUpperCase();
   }

--- a/frontend/src/app/components/admin/usuarios/usuarios.component.css
+++ b/frontend/src/app/components/admin/usuarios/usuarios.component.css
@@ -450,3 +450,31 @@ input[type=checkbox]:checked::after {
 
 .btn-pri-sm:hover:not(:disabled) { filter: brightness(0.9); }
 .btn-pri-sm:disabled { opacity: 0.6; cursor: default; }
+
+/* ── Responsive ──────────────────────────────────── */
+@media (max-width: 900px) {
+  .admin-main { padding: 24px 20px 40px; }
+  .toolbar { flex-direction: column; align-items: stretch; }
+  .search-box { max-width: 100%; }
+  .table-section { overflow-x: auto; }
+  table { min-width: 640px; }
+}
+
+@media (max-width: 600px) {
+  .admin-main { padding: 20px 16px 40px 16px; }
+  .page-head h1 { font-size: 20px; padding-left: 56px; min-height: 36px; display: flex; align-items: center; }
+  .tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .tabs::-webkit-scrollbar { display: none; }
+  .tab { white-space: nowrap; flex-shrink: 0; }
+  .btn-pri { width: 100%; justify-content: center; padding: 10px 14px; }
+}
+
+@media (max-width: 480px) {
+  .admin-main { padding: 16px 12px 32px; }
+  .page-head h1 { font-size: 18px; }
+  .btn-pri, .btn-pri-sm, .btn-ghost, .btn-danger { width: 100%; }
+}


### PR DESCRIPTION
## Resumen
- Adapta las 3 vistas de Admin (panel, usuarios, dias-especiales) a navegacion movil
- Cambio mas critico: el sidebar admin antes ocupaba 220px fijos - ahora en 600px se convierte en drawer encapsulado en el componente compartido
- Build verificado: `npx ng build --configuration=development` OK (4.6s)

## Cambios principales

### admin-sidebar (componente shared)
- Estado interno `isOpen` con metodos toggle/close/onNavigate (cierra drawer al cambiar seccion)
- Hamburguesa fija top-left (visible solo ≤600px) + backdrop semi-transparente
- Sidebar como `position: fixed` con `transform: translateX(-100%)` cuando cerrado
- Reutilizado automaticamente por las 3 vistas que importan el componente

### admin-dashboard (Panel)
- 768px: padding compacto, title mas chico
- 600px: topbar padding-left para no chocar con hamburguesa, stats-grid 1col
- 480px: padding minimo, title 16px

### usuarios (CRUD)
- 900px: toolbar apilada, tabla con scroll horizontal (min-width 640px)
- 600px: tabs scrollables horizontal, h1 con padding-left para hamburguesa
- 480px: botones full-width

### dias-especiales (Calendario)
- 900px: cols 1fr (calendario y lista apiladas), btn-primary full-width
- 600px: calendario compacto, modal-actions apiladas
- 480px: paddings minimos

## Test plan
- [ ] DevTools modo iPhone SE (375x667):
  - [ ] Login admin (`/acceso-gestion`): card legible
  - [ ] Hamburguesa visible solo en ≤600px en las 3 vistas
  - [ ] Drawer abre con backdrop, cierra al click en backdrop o nav item
  - [ ] Panel: stats-grid 1col, topbar legible (no choca con hamburguesa)
  - [ ] Usuarios: tabla con scroll horizontal funciona, tabs scrollables, modal crear/editar usable
  - [ ] Dias-especiales: calendario y lista apiladas, modal agregar funciona
- [ ] Tablet (768px - 900px): sidebar visible 200-220px (no drawer)
- [ ] Dark mode en hamburguesa, backdrop y drawer

## Notas
- 6 archivos modificados, +151 / -4 lineas
- 2FA admin solo en produccion (no afecta este PR)
- Encapsulamiento: la hamburguesa vive dentro de admin-sidebar, no hay duplicacion en las 3 vistas padre

---

## Series completa de PRs responsive

| # | PR | Estado |
|---|---|---|
| #58 | Dominio Vercel yoltec.vercel.app | Pendiente |
| #59 | Responsive Alumno + Auth | Pendiente |
| #60 | Responsive Doctor | Pendiente |
| #61 (este) | Responsive Admin | Pendiente |