### PR TITLE
fix: detalles responsive movil en doctor (pre-evaluaciones e inicio)

### DIFF
--- a/frontend/src/app/components/doctor/components-doctor/doctor-inicio/doctor-inicio.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-inicio/doctor-inicio.component.css
@@ -84,6 +84,7 @@
 }
 .card-body {
   padding: 6px 0;
+  overflow-x: auto;
 }
 
 /* ---- Row layout ---- */
@@ -277,9 +278,22 @@ tr:hover td {
   }
 }
 
+/* En ≤600px ocultar la columna Motivo (la mas ancha) para evitar scroll horizontal de la pagina. El detalle queda accesible via boton "Abrir". */
+@media (max-width: 600px) {
+  table th:nth-child(3),
+  table td:nth-child(3) { display: none; }
+  th, td { padding: 10px 12px; font-size: 12px; }
+  .av-sm { width: 24px; height: 24px; font-size: 10px; margin-right: 6px; }
+  .badge { padding: 2px 7px; font-size: 10px; }
+  .btn-ghost-sm { padding: 4px 8px; font-size: 11px; }
+}
+
 @media (max-width: 480px) {
   .kpis { gap: 10px; }
   .kpi, .card { padding: 14px; }
   .kpi-v { font-size: 24px; }
   .card-head h2 { font-size: 15px; }
+  /* En pantallas muy chicas ocultar tambien Estatus para garantizar 0 scroll horizontal */
+  table th:nth-child(4),
+  table td:nth-child(4) { display: none; }
 }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css
@@ -481,6 +481,32 @@
   .ffld input, .ffld select { min-width: 0; width: 100%; }
 }
 
+/* En ≤600px el header de la card pasa a 2 filas: identidad (avatar+nombre+badge) y meta abajo. Evita que ID y "Enviada" se encimen con nombres largos. */
+@media (max-width: 600px) {
+  .pc-head {
+    flex-wrap: wrap;
+    padding: 14px 16px;
+    gap: 10px;
+  }
+  .who { flex: 1 1 auto; min-width: 0; }
+  .who b { font-size: 14px; line-height: 1.3; }
+  .badge { flex-shrink: 0; align-self: flex-start; }
+  .meta {
+    flex-basis: 100%;
+    text-align: left;
+    margin-top: 4px;
+    padding-top: 10px;
+    border-top: 1px solid var(--yol-border);
+    font-size: 11px;
+    line-height: 1.55;
+  }
+  .meta b {
+    display: inline;
+    font-size: 12px;
+    margin-right: 8px;
+  }
+}
+
 @media (max-width: 480px) {
   .pe-header, .pe-content { padding-left: 14px; padding-right: 14px; }
   .pe-header h2 { font-size: 18px; }


### PR DESCRIPTION
## Resumen

Dos fixes visuales detectados en QA mobile post-merge del responsive original (#59-#61):

1. **Pre-evaluaciones IA (doctor)** — el header de la card encimaba el nombre del paciente con la metadata (ID + "Enviada"/"Revisada") cuando el nombre era largo. En ≤600px ahora el header pasa a 2 filas: identidad arriba (avatar + nombre + badge) y metadata abajo con separador.

2. **Doctor — Citas del dia (inicio)** — la tabla de 5 columnas provocaba scroll horizontal de la pagina completa en moviles. Se agrega `overflow-x: auto` defensivo al `.card-body` y se ocultan columnas no criticas en mobile (Motivo en ≤600px, ademas Estatus en ≤480px). El detalle queda accesible via el boton "Abrir".

## Archivos modificados

- `frontend/src/app/components/doctor/components-doctor/doctor-pre-evaluaciones/doctor-pre-evaluaciones.component.css`
- `frontend/src/app/components/doctor/components-doctor/doctor-inicio/doctor-inicio.component.css`

## Test plan

- [ ] Validar en DevTools 375px (iPhone SE), 393px (iPhone 14) y 360px (Galaxy)
- [ ] Pre-evaluaciones IA con doctor: cards sin overlap de texto, lectura clara
- [ ] Inicio doctor: tabla "Citas del dia" sin scroll horizontal de pagina