### PR TITLE
feat(mobile): hardening + diagnostico real en citas pasadas (auditoria 2026-05-25)

### DIFF
--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -21,7 +21,10 @@ class CitaController extends Controller
 
         $citas = $user->esAlumno()
             ? Cita::where('alumno_id', $user->id)
-                ->with(['doctor:id,nombre,apellido,username'])
+                ->with([
+                    'doctor:id,nombre,apellido,username',
+                    'consulta:id,cita_id,diagnostico',
+                ])
                 ->orderBy('fecha_cita', 'desc')->orderBy('hora_cita', 'desc')->get()
             : Cita::with(['alumno:id,nombre,apellido,numero_control'])
                 ->orderBy('fecha_cita', 'desc')->orderBy('hora_cita', 'desc')->get();

--- a/mobile/lib/models/cita.dart
+++ b/mobile/lib/models/cita.dart
@@ -7,6 +7,8 @@ class Cita {
   final String estatus;
   final int? alumnoId;
   final Map<String, dynamic>? alumno;
+  // Diagnóstico extraído de la consulta asociada (solo en citas atendidas)
+  final String? diagnostico;
 
   const Cita({
     required this.id,
@@ -17,6 +19,7 @@ class Cita {
     required this.estatus,
     this.alumnoId,
     this.alumno,
+    this.diagnostico,
   });
 
   bool get isProgramada => estatus == 'programada';
@@ -64,6 +67,7 @@ class Cita {
   }
 
   factory Cita.fromJson(Map<String, dynamic> json) {
+    final consulta = json['consulta'] as Map<String, dynamic>?;
     return Cita(
       id: json['id'] as int,
       claveCita: json['clave_cita'] as String? ?? '',
@@ -73,6 +77,7 @@ class Cita {
       estatus: json['estatus'] as String? ?? 'programada',
       alumnoId: json['alumno_id'] as int?,
       alumno: json['alumno'] as Map<String, dynamic>?,
+      diagnostico: consulta?['diagnostico'] as String?,
     );
   }
 
@@ -86,6 +91,7 @@ class Cita {
       'estatus': estatus,
       'alumno_id': alumnoId,
       'alumno': alumno,
+      if (diagnostico != null) 'consulta': {'diagnostico': diagnostico},
     };
   }
 }

--- a/mobile/lib/screens/student/citas_tab.dart
+++ b/mobile/lib/screens/student/citas_tab.dart
@@ -394,7 +394,9 @@ class _CitaCard extends StatelessWidget {
                       ),
                     ),
                     TextSpan(
-                      text: 'Disponible en consulta',
+                      text: (cita.diagnostico?.trim().isNotEmpty ?? false)
+                          ? cita.diagnostico!
+                          : 'Pendiente de registrar',
                       style: TextStyle(
                         fontSize: 12.5,
                         color: textSubtle,

--- a/mobile/lib/screens/student/perfil_tab.dart
+++ b/mobile/lib/screens/student/perfil_tab.dart
@@ -119,12 +119,25 @@ class _PerfilTabState extends State<PerfilTab> {
       imageQuality: 80,
     );
     if (picked == null || !mounted) return;
+    final file = File(picked.path);
+    // Backend valida max:2048; cortamos antes para dar feedback amigable y no gastar red.
+    final sizeBytes = await file.length();
+    if (!mounted) return;
+    if (sizeBytes > 2 * 1024 * 1024) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('La foto supera 2 MB. Elige otra o reduce la calidad.'),
+          backgroundColor: AppTheme.error,
+        ),
+      );
+      return;
+    }
     try {
       final token =
           Provider.of<AuthService>(context, listen: false).token ?? '';
       final result = await ApiService.postMultipart(
         '/perfil/foto',
-        File(picked.path),
+        file,
         'foto',
         token: token,
       );

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1,11 +1,20 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:yoltec_mobile/models/user.dart';
 import 'package:yoltec_mobile/services/api_service.dart';
 import 'package:yoltec_mobile/services/notification_service.dart';
 
 class AuthService extends ChangeNotifier {
+  // Secure storage (Keychain iOS / EncryptedSharedPreferences Android) para el token.
+  // user_data se sigue guardando en SharedPreferences porque no es secreto.
+  static const _secureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+  static const _kTokenKey = 'auth_token';
+  static const _kUserKey = 'user_data';
+
   String? _token;
   User? _currentUser;
   bool _isLoading = false;
@@ -25,14 +34,13 @@ class AuthService extends ChangeNotifier {
 
     try {
       final prefs = await SharedPreferences.getInstance();
-      final userJson = prefs.getString('user_data');
-      final storedToken = prefs.getString('auth_token');
+      final userJson = prefs.getString(_kUserKey);
+      final storedToken = await _readTokenWithMigration(prefs);
 
       if (storedToken != null && userJson != null) {
         final tokenValid = await _verifyToken(storedToken);
         if (!tokenValid) {
-          await prefs.remove('user_data');
-          await prefs.remove('auth_token');
+          await _clearStoredAuth(prefs);
         } else {
           _token = storedToken;
           _currentUser = User.fromJson(
@@ -46,6 +54,27 @@ class AuthService extends ChangeNotifier {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  // Lee el token desde secure storage. Si existe uno legacy en SharedPreferences
+  // (instalaciones previas a la migración), lo mueve y limpia.
+  Future<String?> _readTokenWithMigration(SharedPreferences prefs) async {
+    final secureToken = await _secureStorage.read(key: _kTokenKey);
+    if (secureToken != null) return secureToken;
+
+    final legacyToken = prefs.getString(_kTokenKey);
+    if (legacyToken != null) {
+      await _secureStorage.write(key: _kTokenKey, value: legacyToken);
+      await prefs.remove(_kTokenKey);
+      return legacyToken;
+    }
+    return null;
+  }
+
+  Future<void> _clearStoredAuth(SharedPreferences prefs) async {
+    await prefs.remove(_kUserKey);
+    await prefs.remove(_kTokenKey); // por si quedó residuo del esquema viejo
+    await _secureStorage.delete(key: _kTokenKey);
   }
 
   /// Login con credenciales (usuario + contraseña).
@@ -71,8 +100,8 @@ class AuthService extends ChangeNotifier {
 
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString(
-            'user_data', json.encode(_currentUser!.toJson()));
-        await prefs.setString('auth_token', _token!);
+            _kUserKey, json.encode(_currentUser!.toJson()));
+        await _secureStorage.write(key: _kTokenKey, value: _token!);
 
         // Registrar token FCM en el backend
         final fcmToken = await NotificationService.getToken();
@@ -125,8 +154,7 @@ class AuthService extends ChangeNotifier {
     _currentUser = null;
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('user_data');
-    await prefs.remove('auth_token');
+    await _clearStoredAuth(prefs);
 
     notifyListeners();
   }

--- a/mobile/linux/flutter/generated_plugin_registrant.cc
+++ b/mobile/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
 }

--- a/mobile/linux/flutter/generated_plugins.cmake
+++ b/mobile/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  flutter_secure_storage_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -251,6 +251,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.34"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -389,6 +437,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   leak_tracker:
     dependency: transitive
     description:
@@ -746,6 +802,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -19,6 +19,9 @@ dependencies:
   # Almacenamiento local
   shared_preferences: ^2.2.2
 
+  # Almacenamiento seguro (Keychain iOS / EncryptedSharedPreferences Android) para el auth_token
+  flutter_secure_storage: ^9.2.2
+
   # Internacionalizacion (para DatePicker en espanol)
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
## Sesión C — Mobile + backend asociado (Fase 1 / auditoría 2026-05-25)

Insumo: [docs/plan-accion-auditoria-20260525.md](../blob/main/docs/plan-accion-auditoria-20260525.md). Reality-check del código antes de aplicar: **3 de 7 items eran falsos positivos o de bajo valor**; este PR cubre los 4 cambios reales.

## Cambios

### Seguridad
- **`mobile/lib/services/auth_service.dart`** — token migrado a `flutter_secure_storage` (Keychain en iOS, `EncryptedSharedPreferences` en Android). Antes vivía en `SharedPreferences` plain text, accesible con `adb backup` o root.
  - Migración suave: si hay `auth_token` legacy en SharedPreferences, lo mueve a secure storage en el primer arranque y limpia. Usuarios con la app instalada NO tienen que volver a loguearse.
- **`mobile/pubspec.yaml`** — agrega `flutter_secure_storage: ^9.2.2`. No es alternativa al framework — Flutter no expone Keychain/Keystore nativos.

### Bug visible — diagnóstico en citas atendidas
Antes la tarjeta de cita pasada decía siempre **"Disponible en consulta"** (hardcoded). Ahora muestra el diagnóstico real.

- **`backend/app/Http/Controllers/CitaController.php`** — `index()` del alumno hace eager-load de `consulta:id,cita_id,diagnostico` (campos mínimos). No afecta perf ni rompe contrato (campo nuevo opcional).
- **`mobile/lib/models/cita.dart`** — agrega `String? diagnostico` extraído de `json['consulta']?['diagnostico']`.
- **`mobile/lib/screens/student/citas_tab.dart`** — muestra `cita.diagnostico` cuando existe; cae a `"Pendiente de registrar"` si la consulta todavía no fue guardada.

### Defensa en profundidad
- **`mobile/lib/screens/student/perfil_tab.dart`** — `_cambiarFoto()` valida `file.length() <= 2MB` antes de enviar al multipart. El backend ya valida `max:2048`; este corte evita usar red y da feedback amigable (snackbar) en vez de un 422.

## Descartados (reality-check)

| Auditoría | Estado |
|---|---|
| C4 — validar expiración token en `_verifyToken()` | Falso positivo: el endpoint `/user` ya retorna 401 si el token expiró, lo cual el método actual ya maneja |
| C2 — cifrar caché offline (`offline_cache_service.dart`) | Postergado post-semestre: añade complejidad con secure_storage para entradas potencialmente grandes; ya tiene TTL 24h |
| C5 — forzar navegación a login tras 401 mid-sesión | Postergado: requiere refactor de `ApiService` con callback global / `GlobalKey<NavigatorState>` |
| C7 — `Image.network` → `cached_network_image` | Postergado: solo 1 uso real (`perfil_tab.dart:449`), no justifica nueva dependencia |

## Test plan

- [x] `flutter analyze` → No issues found
- [x] `php -l CitaController.php` → sin errores
- [ ] App con usuario ya logueado: arrancar → confirmar que sigue autenticado (migración suave del token funcionó)
- [ ] Login nuevo: cerrar app, reabrir, verificar que sigue sesión iniciada
- [ ] Tab "Mis Citas > Pasadas": una cita atendida con consulta registrada debe mostrar el diagnóstico real; otra sin consulta debe decir "Pendiente de registrar"
- [ ] Perfil → cambiar foto con imagen >2MB → snackbar de error sin tocar la red
- [ ] Logout → confirmar que `_secureStorage` queda limpio

## Fuera de scope

- Sesión A backend (PR #65), Sesión D IA (PR #64), Sesión B frontend (pendiente)