### PR TITLE
feat(frontend): hardening UX y seguridad (auditoria 2026-05-25)

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,1 +1,2 @@
 <router-outlet></router-outlet>
+<app-idle-warning></app-idle-warning>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { IdleWarningComponent } from './components/shared/idle-warning/idle-warning.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, IdleWarningComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { IdleWarningComponent } from './components/shared/idle-warning/idle-warning.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, IdleWarningComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/frontend/src/app/components/login/verify-2fa/verify-2fa.component.html
+++ b/frontend/src/app/components/login/verify-2fa/verify-2fa.component.html
@@ -20,15 +20,16 @@
         placeholder="000000"
         inputmode="numeric"
         autocomplete="one-time-code"
+        [disabled]="isLocked"
       />
 
-      <button type="submit" class="btn-primary" [disabled]="isLoading">
+      <button type="submit" class="btn-primary" [disabled]="isLoading || isLocked">
         {{ isLoading ? 'Verificando...' : 'Verificar' }}
       </button>
     </form>
 
     <div class="actions">
-      <button class="btn-link" (click)="onResend()" [disabled]="isResending">
+      <button class="btn-link" (click)="onResend()" [disabled]="isResending || isLocked">
         {{ isResending ? 'Enviando...' : 'Reenviar código' }}
       </button>
       <button class="btn-link secondary" (click)="goBack()">Volver al login</button>

--- a/frontend/src/app/components/login/verify-2fa/verify-2fa.component.ts
+++ b/frontend/src/app/components/login/verify-2fa/verify-2fa.component.ts
@@ -17,11 +17,21 @@ import { API_BASE_URL } from '../../../services/api-config';
 export class Verify2faComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
+  // Bloqueo local tras varios fallos: complementa el rate limit del backend
+  // para que el usuario no siga golpeando endpoints inútilmente.
+  private static readonly MAX_ATTEMPTS = 5;
+  private static readonly LOCKOUT_MINUTES = 15;
+  private static readonly ATTEMPTS_KEY_PREFIX = '2fa_attempts_';
+  private static readonly LOCKOUT_KEY_PREFIX = '2fa_lockout_';
+
   code = '';
   isLoading = false;
   isResending = false;
   errorMessage: string | null = null;
   successMessage: string | null = null;
+  isLocked = false;
+  minutesRemaining = 0;
+  attemptsRemaining: number | null = null;
 
   userId: number | null = null;
   emailMasked = '';
