### PR TITLE
feat(backend): hardening seguridad (auditoria 2026-05-25)

### DIFF
--- a/backend/app/Http/Controllers/IAPriorityController.php
+++ b/backend/app/Http/Controllers/IAPriorityController.php
@@ -7,6 +7,7 @@ use App\IA\Services\IAService;
 use App\Models\Cita;
 use App\Models\PreEvaluacionIA;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Controlador para la IA 1: Clasificador de Prioridad
@@ -109,7 +110,11 @@ class IAPriorityController extends Controller
                     'factores' => $resultado['factores'] ?? [],
                 ];
             } catch (\Exception $e) {
-                // Si falla la clasificación de una, continuar con las demás
+                // Loguear el fallo individual pero continuar con el resto del listado
+                Log::error('Fallo clasificacion IA en cita', [
+                    'cita_id' => $cita->id,
+                    'error'   => $e->getMessage(),
+                ]);
                 continue;
             }
         }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -43,6 +43,7 @@ class User extends Authenticatable
         'password' => 'hashed',
         'fecha_nacimiento' => 'date',
         'es_admin' => 'boolean',
+        'fcm_token' => 'encrypted',
     ];
 
     // Relaciones

--- a/backend/database/migrations/2026_05_25_000001_null_existing_fcm_tokens.php
+++ b/backend/database/migrations/2026_05_25_000001_null_existing_fcm_tokens.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    // Preludio a cifrar fcm_token con cast `encrypted` en User: los valores plain text
+    // existentes lanzarian DecryptException al leerse. Limpiamos a NULL; los dispositivos
+    // re-registran el token en el siguiente login y queda cifrado de origen.
+    public function up(): void
+    {
+        DB::table('users')
+            ->whereNotNull('fcm_token')
+            ->update(['fcm_token' => null]);
+    }
+
+    public function down(): void
+    {
+        // Irreversible — el token original ya no existe
+    }
+};


### PR DESCRIPTION
## Sesión A — Backend security (Fase 1 / auditoría 2026-05-25)

Insumo: [docs/plan-accion-auditoria-20260525.md](../blob/main/docs/plan-accion-auditoria-20260525.md). Tras reality-check del código, **5 de 8 items de la auditoría ya estaban aplicados** (falsos positivos, ver abajo). Este PR cubre los **2 críticos restantes**.

## Cambios

- **`backend/app/Models/User.php`** — cast `encrypted` en `fcm_token`. Antes se guardaba plain text en `users.fcm_token`, lo cual es PII (token Firebase puede usarse para enviar push notifications no autorizadas si la BD se filtra).
- **`backend/database/migrations/2026_05_25_000001_null_existing_fcm_tokens.php`** — limpia a `NULL` los tokens existentes. Es necesario porque con el cast `encrypted` activo, Eloquent intenta descifrar al leer y los valores plain text actuales lanzarían `DecryptException`. Los dispositivos re-registran su token en el siguiente login (la app mobile y el frontend ya envían `fcm_token` en login/perfil — ver `routes/api.php:44`).
- **`backend/app/Http/Controllers/IAPriorityController.php`** — `Log::error` en el catch del listado masivo de prioridad. Antes silenciaba todo error con `continue` (línea 111), perdiendo visibilidad cuando el servicio IA fallaba en producción.

## Falsos positivos descartados (ya aplicados en main)

| # Auditoría | Hallazgo | Estado real |
|---|---|---|
| A2 | foto perfil sin `image\|max:2048` | Ya está en `PerfilController.php:46` |
| A4 | race condition en reservar slot | `reservarSlot()` ya usa `DB::transaction` + `lockForUpdate()` (`CitaService.php:88-107`) |
| A6 | `updateOrCreate` en `ConsultaController::store` | Ya está (línea 32) |
| A7 | reprogramar acepta hora pasada | `validarHorario` ya valida `isToday()` + hora actual; `reprogramar()` agrega `after_or_equal:today` |
| A8 | código 2FA plain text en BD | `Auth2FAService::sendCode` ya hace `Hash::make($code)` (línea 26) y `verifyCode` usa `Hash::check` |

## Postergado a post-semestre

- A3 (`$hidden` para `tipo_sangre`, `alergias`, `enfermedades_cronicas`) — requiere auditar cada endpoint que sirve `User` y agregar `makeVisible` donde corresponda (perfil propio, doctor viendo paciente). Riesgo de romper visualización de datos médicos si se hace apresurado. Va en un PR enfocado más adelante.

## Test plan

- [x] `php -l` en los 3 archivos modificados — sin errores
- [ ] `php artisan migrate` en local → ejecutar migración, verificar que `users.fcm_token` queda NULL
- [ ] Login móvil → confirma re-registro de fcm_token y que `notifyAlumno` puede leerlo descifrado
- [ ] `GET /api/ia/priority/pendientes` con una cita inválida en el set → revisar log Laravel para confirmar que el error aparece
- [ ] Render: deploy hook corre `migrate`; verificar logs

## Fuera de scope (otras sesiones)

- Sesión B (frontend UX/2FA), Sesión C (mobile seguridad + `Cita.diagnostico`). Sesión D ya en PR #64.