@@ -37,9 +47,11 @@ export class Verify2faComponent implements OnInit, OnDestroy {
     const data = JSON.parse(pending);
     this.userId = data.user_id;
     this.emailMasked = data.email_masked;
+    this.checkLockout();
   }
 
   onSubmit() {
+    if (this.checkLockout()) return;
     if (!this.code || !/^\d{6}$/.test(this.code)) {
       this.errorMessage = 'Ingresa el código de 6 dígitos.';
       return;
@@ -56,6 +68,7 @@ export class Verify2faComponent implements OnInit, OnDestroy {
       finalize(() => this.isLoading = false)
     ).subscribe({
       next: (response) => {
+        this.clearAttempts();
         // Guardar device_token para los próximos 30 días
         if (response.device_token) {
           localStorage.setItem(`${response.tipo}_device_token`, response.device_token);
@@ -75,10 +88,54 @@ export class Verify2faComponent implements OnInit, OnDestroy {
         }
       },
       error: (err) => {
-        this.errorMessage = err.error?.message || 'Código inválido o expirado.';
+        this.registerFailedAttempt(err.error?.message || 'Código inválido o expirado.');
         this.code = '';
       }
     });
+  }
+
+  // Marca un intento fallido; al llegar al límite bloquea el formulario por LOCKOUT_MINUTES.
+  private registerFailedAttempt(serverMessage: string): void {
+    if (!this.userId) {
+      this.errorMessage = serverMessage;
+      return;
+    }
+    const key = Verify2faComponent.ATTEMPTS_KEY_PREFIX + this.userId;
+    const attempts = parseInt(localStorage.getItem(key) || '0', 10) + 1;
+    localStorage.setItem(key, attempts.toString());
+
+    const remaining = Verify2faComponent.MAX_ATTEMPTS - attempts;
+    if (remaining <= 0) {
+      const lockoutUntil = Date.now() + Verify2faComponent.LOCKOUT_MINUTES * 60_000;
+      localStorage.setItem(Verify2faComponent.LOCKOUT_KEY_PREFIX + this.userId, lockoutUntil.toString());
+      localStorage.removeItem(key);
+      this.checkLockout();
+      return;
+    }
+    this.attemptsRemaining = remaining;
+    this.errorMessage = `${serverMessage} (te quedan ${remaining} intento${remaining === 1 ? '' : 's'})`;
+  }
+
+  // Devuelve true si hay bloqueo vigente; actualiza el mensaje y deshabilita el form.
+  private checkLockout(): boolean {
+    if (!this.userId) return false;
+    const lockoutKey = Verify2faComponent.LOCKOUT_KEY_PREFIX + this.userId;
+    const lockoutUntil = parseInt(localStorage.getItem(lockoutKey) || '0', 10);
+    if (lockoutUntil <= Date.now()) {
+      if (lockoutUntil > 0) localStorage.removeItem(lockoutKey);
+      this.isLocked = false;
+      return false;
+    }
+    this.isLocked = true;
+    this.minutesRemaining = Math.max(1, Math.ceil((lockoutUntil - Date.now()) / 60_000));
+    this.errorMessage = `Demasiados intentos fallidos. Vuelve a intentar en ${this.minutesRemaining} minuto(s).`;
+    return true;
+  }
+
+  private clearAttempts(): void {
+    if (!this.userId) return;
+    localStorage.removeItem(Verify2faComponent.ATTEMPTS_KEY_PREFIX + this.userId);
+    localStorage.removeItem(Verify2faComponent.LOCKOUT_KEY_PREFIX + this.userId);
   }
 
   onResend() {

--- a/frontend/src/app/components/shared/idle-warning/idle-warning.component.ts
+++ b/frontend/src/app/components/shared/idle-warning/idle-warning.component.ts
@@ -1,0 +1,99 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { AuthService } from '../../../services/auth.service';
+
+// Modal global que avisa al usuario 5 min antes de cerrar la sesión por inactividad.
+// AuthService emite el número de minutos restantes vía idleWarning$ (0 = sin aviso).
+@Component({
+  selector: 'app-idle-warning',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="minutes > 0" class="idle-warning-overlay" role="alertdialog" aria-live="assertive">
+      <div class="idle-warning-modal">
+        <div class="idle-warning-icon">⏱️</div>
+        <h3>Tu sesión está por cerrarse</h3>
+        <p>Por inactividad, cerraremos tu sesión en <strong>{{ minutes }} minuto{{ minutes === 1 ? '' : 's' }}</strong>.</p>
+        <div class="idle-warning-actions">
+          <button class="btn-primary" (click)="continuar()">Continuar sesión</button>
+          <button class="btn-secondary" (click)="cerrar()">Cerrar sesión ahora</button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .idle-warning-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.55);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+      animation: fadeIn 120ms ease-out;
+    }
+    .idle-warning-modal {
+      background: var(--surface, #fff);
+      color: var(--text-primary, #0f172a);
+      border-radius: 12px;
+      padding: 28px 32px;
+      max-width: 420px;
+      width: calc(100% - 32px);
+      text-align: center;
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+    }
+    .idle-warning-icon {
+      font-size: 40px;
+      margin-bottom: 8px;
+    }
+    .idle-warning-modal h3 {
+      margin: 0 0 8px;
+      font-size: 18px;
+    }
+    .idle-warning-modal p {
+      margin: 0 0 20px;
+      color: var(--text-secondary, #475569);
+      font-size: 14px;
+    }
+    .idle-warning-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .idle-warning-actions button {
+      padding: 10px 18px;
+      border-radius: 8px;
+      border: 0;
+      cursor: pointer;
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .btn-primary { background: #2563EB; color: #fff; }
+    .btn-secondary { background: transparent; color: var(--text-secondary, #475569); border: 1px solid var(--border, #e2e8f0); }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+  `],
+})
+export class IdleWarningComponent implements OnInit, OnDestroy {
+  minutes = 0;
+  private sub?: Subscription;
+
+  constructor(private auth: AuthService) {}
+
+  ngOnInit(): void {
+    this.sub = this.auth.idleWarning$.subscribe(m => this.minutes = m);
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  continuar(): void {
+    this.auth.extendSession();
+  }
+
+  cerrar(): void {
+    this.auth.logout();
+  }
+}

--- a/frontend/src/app/components/student/dashboard/student-dashboard.component.html
+++ b/frontend/src/app/components/student/dashboard/student-dashboard.component.html
@@ -16,6 +16,11 @@
 </div>
 
 <div class="dash-content">
+  <div *ngIf="loadError && !loading" class="alert-error-banner">
+    <span>No se pudo cargar tu información. Verifica tu conexión.</span>
+    <button class="btn primary" (click)="cargarDashboard()">Reintentar</button>
+  </div>
+
   <!-- Skeleton loader -->
   <ng-container *ngIf="loading">
     <div class="kpis">

--- a/frontend/src/app/components/student/dashboard/student-dashboard.component.ts
+++ b/frontend/src/app/components/student/dashboard/student-dashboard.component.ts
@@ -28,6 +28,7 @@ export class StudentDashboardInicioComponent implements OnInit, OnDestroy {
   @Output() navegarARecetas = new EventEmitter<void>();
 
   loading = true;
+  loadError = false;
   nombre = '';
   fechaHoy = '';
 
@@ -71,15 +72,20 @@ export class StudentDashboardInicioComponent implements OnInit, OnDestroy {
 
   cargarDashboard(): void {
     this.loading = true;
+    this.loadError = false;
     this.dashboardService.getDashboard()
       .pipe(
         takeUntil(this.destroy$),
-        catchError(() => of({
-          proximas_citas: [],
-          ultima_visita: null,
-          recetas_activas: [],
-          recordatorio: null,
-        } as DashboardAlumno)),
+        catchError(() => {
+          // Marcar el error y dejar vacíos los datos; la UI muestra banner con botón reintentar.
+          this.loadError = true;
+          return of({
+            proximas_citas: [],
+            ultima_visita: null,
+            recetas_activas: [],
+            recordatorio: null,
+          } as DashboardAlumno);
+        }),
         finalize(() => this.loading = false),
       )
       .subscribe(data => this.procesarDashboard(data));

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -32,13 +32,16 @@ export class AuthService implements OnDestroy {
   private userKey = 'user_data';
   private lastActivityKey = 'last_activity';
   private idleTimeoutMs = 30 * 60 * 1000; // 30 minutos
+  private idleWarningMs = 5 * 60 * 1000;  // mostrar aviso 5 min antes de cerrar sesión
   private idleCheckInterval: ReturnType<typeof setInterval> | null = null;
   private userSubject = new BehaviorSubject<User | null>(null);
   private isAuthenticatedSubject = new BehaviorSubject<boolean>(false);
+  private idleWarningSubject = new BehaviorSubject<number>(0); // minutos restantes (0 = sin aviso)
 
   // Exponer observables
   public currentUser$ = this.userSubject.asObservable();
   public isAuthenticated$ = this.isAuthenticatedSubject.asObservable();
+  public idleWarning$ = this.idleWarningSubject.asObservable();
 
   private activityEvents = ['mousemove', 'keydown', 'click', 'scroll', 'touchstart'];
   private boundOnActivity = this.onActivity.bind(this);
@@ -79,12 +82,32 @@ export class AuthService implements OnDestroy {
       this.idleCheckInterval = setInterval(() => {
         if (this.isSessionExpiredByIdle()) {
           this.ngZone.run(() => {
+            this.idleWarningSubject.next(0);
             this.logout();
             this.router.navigate(['/login']);
           });
+          return;
         }
-      }, 60_000);
+        const remainingMs = this.remainingIdleMs();
+        const shouldWarn = remainingMs > 0 && remainingMs <= this.idleWarningMs;
+        const minutes = shouldWarn ? Math.max(1, Math.ceil(remainingMs / 60_000)) : 0;
+        if (minutes !== this.idleWarningSubject.value) {
+          this.ngZone.run(() => this.idleWarningSubject.next(minutes));
+        }
+      }, 30_000);
     });
+  }
+
+  private remainingIdleMs(): number {
+    const last = localStorage.getItem(this.lastActivityKey);
+    if (!last) return this.idleTimeoutMs;
+    return this.idleTimeoutMs - (Date.now() - parseInt(last, 10));
+  }
+
+  // Llamado desde el modal de aviso para extender la sesión sin esperar otra actividad real.
+  extendSession(): void {
+    this.onActivity();
+    this.idleWarningSubject.next(0);
   }
 
   private stopIdleTracking(): void {
@@ -95,6 +118,7 @@ export class AuthService implements OnDestroy {
       clearInterval(this.idleCheckInterval);
       this.idleCheckInterval = null;
     }
+    this.idleWarningSubject.next(0);
   }
 
   login(identificador: string, password: string, tipoUsuario: 'alumno' | 'doctor' | 'admin'): Observable<LoginResponse> {


### PR DESCRIPTION
## Sesión B — Frontend UX/2FA (Fase 1 / auditoría 2026-05-25)

Insumo: [docs/plan-accion-auditoria-20260525.md](../blob/main/docs/plan-accion-auditoria-20260525.md). Reality-check del código: **5 de 9 items eran falsos positivos** (ya aplicados en main). Este PR cubre los 4 reales.

## Cambios

### B1 — Límite local de intentos en 2FA
- **`verify-2fa.component.ts/html`** — contador en localStorage por `user_id`. Tras 5 intentos fallidos, bloquea el formulario por 15 min y deshabilita inputs/botones. Complementa el rate limit del backend (que sí existe) cortando la UI antes de seguir golpeando.

### B5 — Banner reintentar en dashboard del alumno
- **`student/dashboard/student-dashboard.component.ts/html`** — antes `cargarDashboard()` caía silenciosamente a un objeto vacío en error → el usuario veía un dashboard en blanco sin indicación. Ahora marca `loadError` y muestra un banner con botón "Reintentar" que reinvoca la carga.

### B7 — Modal aviso 5min antes del idle timeout
- **`auth.service.ts`** — `idleWarning$: BehaviorSubject<number>` emite minutos restantes cuando faltan ≤5min para los 30min de inactividad. Tick cambiado de 60s → 30s para reacción más fina. Método `extendSession()` permite reset desde UI sin esperar un evento real.
- **`components/shared/idle-warning/idle-warning.component.ts`** — modal global standalone (template + estilos inline). Muestra "Tu sesión cerrará en X minutos" con dos acciones: "Continuar sesión" (reset idle) y "Cerrar sesión ahora" (logout).
- **`app.component.ts/html` + `app.ts`** — monta `<app-idle-warning>` global (toca también `app.ts` legacy porque comparte selector/template con `AppComponent`).

## Falsos positivos descartados (ya aplicados en main)

| # Auditoría | Hallazgo | Estado real |
|---|---|---|
| B2 | skeleton loader en `doctor-citas` ngOnInit | Ya hay `*ngIf="isLoadingCitas"` con placeholder funcional |
| B3 | reorder reprogramar (update post-tap HTTP) | `submitReprogramar` ya hace `loadCitas()` dentro del `.subscribe()` post-HTTP |
| B4 | `takeUntil(destroy$)` en polling doctor-citas | Ya está aplicado (`poll(20).pipe(takeUntil(this.destroy$))`) |
| B6 | manejo `error.status === 0` en interceptor | Ya cubierto en `AuthService.handleError` con mensaje "No se pudo conectar..." |
| B8 | skeleton loader doctor-estadisticas | Ya tiene `skeleton-kpis` + `skeleton-charts` cuando `isLoadingEstadisticas` |
| B9 | botón "Reintentar" en pre-evaluación IA | Ya está el método `reintentar()` y el botón visible en `@if (error)` |

## Test plan

- [x] `npx ng build --configuration=production` → bundle OK
- [ ] Login admin/doctor → ingresar código 2FA inválido 5 veces → form bloqueado 15 min; refrescar página mantiene el bloqueo
- [ ] Detener backend → entrar a dashboard alumno → ver banner "No se pudo cargar..." y reintentar al levantar backend
- [ ] Login alumno → dejar app idle 25 min (con localStorage `last_activity` simulado) → aparece modal de aviso; "Continuar sesión" lo cierra y reinicia los 30 min

## Postergado a post-semestre

- Refactor de `doctor-citas.component.ts` (814 líneas)
- Refactor de `student-dashboard.component.ts` y `admin-dashboard.component.ts`
- Migrar todos los `*ngIf`/`*ngFor` a control flow `@if`/`@for` (hints del compilador Angular 20)