### PR TITLE
refactor(frontend): partir doctor-citas en 4 sub-componentes (fase 5a-3)

### DIFF
--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/detail-drawer/doctor-citas-detail-drawer.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/detail-drawer/doctor-citas-detail-drawer.component.html
@@ -1,0 +1,71 @@
+<div class="overlay" *ngIf="abierto" (click)="close.emit()"></div>
+
+<aside class="drawer" [class.open]="abierto">
+  <ng-container *ngIf="cita">
+
+    <div class="drawer-head">
+      <div>
+        <h2><span class="drawer-ic">▦</span>Detalle de cita</h2>
+        <div class="drawer-sub">{{ formatDateDisplay(cita.fecha_cita) }}</div>
+      </div>
+      <button class="btn-x" (click)="close.emit()">×</button>
+    </div>
+
+    <div class="drawer-body">
+      <div class="d-patient">
+        <div class="av av-md">{{ getCitaInitials(cita) }}</div>
+        <div class="d-patient-info">
+          <b>{{ getCitaName(cita) }}</b>
+          <span class="d-patient-sub">No. <b>{{ cita.alumno?.numero_control ?? '—' }}</b></span>
+        </div>
+      </div>
+
+      <div class="d-grid">
+        <div class="d-cell">
+          <div class="d-label">Fecha</div>
+          <b>{{ formatFechaCorta(cita.fecha_cita) }}</b>
+        </div>
+        <div class="d-cell">
+          <div class="d-label">Hora</div>
+          <b>{{ formatTime(cita.hora_cita) }}</b>
+        </div>
+        <div class="d-cell d-cell-full">
+          <div class="d-label">Estado</div>
+          <span class="estatus-chip"
+            [ngClass]="{
+              'chip-programada': cita.estatus === 'programada',
+              'chip-atendida':   cita.estatus === 'atendida',
+              'chip-cancelada':  cita.estatus === 'cancelada',
+              'chip-no-asistio': cita.estatus === 'no_asistio'
+            }">
+            {{ estatusLabel(cita) }}
+          </span>
+        </div>
+      </div>
+
+      <div class="d-section" *ngIf="cita.motivo">
+        <div class="d-section-head">Motivo</div>
+        <div class="d-text">{{ cita.motivo }}</div>
+      </div>
+    </div>
+
+    <ng-container *ngIf="cita.estatus === 'programada'">
+      <div class="drawer-foot-top">
+        <button *ngIf="cita.alumno" class="btn-sm btn-outline flex1" (click)="verExpediente.emit(cita.alumno.id)">Ver expediente</button>
+        <button class="btn-sm btn-gray flex1" (click)="reprogramar.emit(cita)">Reprogramar</button>
+      </div>
+      <div class="drawer-foot">
+        <button class="btn-sm btn-danger flex1" (click)="cancelar.emit(cita)">Cancelar</button>
+        <button class="btn-sm btn-warn flex1" (click)="noAsistio.emit(cita)">No asistió</button>
+        <button class="btn-sm btn-primary-full flex1" (click)="atender.emit(cita)">Consulta</button>
+      </div>
+    </ng-container>
+
+    <div class="drawer-foot" *ngIf="cita.estatus !== 'programada'">
+      <button class="btn-sm btn-gray flex1" (click)="close.emit()">Cerrar</button>
+      <button class="btn-sm btn-outline flex1" *ngIf="cita.alumno"
+        (click)="verExpediente.emit(cita.alumno.id)">Ver expediente</button>
+    </div>
+
+  </ng-container>
+</aside>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/detail-drawer/doctor-citas-detail-drawer.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/detail-drawer/doctor-citas-detail-drawer.component.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Cita } from '../../../../../services/cita.service';
+import {
+  formatDateDisplay,
+  formatFechaCorta,
+  formatTime,
+  getCitaInitials,
+  getCitaName,
+} from '../doctor-citas-utils';
+
+@Component({
+  selector: 'app-doctor-citas-detail-drawer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './doctor-citas-detail-drawer.component.html',
+})
+export class DoctorCitasDetailDrawerComponent {
+  @Input() cita: Cita | null = null;
+  @Input() abierto = false;
+
+  @Output() close = new EventEmitter<void>();
+  @Output() atender = new EventEmitter<Cita>();
+  @Output() cancelar = new EventEmitter<Cita>();
+  @Output() noAsistio = new EventEmitter<Cita>();
+  @Output() reprogramar = new EventEmitter<Cita>();
+  @Output() verExpediente = new EventEmitter<number>();
+
+  readonly getCitaInitials = getCitaInitials;
+  readonly getCitaName = getCitaName;
+  readonly formatFechaCorta = formatFechaCorta;
+  readonly formatTime = formatTime;
+  readonly formatDateDisplay = formatDateDisplay;
+
+  estatusLabel(c: Cita): string {
+    switch (c.estatus) {
+      case 'programada': return 'Programada';
+      case 'atendida': return 'Atendida';
+      case 'cancelada': return 'Cancelada';
+      case 'no_asistio': return 'No asistió';
+      default: return c.estatus;
+    }
+  }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas-types.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas-types.ts
@@ -1,0 +1,29 @@
+import { AvailabilityStatus, CalendarAvailability } from './doctor-citas-utils';
+
+export interface DayAvailabilityRecord {
+  takenSlots: Set<string>;
+  status: AvailabilityStatus;
+  color?: string;
+  label?: string | null;
+  horaCierre?: string | null;
+}
+
+export interface CalendarDay {
+  date: string;
+  label: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  isPast: boolean;
+  availability: CalendarAvailability;
+  color?: string | null;
+  labelText?: string | null;
+}
+
+export interface CitasFiltro {
+  search: string;
+  estatus: string;
+  fechaDesde: string;
+  fechaHasta: string;
+}
+
+export type { AvailabilityStatus, CalendarAvailability };

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas-utils.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas-utils.ts
@@ -1,0 +1,138 @@
+// Utilidades puras compartidas entre el padre y los sub-componentes de doctor-citas.
+import { Cita } from '../../../../services/cita.service';
+
+export type AvailabilityStatus = 'available' | 'partial' | 'full';
+export type CalendarAvailability = 'none' | AvailabilityStatus;
+
+export function getCitaInitials(cita: Cita): string {
+  const n = cita.alumno?.nombre ?? '';
+  const a = cita.alumno?.apellido ?? '';
+  return (n.charAt(0) + a.charAt(0)).toUpperCase();
+}
+
+export function getCitaName(cita: Cita): string {
+  const n = cita.alumno?.nombre ?? '';
+  const a = cita.alumno?.apellido ?? '';
+  return `${n} ${a}`.trim();
+}
+
+export function getGridCitaClass(cita: Cita): 'ok' | 'cancel' | 'warn' {
+  switch (cita.estatus) {
+    case 'programada': return 'ok';
+    case 'atendida': return 'ok';
+    case 'cancelada': return 'cancel';
+    case 'no_asistio': return 'cancel';
+    default: return 'warn';
+  }
+}
+
+export function trackByCita(_: number, c: Cita): number {
+  return c.id;
+}
+
+export function weekLabelFromStart(weekStart: Date): string {
+  const end = new Date(weekStart);
+  end.setDate(end.getDate() + 5);
+  const months = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+  return `Semana del ${weekStart.getDate()} al ${end.getDate()} ${months[end.getMonth()]}`;
+}
+
+export function buildWeekDays(weekStart: Date, today: string): { date: string; label: string; isToday: boolean }[] {
+  const dayNames = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+  const days: { date: string; label: string; isToday: boolean }[] = [];
+  for (let i = 0; i < 6; i++) {
+    const d = new Date(weekStart);
+    d.setDate(d.getDate() + i);
+    const dateStr = formatDate(d);
+    days.push({ date: dateStr, label: `${dayNames[i]} ${d.getDate()}`, isToday: dateStr === today });
+  }
+  return days;
+}
+
+export function normalizeTime(hora: string): string {
+  const [hours, minutes] = hora.split(':');
+  return `${hours?.padStart(2, '0')}:${(minutes ?? '00').padStart(2, '0')}`;
+}
+
+export function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function toDateFromString(fecha: string, hora?: string): Date {
+  const [year, month, day] = fecha.split('-').map(Number);
+  if (hora) {
+    const [h, min] = normalizeTime(hora).split(':').map(Number);
+    return new Date(year, (month ?? 1) - 1, day ?? 1, h ?? 0, min ?? 0);
+  }
+  return new Date(year, (month ?? 1) - 1, day ?? 1);
+}
+
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+export function getMonday(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function formatTime(hora: string): string {
+  const [hours, minutes] = normalizeTime(hora).split(':').map(Number);
+  const date = new Date();
+  date.setHours(hours, minutes || 0, 0, 0);
+  return new Intl.DateTimeFormat('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false }).format(date);
+}
+
+export function formatDateDisplay(fecha: string): string {
+  const date = toDateFromString(fecha);
+  return new Intl.DateTimeFormat('es-MX', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }).format(date);
+}
+
+export function formatFechaCorta(fecha: string): string {
+  if (!fecha) return '—';
+  const [y, m, d] = fecha.split('-').map(Number);
+  return new Intl.DateTimeFormat('es-MX', { day: 'numeric', month: 'short', year: 'numeric' })
+    .format(new Date(y, (m ?? 1) - 1, d ?? 1)).toUpperCase();
+}
+
+export function generateTimeSlots(): string[] {
+  const slots: string[] = [];
+  for (let hour = 8; hour < 17; hour++) {
+    ['00', '15', '30', '45'].forEach(min => slots.push(`${String(hour).padStart(2, '0')}:${min}`));
+  }
+  return slots;
+}
+
+export function getStatusColor(status: CalendarAvailability): string {
+  switch (status) {
+    case 'available': return '#1e88e5';
+    case 'partial': return '#ffb300';
+    case 'full': return '#ef5350';
+    default: return '#cfd8dc';
+  }
+}
+
+export function applyOpacity(hexColor: string, alpha: number): string {
+  const rgb = hexToRgb(hexColor);
+  if (!rgb) return hexColor;
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  if (h.length !== 6) return null;
+  const n = parseInt(h, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
@@ -1,6 +1,3 @@
-<!-- Overlay para drawer -->
-<div class="overlay" *ngIf="drawerCitaAbierto" (click)="closeDrawer()"></div>
-
 <!-- ===== HEADER ===== -->
 <div class="citas-header">
   <div>
@@ -44,10 +41,10 @@
 
 <!-- ===== PRÓXIMA CITA HERO ===== -->
 <div class="proxima-hero" *ngIf="proximaCitaObj && !isLoadingCitas">
-  <div class="av av-hero">{{ getGridCitaInitials(proximaCitaObj) }}</div>
+  <div class="av av-hero">{{ getCitaInitials(proximaCitaObj) }}</div>
   <div class="proxima-info">
     <div class="proxima-label">Próxima cita</div>
-    <div class="proxima-name">{{ getGridCitaName(proximaCitaObj) }}</div>
+    <div class="proxima-name">{{ getCitaName(proximaCitaObj) }}</div>
     <div class="proxima-meta">
       No. {{ proximaCitaObj.alumno?.numero_control ?? '—' }} · {{ formatFechaCorta(proximaCitaObj.fecha_cita) }}
     </div>
@@ -62,63 +59,20 @@
   </div>
 </div>
 
-<!-- ===== SEMANA GRID (agenda) ===== -->
-<div class="week-grid-card">
-  <div class="week-grid-header">
-    <h2>{{ weekLabel }}</h2>
-    <div class="week-nav">
-      <button class="btn-week" (click)="goToThisWeek()">Hoy</button>
-      <button class="btn-week" (click)="changeWeek(-1)">‹</button>
-      <button class="btn-week" (click)="changeWeek(1)">›</button>
-    </div>
-  </div>
-  <div class="week-grid-table-wrap">
-    <table class="week-grid-table">
-      <thead>
-        <tr>
-          <th class="col-hora">Hora</th>
-          <th *ngFor="let day of weekGridDays" [class.col-today]="day.isToday">
-            {{ day.label }}<span *ngIf="day.isToday" class="today-dot">hoy</span>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let hour of hourGridSlots">
-          <td class="cell-hora">{{ hour | number:'2.0-0' }}:00</td>
-          <td *ngFor="let day of weekGridDays" class="cell-slot" [class.cell-today]="day.isToday">
-            <div *ngFor="let cita of getCitasForSlot(day.date, hour); trackBy: trackByCita"
-                 class="grid-cita" [ngClass]="getGridCitaClass(cita)"
-                 [class.grid-cita-dim]="hayFiltroActivo && !citaMatchaFiltro(cita)"
-                 (click)="openDrawer(cita)">
-              {{ getGridCitaName(cita) }}
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
+<!-- ===== SEMANA GRID ===== -->
+<app-doctor-citas-week-grid
+  [citas]="citas"
+  [hayFiltroActivo]="hayFiltroActivo"
+  [citaMatchaFiltro]="citaMatchaFiltro"
+  (openCita)="openDrawer($event)">
+</app-doctor-citas-week-grid>
 
 <!-- ===== BUSCADOR + FILTROS ===== -->
-<div class="citas-search-bar">
-  <span class="search-ic">⌕</span>
-  <input placeholder="Buscar por alumno, No. control o motivo…"
-         [(ngModel)]="searchCitas" />
-  <div class="filtros-inline">
-    <select [(ngModel)]="filtroEstatus" class="filtro-select-sm">
-      <option value="">Todos los estados</option>
-      <option value="programada">Programada</option>
-      <option value="atendida">Atendida</option>
-      <option value="cancelada">Cancelada</option>
-      <option value="no_asistio">No asistió</option>
-    </select>
-    <input type="date" [(ngModel)]="filtroFechaDesde" class="filtro-fecha-sm">
-    <input type="date" [(ngModel)]="filtroFechaHasta" class="filtro-fecha-sm">
-    <button class="btn-limpiar-sm"
-      *ngIf="filtroEstatus || filtroFechaDesde || filtroFechaHasta || searchCitas"
-      (click)="limpiarFiltros()">Limpiar</button>
-  </div>
-</div>
+<app-doctor-citas-filtros
+  [filtro]="filtro"
+  (filtroChange)="onFiltroChange($event)"
+  (limpiar)="limpiarFiltros()">
+</app-doctor-citas-filtros>
 
 <!-- Loading / Error -->
 <div *ngIf="isLoadingCitas" class="placeholder">Cargando citas…</div>
@@ -127,7 +81,6 @@
 <!-- ===== LISTA DE CITAS ===== -->
 <div class="table-wrap" *ngIf="!isLoadingCitas && !citasError">
 
-  <!-- Pendientes -->
   <div class="table-section-head" *ngIf="filteredPendingCitas.length > 0">
     <span><b>{{ filteredPendingCitas.length }}</b> cita{{ filteredPendingCitas.length !== 1 ? 's' : '' }} pendiente{{ filteredPendingCitas.length !== 1 ? 's' : '' }}</span>
   </div>
@@ -136,9 +89,9 @@
        *ngFor="let c of filteredPendingCitas; trackBy: trackByCita"
        (click)="openDrawer(c)"
        [class.sel]="drawerCita?.id === c.id">
-    <div class="av">{{ getGridCitaInitials(c) }}</div>
+    <div class="av">{{ getCitaInitials(c) }}</div>
     <div class="who">
-      <b>{{ getGridCitaName(c) }}</b>
+      <b>{{ getCitaName(c) }}</b>
       <span>No. {{ c.alumno?.numero_control ?? '—' }}</span>
     </div>
     <span class="badge-fecha">
@@ -152,7 +105,6 @@
     </div>
   </div>
 
-  <!-- Historial -->
   <div class="table-section-head historial-head" *ngIf="filteredHandledCitas.length > 0">
     <span><b>{{ filteredHandledCitas.length }}</b> cita{{ filteredHandledCitas.length !== 1 ? 's' : '' }} en historial</span>
   </div>
@@ -161,9 +113,9 @@
        *ngFor="let c of pagedHandledCitas; trackBy: trackByCita"
        (click)="openDrawer(c)"
        [class.sel]="drawerCita?.id === c.id">
-    <div class="av av-muted">{{ getGridCitaInitials(c) }}</div>
+    <div class="av av-muted">{{ getCitaInitials(c) }}</div>
     <div class="who">
-      <b>{{ getGridCitaName(c) }}</b>
+      <b>{{ getCitaName(c) }}</b>
       <span>No. {{ c.alumno?.numero_control ?? '—' }}</span>
     </div>
     <span class="badge-fecha badge-fecha-muted">
@@ -175,7 +127,7 @@
         'chip-cancelada':  c.estatus === 'cancelada',
         'chip-no-asistio': c.estatus === 'no_asistio'
       }">
-      {{ c.estatus === 'atendida' ? 'Atendida' : c.estatus === 'cancelada' ? 'Cancelada' : 'No asistió' }}
+      {{ estatusLabelHistorial(c) }}
     </span>
     <div class="motivo-col">{{ c.motivo || 'Sin motivo' }}</div>
     <div class="row-actions" (click)="$event.stopPropagation()">
@@ -183,7 +135,6 @@
     </div>
   </div>
 
-  <!-- Paginación historial -->
   <div class="pagination-bar" *ngIf="totalPaginasHistorial > 1">
     <button class="btn-sm btn-outline"
             (click)="cambiarPaginaHistorial(historialPagina - 1)"
@@ -194,7 +145,6 @@
             [disabled]="historialPagina === totalPaginasHistorial">Siguiente ›</button>
   </div>
 
-  <!-- Vacío -->
   <div class="placeholder" *ngIf="filteredPendingCitas.length === 0 && filteredHandledCitas.length === 0">
     <div class="placeholder-ic">▦</div>
     <b>Sin citas</b>
@@ -202,231 +152,24 @@
   </div>
 </div>
 
-<!-- ===== DRAWER: Detalle de cita ===== -->
-<aside class="drawer" [class.open]="drawerCitaAbierto">
-  <ng-container *ngIf="drawerCita">
+<!-- ===== DRAWER ===== -->
+<app-doctor-citas-detail-drawer
+  [cita]="drawerCita"
+  [abierto]="drawerCitaAbierto"
+  (close)="closeDrawer()"
+  (atender)="drawerAtender($event)"
+  (cancelar)="drawerCancelar($event)"
+  (noAsistio)="drawerNoAsistio($event)"
+  (reprogramar)="drawerReprogramar($event)"
+  (verExpediente)="openPerfilAlumno($event)">
+</app-doctor-citas-detail-drawer>
 
-    <div class="drawer-head">
-      <div>
-        <h2><span class="drawer-ic">▦</span>Detalle de cita</h2>
-        <div class="drawer-sub">{{ formatDateDisplay(drawerCita.fecha_cita) }}</div>
-      </div>
-      <button class="btn-x" (click)="closeDrawer()">×</button>
-    </div>
-
-    <div class="drawer-body">
-      <div class="d-patient">
-        <div class="av av-md">{{ getGridCitaInitials(drawerCita) }}</div>
-        <div class="d-patient-info">
-          <b>{{ getGridCitaName(drawerCita) }}</b>
-          <span class="d-patient-sub">No. <b>{{ drawerCita.alumno?.numero_control ?? '—' }}</b></span>
-        </div>
-      </div>
-
-      <div class="d-grid">
-        <div class="d-cell">
-          <div class="d-label">Fecha</div>
-          <b>{{ formatFechaCorta(drawerCita.fecha_cita) }}</b>
-        </div>
-        <div class="d-cell">
-          <div class="d-label">Hora</div>
-          <b>{{ formatTime(drawerCita.hora_cita) }}</b>
-        </div>
-        <div class="d-cell d-cell-full">
-          <div class="d-label">Estado</div>
-          <span class="estatus-chip"
-            [ngClass]="{
-              'chip-programada': drawerCita.estatus === 'programada',
-              'chip-atendida':   drawerCita.estatus === 'atendida',
-              'chip-cancelada':  drawerCita.estatus === 'cancelada',
-              'chip-no-asistio': drawerCita.estatus === 'no_asistio'
-            }">
-            {{ drawerCita.estatus === 'programada' ? 'Programada'
-               : drawerCita.estatus === 'atendida' ? 'Atendida'
-               : drawerCita.estatus === 'cancelada' ? 'Cancelada'
-               : 'No asistió' }}
-          </span>
-        </div>
-      </div>
-
-      <div class="d-section" *ngIf="drawerCita.motivo">
-        <div class="d-section-head">Motivo</div>
-        <div class="d-text">{{ drawerCita.motivo }}</div>
-      </div>
-    </div>
-
-    <!-- Footer para citas programadas -->
-    <ng-container *ngIf="drawerCita.estatus === 'programada'">
-      <div class="drawer-foot-top">
-        <button *ngIf="drawerCita.alumno" class="btn-sm btn-outline flex1" (click)="openPerfilAlumno(drawerCita.alumno.id)">Ver expediente</button>
-        <button class="btn-sm btn-gray flex1" (click)="drawerReprogramar(drawerCita)">Reprogramar</button>
-      </div>
-      <div class="drawer-foot">
-        <button class="btn-sm btn-danger flex1" (click)="drawerCancelar(drawerCita)">Cancelar</button>
-        <button class="btn-sm btn-warn flex1" (click)="drawerNoAsistio(drawerCita)">No asistió</button>
-        <button class="btn-sm btn-primary-full flex1" (click)="drawerAtender(drawerCita)">Consulta</button>
-      </div>
-    </ng-container>
-
-    <!-- Footer para citas ya gestionadas -->
-    <div class="drawer-foot" *ngIf="drawerCita.estatus !== 'programada'">
-      <button class="btn-sm btn-gray flex1" (click)="closeDrawer()">Cerrar</button>
-      <button class="btn-sm btn-outline flex1" *ngIf="drawerCita.alumno"
-        (click)="openPerfilAlumno(drawerCita.alumno.id)">Ver expediente</button>
-    </div>
-
-  </ng-container>
-</aside>
-
-<!-- ===== MODAL: 3 pasos — Nueva cita ===== -->
-<div class="modal-overlay" *ngIf="showCreateForm" (click)="toggleCreateForm()">
-  <div class="modal-3step" (click)="$event.stopPropagation()">
-
-    <div class="modal-3step-head">
-      <div>
-        <h3>Nueva cita</h3>
-        <div class="step-indicator">
-          <span class="step-dot" [class.active]="createStep >= 1" [class.done]="createStep > 1">1</span>
-          <span class="step-line"></span>
-          <span class="step-dot" [class.active]="createStep >= 2" [class.done]="createStep > 2">2</span>
-          <span class="step-line"></span>
-          <span class="step-dot" [class.active]="createStep >= 3">3</span>
-        </div>
-      </div>
-      <button class="modal-close" (click)="toggleCreateForm()">✕</button>
-    </div>
-
-    <div *ngIf="submitMessage" class="form-msg">{{ submitMessage }}</div>
-
-    <form #createCitaForm="ngForm" (ngSubmit)="onCreateCita(createCitaForm)">
-
-      <!-- Paso 1: Alumno -->
-      <div *ngIf="createStep === 1" class="step-body">
-        <div class="step-title">¿Para quién es la cita?</div>
-        <div class="form-group">
-          <label>Número de control del alumno</label>
-          <input type="text" name="numero_control" [(ngModel)]="createFormData.numero_control"
-            placeholder="Ej. 22690495" autocomplete="off" />
-        </div>
-      </div>
-
-      <!-- Paso 2: Fecha y hora -->
-      <div *ngIf="createStep === 2" class="step-body">
-        <div class="step-title">¿Cuándo?</div>
-        <div class="calendar-card">
-          <div class="calendar-header">
-            <button type="button" class="calendar-nav" (click)="changeMonth(-1)" [disabled]="isCurrentMonth">‹</button>
-            <h4>{{ calendarLabel | titlecase }}</h4>
-            <button type="button" class="calendar-nav" (click)="changeMonth(1)">›</button>
-          </div>
-          <div class="calendar-legend">
-            <span><span class="dot available"></span> Disponible</span>
-            <span><span class="dot partial"></span> Parcial</span>
-            <span><span class="dot full"></span> Sin lugares</span>
-          </div>
-          <div class="calendar-weekdays">
-            <span *ngFor="let day of weekDays">{{ day }}</span>
-          </div>
-          <div class="calendar-grid">
-            <ng-container *ngFor="let week of calendarWeeks">
-              <button type="button" *ngFor="let day of week" class="calendar-day" [ngClass]="{
-                outside: !day.isCurrentMonth,
-                today: day.isToday,
-                selected: isSelectedDate(day.date),
-                unavailable: isDayUnavailable(day),
-                'status-available': day.availability === 'available',
-                'status-partial': day.availability === 'partial',
-                'status-full': day.availability === 'full',
-                'status-none': day.availability === 'none'
-              }" [ngStyle]="getDayStyle(day)" [attr.aria-pressed]="isSelectedDate(day.date)"
-                (click)="selectCalendarDay(day)">
-                <span class="day-number">{{ day.label }}</span>
-                <span class="day-badge" *ngIf="day.labelText">{{ day.labelText }}</span>
-              </button>
-            </ng-container>
-          </div>
-        </div>
-        <div class="selected-date-info" *ngIf="createFormData.fecha_cita">
-          <strong>Seleccionaste:</strong> {{ formatDateDisplay(createFormData.fecha_cita) }}
-        </div>
-        <div class="warning-banner" *ngIf="selectedDayWarning">⚠ {{ selectedDayWarning }}</div>
-        <div class="slots-wrapper" *ngIf="createFormData.fecha_cita"
-             [class.disabled]="!hasAvailableSlotsForSelectedDate">
-          <div class="slots-legend">
-            <span class="leg-dot free"></span> Libre
-            <span class="leg-dot selected-dot"></span> Seleccionado
-            <span class="leg-dot booked-dot"></span> Ocupado
-          </div>
-          <div class="slots-group">
-            <span class="slots-period">Mañana</span>
-            <div class="time-slots">
-              <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(0, 16)"
-                [class.selected]="createFormData.hora_cita === normalizeTime(slot)"
-                [class.booked]="isSlotUnavailable(slot)"
-                [disabled]="isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
-                {{ formatTime(slot) }}
-              </button>
-            </div>
-          </div>
-          <div class="slots-group">
-            <span class="slots-period">Tarde</span>
-            <div class="time-slots">
-              <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(16)"
-                [class.selected]="createFormData.hora_cita === normalizeTime(slot)"
-                [class.booked]="isSlotUnavailable(slot)"
-                [disabled]="isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
-                {{ formatTime(slot) }}
-              </button>
-            </div>
-          </div>
-          <small class="helper-text warning" *ngIf="!hasAvailableSlotsForSelectedDate">
-            Este día ya no tiene espacios disponibles.
-          </small>
-        </div>
-        <small class="helper-text" *ngIf="!createFormData.fecha_cita">
-          Selecciona un día disponible para ver las horas libres.
-        </small>
-      </div>
-
-      <!-- Paso 3: Confirmar + motivo -->
-      <div *ngIf="createStep === 3" class="step-body">
-        <div class="step-title">Confirmar cita</div>
-        <div class="confirm-summary">
-          <div class="confirm-row">
-            <span>Alumno</span>
-            <b>No. {{ createFormData.numero_control }}</b>
-          </div>
-          <div class="confirm-row">
-            <span>Fecha</span>
-            <b>{{ formatDateDisplay(createFormData.fecha_cita ?? '') }}</b>
-          </div>
-          <div class="confirm-row">
-            <span>Hora</span>
-            <b>{{ formatTime(createFormData.hora_cita ?? '') }}</b>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>Motivo (opcional)</label>
-          <textarea name="motivo" [(ngModel)]="createFormData.motivo" rows="3"
-            placeholder="Describe el motivo de la consulta…"></textarea>
-        </div>
-      </div>
-
-      <div class="modal-3step-foot">
-        <button type="button" class="btn-secondary"
-          (click)="createStep > 1 ? stepBack() : toggleCreateForm()">
-          {{ createStep > 1 ? 'Atrás' : 'Cancelar' }}
-        </button>
-        <button type="button" class="btn-primary" *ngIf="createStep < 3" (click)="stepNext()">
-          Siguiente
-        </button>
-        <button type="submit" class="btn-primary" *ngIf="createStep === 3" [disabled]="isSubmitting">
-          {{ isSubmitting ? 'Agendando…' : 'Agendar cita' }}
-        </button>
-      </div>
-    </form>
-  </div>
-</div>
+<!-- ===== MODAL: Nueva cita ===== -->
+<app-nueva-cita-modal
+  [visible]="showCreateForm"
+  (close)="showCreateForm = false"
+  (created)="onCitaCreated()">
+</app-nueva-cita-modal>
 
 <!-- ===== MODAL: Registrar consulta ===== -->
 <div class="modal-overlay" *ngIf="showConsultaForm" (click)="closeConsultaForm()">

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.ts
@@ -1,42 +1,44 @@
-import { Component, OnDestroy, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnDestroy, OnInit, Output, EventEmitter, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, NgForm } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 import { Subject, of } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
-import { Cita, CitaService, CreateCitaPayload, AvailabilityStatus, CitaAvailabilityDay } from '../../../../services/cita.service';
+import { Cita, CitaService } from '../../../../services/cita.service';
 import { ConsultaService } from '../../../../services/consulta.service';
 import { PerfilMedicoService, PerfilMedico, ConsultaHistorial } from '../../../../services/perfil-medico.service';
 import { PollingService } from '../../../../services/polling.service';
-
-type CalendarAvailability = 'none' | AvailabilityStatus;
-
-interface DayAvailabilityRecord {
-  takenSlots: Set<string>;
-  status: AvailabilityStatus;
-  color?: string;
-  label?: string | null;
-  horaCierre?: string | null;
-}
-
-interface CalendarDay {
-  date: string;
-  label: number;
-  isCurrentMonth: boolean;
-  isToday: boolean;
-  isPast: boolean;
-  availability: CalendarAvailability;
-  color?: string | null;
-  labelText?: string | null;
-}
+import { CitasFiltro } from './doctor-citas-types';
+import {
+  formatDate,
+  formatFechaCorta,
+  formatTime,
+  generateTimeSlots,
+  getCitaInitials,
+  getCitaName,
+  normalizeTime,
+  toDateFromString,
+  trackByCita,
+} from './doctor-citas-utils';
+import { DoctorCitasFiltrosComponent } from './filtros/doctor-citas-filtros.component';
+import { DoctorCitasWeekGridComponent } from './week-grid/doctor-citas-week-grid.component';
+import { DoctorCitasDetailDrawerComponent } from './detail-drawer/doctor-citas-detail-drawer.component';
+import { NuevaCitaModalComponent } from './nueva-cita-modal/nueva-cita-modal.component';
 
 @Component({
   selector: 'app-doctor-citas',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    DoctorCitasFiltrosComponent,
+    DoctorCitasWeekGridComponent,
+    DoctorCitasDetailDrawerComponent,
+    NuevaCitaModalComponent,
+  ],
   templateUrl: './doctor-citas.component.html',
-  styleUrls: ['./doctor-citas.component.css']   // <-- Línea faltante
+  styleUrls: ['./doctor-citas.component.css'],
+  encapsulation: ViewEncapsulation.None,
 })
-
 export class DoctorCitasComponent implements OnInit, OnDestroy {
   @Output() openFicha = new EventEmitter<number>();
 
@@ -45,23 +47,10 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   citasError: string | null = null;
   pendingCitas: Cita[] = [];
   handledCitas: Cita[] = [];
-  searchCitas = '';
+
+  filtro: CitasFiltro = { search: '', estatus: '', fechaDesde: '', fechaHasta: '' };
 
   showCreateForm = false;
-  isSubmitting = false;
-  submitMessage: string | null = null;
-
-  createFormData: Partial<CreateCitaPayload & { numero_control: string }> = {
-    fecha_cita: '', hora_cita: '', motivo: '', numero_control: ''
-  };
-
-  readonly timeSlots: string[] = this.generateTimeSlots();
-  readonly totalSlotsPerDay = this.timeSlots.length;
-  readonly weekDays: string[] = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
-  currentMonth: Date = this.startOfMonth(new Date());
-  calendarWeeks: CalendarDay[][] = [];
-  availabilityMap: Map<string, DayAvailabilityRecord> = new Map();
-  isLoadingAvailability = false;
 
   // Modal consulta
   showConsultaForm = false;
@@ -78,11 +67,6 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   isLoadingPerfilAlumno = false;
   historialAlumnoExpandido: number | null = null;
 
-  // Filtros
-  filtroEstatus = '';
-  filtroFechaDesde = '';
-  filtroFechaHasta = '';
-
   // Paginación client-side del historial
   historialPagina = 1;
   readonly historialPorPagina = 10;
@@ -90,9 +74,6 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   // Drawer de detalle
   drawerCita: Cita | null = null;
   drawerCitaAbierto = false;
-
-  // Modal nueva cita — pasos
-  createStep: 1 | 2 | 3 = 1;
 
   // Modal reprogramar
   showReprogramarModal = false;
@@ -102,12 +83,21 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   reprogramarMsg: string | null = null;
   isSubmittingReprogramar = false;
 
-  // Vista semanal grid
-  currentWeekStart: Date = this.getMonday(new Date());
-  readonly hourGridSlots: number[] = [8, 9, 10, 11, 12, 13, 14, 15, 16];
-  readonly gridDayNames = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+  isSubmitting = false;
+  submitMessage: string | null = null;
 
-  readonly today = this.formatDate(new Date());
+  readonly timeSlots: string[] = generateTimeSlots();
+  readonly today = formatDate(new Date());
+  readonly trackByCita = trackByCita;
+  readonly getCitaInitials = getCitaInitials;
+  readonly getCitaName = getCitaName;
+  readonly formatTime = formatTime;
+  readonly formatFechaCorta = formatFechaCorta;
+  readonly normalizeTime = normalizeTime;
+
+  // Bind necesario para pasar al sub-componente como Input
+  readonly citaMatchaFiltro = (c: Cita) => this.filterCitas([c]).length > 0;
+
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -118,14 +108,9 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.buildCalendar();
-    this.loadAvailability();
     this.loadCitas();
     // Refresca cada 20s mientras la pestana este visible — citas nuevas/canceladas aparecen sin recargar
-    this.polling.poll(20).pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.loadCitas();
-      this.loadAvailability();
-    });
+    this.polling.poll(20).pipe(takeUntil(this.destroy$)).subscribe(() => this.loadCitas());
   }
 
   ngOnDestroy(): void {
@@ -136,14 +121,9 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   get filteredPendingCitas(): Cita[] { return this.filterCitas(this.pendingCitas); }
   get filteredHandledCitas(): Cita[] { return this.filterCitas(this.handledCitas); }
 
-  // True si hay algún filtro activo — usado para atenuar el calendario
   get hayFiltroActivo(): boolean {
-    return !!(this.searchCitas.trim() || this.filtroEstatus || this.filtroFechaDesde || this.filtroFechaHasta);
-  }
-
-  // True si la cita matchea los filtros activos — para atenuar grid semanal
-  citaMatchaFiltro(cita: Cita): boolean {
-    return this.filterCitas([cita]).length > 0;
+    const f = this.filtro;
+    return !!(f.search.trim() || f.estatus || f.fechaDesde || f.fechaHasta);
   }
 
   get pagedHandledCitas(): Cita[] {
@@ -177,138 +157,27 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     }).length;
   }
 
-  private filterCitas(citas: Cita[]): Cita[] {
-    let result = citas;
-    const q = this.searchCitas.trim().toLowerCase();
-    if (q) {
-      result = result.filter(c => {
-        const nombre = `${c.alumno?.nombre ?? ''} ${c.alumno?.apellido ?? ''}`.toLowerCase();
-        return nombre.includes(q) || (c.alumno?.numero_control ?? '').toLowerCase().includes(q) || (c.motivo ?? '').toLowerCase().includes(q);
-      });
-    }
-    if (this.filtroEstatus) {
-      result = result.filter(c => c.estatus === this.filtroEstatus);
-    }
-    if (this.filtroFechaDesde) {
-      result = result.filter(c => c.fecha_cita >= this.filtroFechaDesde);
-    }
-    if (this.filtroFechaHasta) {
-      result = result.filter(c => c.fecha_cita <= this.filtroFechaHasta);
-    }
-    return result;
+  estatusLabelHistorial(c: Cita): string {
+    return c.estatus === 'atendida' ? 'Atendida' : c.estatus === 'cancelada' ? 'Cancelada' : 'No asistió';
   }
 
   limpiarFiltros(): void {
-    this.filtroEstatus = '';
-    this.filtroFechaDesde = '';
-    this.filtroFechaHasta = '';
-    this.searchCitas = '';
+    this.filtro = { search: '', estatus: '', fechaDesde: '', fechaHasta: '' };
     this.historialPagina = 1;
   }
 
-  get calendarLabel(): string {
-    return new Intl.DateTimeFormat('es-MX', { month: 'long', year: 'numeric' }).format(this.currentMonth);
-  }
-
-  get isCurrentMonth(): boolean {
-    const now = new Date();
-    return this.currentMonth.getFullYear() === now.getFullYear() && this.currentMonth.getMonth() === now.getMonth();
-  }
-
-  // Aviso para días con atención reducida — null si el día es normal o no seleccionado
-  get selectedDayWarning(): string | null {
-    const fecha = this.createFormData.fecha_cita;
-    if (!fecha) return null;
-    const rec = this.getDayRecord(fecha);
-    if (!rec || rec.status !== 'partial') return null;
-    const baseMsg = rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
-    return rec.horaCierre ? `${baseMsg} (cierre a las ${rec.horaCierre})` : baseMsg;
-  }
-
-  get hasAvailableSlotsForSelectedDate(): boolean {
-    if (!this.createFormData.fecha_cita) return false;
-    const record = this.getDayRecord(this.createFormData.fecha_cita);
-    if (record?.status === 'full') return false;
-    const takenSlots = record?.takenSlots ?? new Set<string>();
-    return this.timeSlots.some(slot => !takenSlots.has(this.normalizeTime(slot)));
+  onFiltroChange(filtro: CitasFiltro): void {
+    this.filtro = filtro;
+    this.historialPagina = 1;
   }
 
   toggleCreateForm(): void {
     this.showCreateForm = !this.showCreateForm;
-    this.createStep = 1;
-    this.submitMessage = null;
-    if (this.showCreateForm) {
-      this.loadAvailability();
-    } else {
-      this.resetForm();
-    }
   }
 
-  changeMonth(direction: number): void {
-    this.currentMonth = this.startOfMonth(new Date(this.currentMonth.getFullYear(), this.currentMonth.getMonth() + direction, 1));
-    this.availabilityMap = new Map();
-    this.buildCalendar();
-    this.loadAvailability();
-  }
-
-  selectCalendarDay(day: CalendarDay): void {
-    if (day.isPast || !day.isCurrentMonth || day.availability === 'full') return;
-    this.onDateChange(day.date);
-  }
-
-  selectTimeSlot(slot: string): void {
-    if (!this.createFormData.fecha_cita || this.isSlotUnavailable(slot)) return;
-    this.createFormData.hora_cita = this.normalizeTime(slot);
-    this.submitMessage = null;
-  }
-
-  onCreateCita(form: NgForm): void {
-    const noCtrl = this.createFormData.numero_control?.trim();
-    if (!noCtrl || !this.createFormData.fecha_cita || !this.createFormData.hora_cita) {
-      this.submitMessage = 'Completa todos los campos requeridos.';
-      return;
-    }
-
-    const normalizedTime = this.normalizeTime(this.createFormData.hora_cita!);
-    if (this.isSlotUnavailable(normalizedTime)) {
-      this.submitMessage = 'La hora seleccionada ya está ocupada.';
-      return;
-    }
-
-    const payload: CreateCitaPayload = {
-      fecha_cita: this.createFormData.fecha_cita!,
-      hora_cita: normalizedTime,
-      motivo: this.createFormData.motivo || undefined,
-      numero_control: (this.createFormData.numero_control ?? '').trim()
-    };
-
-    this.isSubmitting = true;
-    this.submitMessage = null;
-
-    this.citaService.createCita(payload)
-      .pipe(
-        takeUntil(this.destroy$),
-        catchError(error => {
-          const errores = error?.error?.errors;
-          if (errores && typeof errores === 'object') {
-            const first = Object.keys(errores)[0];
-            const msgs = (errores as any)[first];
-            if (Array.isArray(msgs) && msgs.length > 0) { this.submitMessage = msgs[0]; return of(null); }
-          }
-          this.submitMessage = error?.error?.message || 'No se pudo agendar la cita.';
-          return of(null);
-        }),
-        finalize(() => { this.isSubmitting = false; })
-      )
-      .subscribe(response => {
-        if (response?.cita) {
-          this.createStep = 1;
-          this.loadCitas();
-          this.loadAvailability();
-          this.resetForm();
-          this.showCreateForm = false;
-        }
-      });
+  onCitaCreated(): void {
+    this.showCreateForm = false;
+    this.loadCitas();
   }
 
   onCancelCita(cita: Cita): void {
@@ -324,7 +193,6 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
         if (response?.cita) {
           this.submitMessage = 'Cita cancelada correctamente.';
           this.loadCitas();
-          this.loadAvailability();
         }
       });
   }
@@ -412,7 +280,7 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
   openReprogramar(cita: Cita): void {
     this.reprogramarCitaId = cita.id;
     this.reprogramarFecha = cita.fecha_cita;
-    this.reprogramarHora = this.normalizeTime(cita.hora_cita);
+    this.reprogramarHora = normalizeTime(cita.hora_cita);
     this.reprogramarMsg = null;
     this.showReprogramarModal = true;
   }
@@ -440,13 +308,10 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
         if (response) {
           this.reprogramarMsg = 'Cita reprogramada correctamente.';
           this.loadCitas();
-          this.loadAvailability();
           this.closeReprogramar();
         }
       });
   }
-
-  // === Drawer de detalle ===
 
   openDrawer(cita: Cita): void {
     this.drawerCita = cita;
@@ -458,135 +323,38 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
     this.drawerCitaAbierto = false;
   }
 
-  drawerAtender(cita: Cita): void {
-    this.closeDrawer();
-    this.onMarkAsAttended(cita);
+  drawerAtender(cita: Cita): void { this.closeDrawer(); this.onMarkAsAttended(cita); }
+  drawerCancelar(cita: Cita): void { this.closeDrawer(); this.onCancelCita(cita); }
+  drawerNoAsistio(cita: Cita): void { this.closeDrawer(); this.onMarkAsNoShow(cita); }
+  drawerReprogramar(cita: Cita): void { this.closeDrawer(); this.openReprogramar(cita); }
+
+  // Filtra slots a futuras si fecha == hoy; devuelve todos si es fecha posterior.
+  slotsParaFecha(fecha: string): string[] {
+    if (fecha !== this.today) return this.timeSlots;
+    const now = new Date();
+    const horaActual = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+    return this.timeSlots.filter(s => s > horaActual);
   }
 
-  drawerCancelar(cita: Cita): void {
-    this.closeDrawer();
-    this.onCancelCita(cita);
-  }
-
-  drawerNoAsistio(cita: Cita): void {
-    this.closeDrawer();
-    this.onMarkAsNoShow(cita);
-  }
-
-  drawerReprogramar(cita: Cita): void {
-    this.closeDrawer();
-    this.openReprogramar(cita);
-  }
-
-  stepNext(): void {
-    if (this.createStep === 1) {
-      if (!this.createFormData.numero_control?.trim()) {
-        this.submitMessage = 'Ingresa el número de control del alumno.';
-        return;
-      }
-      this.submitMessage = null;
-      this.createStep = 2;
-    } else if (this.createStep === 2) {
-      if (!this.createFormData.fecha_cita) {
-        this.submitMessage = 'Selecciona una fecha.';
-        return;
-      }
-      if (!this.createFormData.hora_cita) {
-        this.submitMessage = 'Selecciona una hora.';
-        return;
-      }
-      this.submitMessage = null;
-      this.createStep = 3;
-    }
-  }
-
-  stepBack(): void {
-    if (this.createStep > 1) this.createStep = (this.createStep - 1) as 1 | 2 | 3;
-    this.submitMessage = null;
-  }
-
-  formatFechaCorta(fecha: string): string {
-    if (!fecha) return '—';
-    const [y, m, d] = fecha.split('-').map(Number);
-    return new Intl.DateTimeFormat('es-MX', { day: 'numeric', month: 'short', year: 'numeric' })
-      .format(new Date(y, (m ?? 1) - 1, d ?? 1)).toUpperCase();
-  }
-
-  // === Vista semanal ===
-
-  get weekGridDays(): { date: string; label: string; isToday: boolean }[] {
-    const days: { date: string; label: string; isToday: boolean }[] = [];
-    const dayNames = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
-    for (let i = 0; i < 6; i++) {
-      const d = new Date(this.currentWeekStart);
-      d.setDate(d.getDate() + i);
-      const dateStr = this.formatDate(d);
-      days.push({
-        date: dateStr,
-        label: `${dayNames[i]} ${d.getDate()}`,
-        isToday: dateStr === this.today
+  private filterCitas(citas: Cita[]): Cita[] {
+    let result = citas;
+    const q = this.filtro.search.trim().toLowerCase();
+    if (q) {
+      result = result.filter(c => {
+        const nombre = `${c.alumno?.nombre ?? ''} ${c.alumno?.apellido ?? ''}`.toLowerCase();
+        return nombre.includes(q) || (c.alumno?.numero_control ?? '').toLowerCase().includes(q) || (c.motivo ?? '').toLowerCase().includes(q);
       });
     }
-    return days;
-  }
-
-  get weekLabel(): string {
-    const end = new Date(this.currentWeekStart);
-    end.setDate(end.getDate() + 5);
-    const months = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
-    const startDay = this.currentWeekStart.getDate();
-    const endDay = end.getDate();
-    const month = months[end.getMonth()];
-    return `Semana del ${startDay} al ${endDay} ${month}`;
-  }
-
-  changeWeek(direction: number): void {
-    const next = new Date(this.currentWeekStart);
-    next.setDate(next.getDate() + (direction * 7));
-    this.currentWeekStart = next;
-  }
-
-  goToThisWeek(): void {
-    this.currentWeekStart = this.getMonday(new Date());
-  }
-
-  getCitasForSlot(date: string, hour: number): Cita[] {
-    return this.citas.filter(c => {
-      if (c.fecha_cita !== date) return false;
-      const h = parseInt(c.hora_cita.split(':')[0], 10);
-      return h === hour;
-    });
-  }
-
-  getGridCitaClass(cita: Cita): string {
-    switch (cita.estatus) {
-      case 'programada': return 'ok';
-      case 'atendida': return 'ok';
-      case 'cancelada': return 'cancel';
-      case 'no_asistio': return 'cancel';
-      default: return 'warn';
+    if (this.filtro.estatus) {
+      result = result.filter(c => c.estatus === this.filtro.estatus);
     }
-  }
-
-  getGridCitaInitials(cita: Cita): string {
-    const n = cita.alumno?.nombre ?? '';
-    const a = cita.alumno?.apellido ?? '';
-    return (n.charAt(0) + a.charAt(0)).toUpperCase();
-  }
-
-  getGridCitaName(cita: Cita): string {
-    const n = cita.alumno?.nombre ?? '';
-    const a = cita.alumno?.apellido ?? '';
-    return `${n} ${a}`.trim();
-  }
-
-  private getMonday(date: Date): Date {
-    const d = new Date(date);
-    const day = d.getDay();
-    const diff = day === 0 ? -6 : 1 - day;
-    d.setDate(d.getDate() + diff);
-    d.setHours(0, 0, 0, 0);
-    return d;
+    if (this.filtro.fechaDesde) {
+      result = result.filter(c => c.fecha_cita >= this.filtro.fechaDesde);
+    }
+    if (this.filtro.fechaHasta) {
+      result = result.filter(c => c.fecha_cita <= this.filtro.fechaHasta);
+    }
+    return result;
   }
 
   private loadCitas(): void {
@@ -600,217 +368,12 @@ export class DoctorCitasComponent implements OnInit, OnDestroy {
       )
       .subscribe(citas => {
         this.citas = citas;
-        const ahora = new Date();
         this.pendingCitas = citas
           .filter(c => c.estatus === 'programada')
-          .sort((a, b) => this.toDate(a.fecha_cita, a.hora_cita).getTime() - this.toDate(b.fecha_cita, b.hora_cita).getTime());
+          .sort((a, b) => toDateFromString(a.fecha_cita, a.hora_cita).getTime() - toDateFromString(b.fecha_cita, b.hora_cita).getTime());
         this.handledCitas = citas
           .filter(c => c.estatus !== 'programada')
-          .sort((a, b) => this.toDate(b.fecha_cita, b.hora_cita).getTime() - this.toDate(a.fecha_cita, a.hora_cita).getTime());
+          .sort((a, b) => toDateFromString(b.fecha_cita, b.hora_cita).getTime() - toDateFromString(a.fecha_cita, a.hora_cita).getTime());
       });
   }
-
-  private loadAvailability(): void {
-    this.isLoadingAvailability = true;
-    const month = this.currentMonth.getMonth() + 1;
-    const year = this.currentMonth.getFullYear();
-    this.citaService.getAvailability(month, year)
-      .pipe(
-        takeUntil(this.destroy$),
-        catchError(() => of(null)),
-        finalize(() => { this.isLoadingAvailability = false; })
-      )
-      .subscribe(response => {
-        if (response?.days) {
-          this.applyAvailability(response.days);
-        } else {
-          this.availabilityMap = new Map();
-        }
-        this.buildCalendar();
-      });
-  }
-
-  private applyAvailability(days: CitaAvailabilityDay[]): void {
-    const map = new Map<string, DayAvailabilityRecord>();
-    days.forEach(day => {
-      const takenSlots = new Set<string>((day.taken_slots || []).map(s => this.normalizeTime(s)));
-      let status: AvailabilityStatus;
-      if (day.special?.status) {
-        status = day.special.status;
-      } else if (takenSlots.size === 0) {
-        status = 'available';
-      } else if (takenSlots.size >= this.totalSlotsPerDay) {
-        status = 'full';
-      } else {
-        status = 'partial';
-      }
-      map.set(day.date, { takenSlots, status, color: day.special?.color ?? undefined, label: day.special?.label ?? null, horaCierre: day.special?.hora_cierre ?? null });
-    });
-    this.availabilityMap = map;
-  }
-
-  private buildCalendar(): void {
-    const reference = this.startOfMonth(this.currentMonth);
-    const firstDayIndex = reference.getDay();
-    const calendarStart = new Date(reference);
-    calendarStart.setDate(calendarStart.getDate() - firstDayIndex);
-
-    const today = this.startOfDay(new Date());
-    const weeks: CalendarDay[][] = [];
-    let cursor = new Date(calendarStart);
-
-    for (let week = 0; week < 6; week++) {
-      const weekDays: CalendarDay[] = [];
-      for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
-        const date = new Date(cursor);
-        const dateStr = this.formatDate(date);
-        const isCurrentMonth = date.getMonth() === reference.getMonth();
-        const isPast = this.startOfDay(date).getTime() < today.getTime();
-        const isToday = this.startOfDay(date).getTime() === today.getTime();
-        const meta = this.resolveCalendarMetadata(dateStr, isCurrentMonth, isPast);
-        weekDays.push({ date: dateStr, label: date.getDate(), isCurrentMonth, isToday, isPast, ...meta });
-        cursor.setDate(cursor.getDate() + 1);
-      }
-      weeks.push(weekDays);
-    }
-    this.calendarWeeks = weeks;
-  }
-
-  private resolveCalendarMetadata(dateStr: string, isCurrentMonth: boolean, isPast: boolean): { availability: CalendarAvailability; color: string | null; labelText: string | null } {
-    if (!isCurrentMonth || isPast) return { availability: 'none', color: null, labelText: null };
-    if (this.toDate(dateStr).getDay() === 0) return { availability: 'full', color: '#ef5350', labelText: 'Cerrado' };
-    const record = this.getDayRecord(dateStr);
-    if (!record) return { availability: 'available', color: this.getStatusColor('available'), labelText: null };
-    return { availability: record.status, color: record.color ?? this.getStatusColor(record.status), labelText: record.label ?? null };
-  }
-
-  private getDayRecord(date: string): DayAvailabilityRecord | undefined {
-    return this.availabilityMap.get(date);
-  }
-
-  public isSelectedDate(date: string): boolean { return this.createFormData.fecha_cita === date; }
-
-  public isDayUnavailable(day: CalendarDay): boolean {
-    return !day.isCurrentMonth || day.isPast || day.availability === 'full';
-  }
-
-  public getDayStyle(day: CalendarDay): { [key: string]: string } | null {
-    if (day.availability === 'none') return null;
-    const baseColor = day.color ?? this.getStatusColor(day.availability);
-    const background = this.applyOpacity(baseColor, day.availability === 'full' ? 0.25 : 0.15);
-    const border = this.applyOpacity(baseColor, 0.6);
-    const style: { [key: string]: string } = { 'background-color': background, 'border-color': border };
-    if (day.isToday) style['box-shadow'] = `0 0 0 2px ${this.applyOpacity('#1e88e5', 0.4)}`;
-    return style;
-  }
-
-  public onDateChange(date: string): void {
-    this.createFormData.fecha_cita = date;
-    if (this.createFormData.hora_cita && this.isSlotUnavailable(this.createFormData.hora_cita)) {
-      this.createFormData.hora_cita = '';
-    }
-    this.submitMessage = null;
-    this.buildCalendar();
-  }
-
-  public isSlotUnavailable(slot: string): boolean {
-    if (!this.createFormData.fecha_cita) return false;
-    const normalizedSlot = this.normalizeTime(slot);
-    if (this.createFormData.fecha_cita === this.today) {
-      const [hours, minutes] = normalizedSlot.split(':').map(Number);
-      const slotDate = new Date();
-      slotDate.setHours(hours ?? 0, minutes ?? 0, 0, 0);
-      if (slotDate.getTime() <= new Date().getTime()) return true;
-    }
-    const record = this.getDayRecord(this.createFormData.fecha_cita);
-    if (record?.status === 'full') return true;
-    if (record?.horaCierre && normalizedSlot >= record.horaCierre) return true;
-    if (record?.takenSlots.has(normalizedSlot)) return true;
-    return this.citas.some(c =>
-      c.fecha_cita === this.createFormData.fecha_cita &&
-      c.estatus === 'programada' &&
-      this.normalizeTime(c.hora_cita) === normalizedSlot
-    );
-  }
-
-  public formatDateDisplay(fecha: string): string {
-    const date = this.toDate(fecha);
-    return new Intl.DateTimeFormat('es-MX', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }).format(date);
-  }
-
-  public formatTime(hora: string): string {
-    const [hours, minutes] = this.normalizeTime(hora).split(':').map(Number);
-    const date = new Date();
-    date.setHours(hours, minutes || 0, 0, 0);
-    return new Intl.DateTimeFormat('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false }).format(date);
-  }
-
-  public normalizeTime(hora: string): string {
-    const [hours, minutes] = hora.split(':');
-    return `${hours?.padStart(2, '0')}:${(minutes ?? '00').padStart(2, '0')}`;
-  }
-
-  private resetForm(): void {
-    this.createFormData = { fecha_cita: '', hora_cita: '', motivo: '', numero_control: '' };
-  }
-
-  private formatDate(date: Date): string {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, '0');
-    const d = String(date.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-  }
-
-  private toDate(fecha: string, hora?: string): Date {
-    const [year, month, day] = fecha.split('-').map(Number);
-    if (hora) {
-      const [h, min] = this.normalizeTime(hora).split(':').map(Number);
-      return new Date(year, (month ?? 1) - 1, day ?? 1, h ?? 0, min ?? 0);
-    }
-    return new Date(year, (month ?? 1) - 1, day ?? 1);
-  }
-
-  private startOfDay(date: Date): Date { return new Date(date.getFullYear(), date.getMonth(), date.getDate()); }
-  private startOfMonth(date: Date): Date { return new Date(date.getFullYear(), date.getMonth(), 1); }
-
-  private getStatusColor(status: CalendarAvailability): string {
-    switch (status) {
-      case 'available': return '#1e88e5';
-      case 'partial': return '#ffb300';
-      case 'full': return '#ef5350';
-      default: return '#cfd8dc';
-    }
-  }
-
-  private applyOpacity(hexColor: string, alpha: number): string {
-    const rgb = this.hexToRgb(hexColor);
-    if (!rgb) return hexColor;
-    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
-  }
-
-  private hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-    let h = hex.replace('#', '');
-    if (h.length === 3) h = h.split('').map(c => c + c).join('');
-    if (h.length !== 6) return null;
-    const n = parseInt(h, 16);
-    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
-  }
-
-  private generateTimeSlots(): string[] {
-    const slots: string[] = [];
-    for (let hour = 8; hour < 17; hour++) {
-      ['00', '15', '30', '45'].forEach(min => slots.push(`${String(hour).padStart(2, '0')}:${min}`));
-    }
-    return slots;
-  }
-
-  // Filtra slots a futuras si fecha == hoy; devuelve todos si es fecha posterior.
-  slotsParaFecha(fecha: string): string[] {
-    if (fecha !== this.today) return this.timeSlots;
-    const now = new Date();
-    const horaActual = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
-    return this.timeSlots.filter(s => s > horaActual);
-  }
-
-  trackByCita(_: number, c: Cita): number { return c.id; }
 }

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/filtros/doctor-citas-filtros.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/filtros/doctor-citas-filtros.component.html
@@ -1,0 +1,29 @@
+<div class="citas-search-bar">
+  <span class="search-ic">⌕</span>
+  <input placeholder="Buscar por alumno, No. control o motivo…"
+         [ngModel]="filtro.search"
+         (ngModelChange)="update('search', $event)" />
+  <div class="filtros-inline">
+    <select [ngModel]="filtro.estatus"
+            (ngModelChange)="update('estatus', $event)"
+            class="filtro-select-sm">
+      <option value="">Todos los estados</option>
+      <option value="programada">Programada</option>
+      <option value="atendida">Atendida</option>
+      <option value="cancelada">Cancelada</option>
+      <option value="no_asistio">No asistió</option>
+    </select>
+    <input type="date"
+           [ngModel]="filtro.fechaDesde"
+           (ngModelChange)="update('fechaDesde', $event)"
+           class="filtro-fecha-sm">
+    <input type="date"
+           [ngModel]="filtro.fechaHasta"
+           (ngModelChange)="update('fechaHasta', $event)"
+           class="filtro-fecha-sm">
+    <button type="button"
+            class="btn-limpiar-sm"
+            *ngIf="hayFiltro"
+            (click)="limpiar.emit()">Limpiar</button>
+  </div>
+</div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/filtros/doctor-citas-filtros.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/filtros/doctor-citas-filtros.component.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { CitasFiltro } from '../doctor-citas-types';
+
+@Component({
+  selector: 'app-doctor-citas-filtros',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './doctor-citas-filtros.component.html',
+})
+export class DoctorCitasFiltrosComponent {
+  @Input() filtro: CitasFiltro = { search: '', estatus: '', fechaDesde: '', fechaHasta: '' };
+  @Output() filtroChange = new EventEmitter<CitasFiltro>();
+  @Output() limpiar = new EventEmitter<void>();
+
+  get hayFiltro(): boolean {
+    const f = this.filtro;
+    return !!(f.search || f.estatus || f.fechaDesde || f.fechaHasta);
+  }
+
+  update<K extends keyof CitasFiltro>(key: K, value: CitasFiltro[K]): void {
+    this.filtro = { ...this.filtro, [key]: value };
+    this.filtroChange.emit(this.filtro);
+  }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/nueva-cita-modal/nueva-cita-modal.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/nueva-cita-modal/nueva-cita-modal.component.html
@@ -1,0 +1,145 @@
+<div class="modal-overlay" *ngIf="visible" (click)="onClose()">
+  <div class="modal-3step" (click)="$event.stopPropagation()">
+
+    <div class="modal-3step-head">
+      <div>
+        <h3>Nueva cita</h3>
+        <div class="step-indicator">
+          <span class="step-dot" [class.active]="createStep >= 1" [class.done]="createStep > 1">1</span>
+          <span class="step-line"></span>
+          <span class="step-dot" [class.active]="createStep >= 2" [class.done]="createStep > 2">2</span>
+          <span class="step-line"></span>
+          <span class="step-dot" [class.active]="createStep >= 3">3</span>
+        </div>
+      </div>
+      <button class="modal-close" (click)="onClose()">✕</button>
+    </div>
+
+    <div *ngIf="submitMessage" class="form-msg">{{ submitMessage }}</div>
+
+    <form #createCitaForm="ngForm" (ngSubmit)="onCreateCita(createCitaForm)">
+
+      <div *ngIf="createStep === 1" class="step-body">
+        <div class="step-title">¿Para quién es la cita?</div>
+        <div class="form-group">
+          <label>Número de control del alumno</label>
+          <input type="text" name="numero_control" [(ngModel)]="formData.numero_control"
+            placeholder="Ej. 22690495" autocomplete="off" />
+        </div>
+      </div>
+
+      <div *ngIf="createStep === 2" class="step-body">
+        <div class="step-title">¿Cuándo?</div>
+        <div class="calendar-card">
+          <div class="calendar-header">
+            <button type="button" class="calendar-nav" (click)="changeMonth(-1)" [disabled]="isCurrentMonth">‹</button>
+            <h4>{{ calendarLabel | titlecase }}</h4>
+            <button type="button" class="calendar-nav" (click)="changeMonth(1)">›</button>
+          </div>
+          <div class="calendar-legend">
+            <span><span class="dot available"></span> Disponible</span>
+            <span><span class="dot partial"></span> Parcial</span>
+            <span><span class="dot full"></span> Sin lugares</span>
+          </div>
+          <div class="calendar-weekdays">
+            <span *ngFor="let day of weekDays">{{ day }}</span>
+          </div>
+          <div class="calendar-grid">
+            <ng-container *ngFor="let week of calendarWeeks">
+              <button type="button" *ngFor="let day of week" class="calendar-day" [ngClass]="{
+                outside: !day.isCurrentMonth,
+                today: day.isToday,
+                selected: isSelectedDate(day.date),
+                unavailable: isDayUnavailable(day),
+                'status-available': day.availability === 'available',
+                'status-partial': day.availability === 'partial',
+                'status-full': day.availability === 'full',
+                'status-none': day.availability === 'none'
+              }" [ngStyle]="getDayStyle(day)" [attr.aria-pressed]="isSelectedDate(day.date)"
+                (click)="selectCalendarDay(day)">
+                <span class="day-number">{{ day.label }}</span>
+                <span class="day-badge" *ngIf="day.labelText">{{ day.labelText }}</span>
+              </button>
+            </ng-container>
+          </div>
+        </div>
+        <div class="selected-date-info" *ngIf="formData.fecha_cita">
+          <strong>Seleccionaste:</strong> {{ formatDateDisplay(formData.fecha_cita) }}
+        </div>
+        <div class="warning-banner" *ngIf="selectedDayWarning">⚠ {{ selectedDayWarning }}</div>
+        <div class="slots-wrapper" *ngIf="formData.fecha_cita"
+             [class.disabled]="!hasAvailableSlotsForSelectedDate">
+          <div class="slots-legend">
+            <span class="leg-dot free"></span> Libre
+            <span class="leg-dot selected-dot"></span> Seleccionado
+            <span class="leg-dot booked-dot"></span> Ocupado
+          </div>
+          <div class="slots-group">
+            <span class="slots-period">Mañana</span>
+            <div class="time-slots">
+              <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(0, 16)"
+                [class.selected]="formData.hora_cita === normalizeTime(slot)"
+                [class.booked]="isSlotUnavailable(slot)"
+                [disabled]="isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
+                {{ formatTime(slot) }}
+              </button>
+            </div>
+          </div>
+          <div class="slots-group">
+            <span class="slots-period">Tarde</span>
+            <div class="time-slots">
+              <button type="button" class="slot-button" *ngFor="let slot of timeSlots.slice(16)"
+                [class.selected]="formData.hora_cita === normalizeTime(slot)"
+                [class.booked]="isSlotUnavailable(slot)"
+                [disabled]="isSlotUnavailable(slot)" (click)="selectTimeSlot(slot)">
+                {{ formatTime(slot) }}
+              </button>
+            </div>
+          </div>
+          <small class="helper-text warning" *ngIf="!hasAvailableSlotsForSelectedDate">
+            Este día ya no tiene espacios disponibles.
+          </small>
+        </div>
+        <small class="helper-text" *ngIf="!formData.fecha_cita">
+          Selecciona un día disponible para ver las horas libres.
+        </small>
+      </div>
+
+      <div *ngIf="createStep === 3" class="step-body">
+        <div class="step-title">Confirmar cita</div>
+        <div class="confirm-summary">
+          <div class="confirm-row">
+            <span>Alumno</span>
+            <b>No. {{ formData.numero_control }}</b>
+          </div>
+          <div class="confirm-row">
+            <span>Fecha</span>
+            <b>{{ formatDateDisplay(formData.fecha_cita ?? '') }}</b>
+          </div>
+          <div class="confirm-row">
+            <span>Hora</span>
+            <b>{{ formatTime(formData.hora_cita ?? '') }}</b>
+          </div>
+        </div>
+        <div class="form-group">
+          <label>Motivo (opcional)</label>
+          <textarea name="motivo" [(ngModel)]="formData.motivo" rows="3"
+            placeholder="Describe el motivo de la consulta…"></textarea>
+        </div>
+      </div>
+
+      <div class="modal-3step-foot">
+        <button type="button" class="btn-secondary"
+          (click)="createStep > 1 ? stepBack() : onClose()">
+          {{ createStep > 1 ? 'Atrás' : 'Cancelar' }}
+        </button>
+        <button type="button" class="btn-primary" *ngIf="createStep < 3" (click)="stepNext()">
+          Siguiente
+        </button>
+        <button type="submit" class="btn-primary" *ngIf="createStep === 3" [disabled]="isSubmitting">
+          {{ isSubmitting ? 'Agendando…' : 'Agendar cita' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/nueva-cita-modal/nueva-cita-modal.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/nueva-cita-modal/nueva-cita-modal.component.ts
@@ -1,0 +1,304 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, NgForm } from '@angular/forms';
+import { Subject, of } from 'rxjs';
+import { catchError, finalize, takeUntil } from 'rxjs/operators';
+import { Cita, CitaService, CreateCitaPayload, CitaAvailabilityDay } from '../../../../../services/cita.service';
+import {
+  AvailabilityStatus,
+  CalendarAvailability,
+  applyOpacity,
+  formatDate,
+  formatDateDisplay,
+  formatTime,
+  generateTimeSlots,
+  getStatusColor,
+  normalizeTime,
+  startOfDay,
+  startOfMonth,
+  toDateFromString,
+} from '../doctor-citas-utils';
+import { CalendarDay, DayAvailabilityRecord } from '../doctor-citas-types';
+
+@Component({
+  selector: 'app-nueva-cita-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './nueva-cita-modal.component.html',
+})
+export class NuevaCitaModalComponent implements OnInit, OnDestroy {
+  @Input() visible = false;
+  @Output() close = new EventEmitter<void>();
+  @Output() created = new EventEmitter<Cita>();
+
+  readonly timeSlots: string[] = generateTimeSlots();
+  readonly totalSlotsPerDay = this.timeSlots.length;
+  readonly weekDays: string[] = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+  readonly today = formatDate(new Date());
+
+  createStep: 1 | 2 | 3 = 1;
+  currentMonth: Date = startOfMonth(new Date());
+  calendarWeeks: CalendarDay[][] = [];
+  availabilityMap: Map<string, DayAvailabilityRecord> = new Map();
+
+  formData: Partial<CreateCitaPayload & { numero_control: string }> = {
+    fecha_cita: '', hora_cita: '', motivo: '', numero_control: '',
+  };
+  submitMessage: string | null = null;
+  isSubmitting = false;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private citaService: CitaService) {}
+
+  ngOnInit(): void {
+    this.buildCalendar();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['visible'] && changes['visible'].currentValue) {
+      this.createStep = 1;
+      this.submitMessage = null;
+      this.loadAvailability();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  get calendarLabel(): string {
+    return new Intl.DateTimeFormat('es-MX', { month: 'long', year: 'numeric' }).format(this.currentMonth);
+  }
+
+  get isCurrentMonth(): boolean {
+    const now = new Date();
+    return this.currentMonth.getFullYear() === now.getFullYear() && this.currentMonth.getMonth() === now.getMonth();
+  }
+
+  get selectedDayWarning(): string | null {
+    const fecha = this.formData.fecha_cita;
+    if (!fecha) return null;
+    const rec = this.availabilityMap.get(fecha);
+    if (!rec || rec.status !== 'partial') return null;
+    const baseMsg = rec.label ? `Atención reducida hoy: ${rec.label}` : 'Este día tiene atención reducida.';
+    return rec.horaCierre ? `${baseMsg} (cierre a las ${rec.horaCierre})` : baseMsg;
+  }
+
+  get hasAvailableSlotsForSelectedDate(): boolean {
+    if (!this.formData.fecha_cita) return false;
+    const record = this.availabilityMap.get(this.formData.fecha_cita);
+    if (record?.status === 'full') return false;
+    const takenSlots = record?.takenSlots ?? new Set<string>();
+    return this.timeSlots.some(slot => !takenSlots.has(normalizeTime(slot)));
+  }
+
+  isSelectedDate(date: string): boolean { return this.formData.fecha_cita === date; }
+
+  isDayUnavailable(day: CalendarDay): boolean {
+    return !day.isCurrentMonth || day.isPast || day.availability === 'full';
+  }
+
+  getDayStyle(day: CalendarDay): { [key: string]: string } | null {
+    if (day.availability === 'none') return null;
+    const baseColor = day.color ?? getStatusColor(day.availability);
+    const background = applyOpacity(baseColor, day.availability === 'full' ? 0.25 : 0.15);
+    const border = applyOpacity(baseColor, 0.6);
+    const style: { [key: string]: string } = { 'background-color': background, 'border-color': border };
+    if (day.isToday) style['box-shadow'] = `0 0 0 2px ${applyOpacity('#1e88e5', 0.4)}`;
+    return style;
+  }
+
+  isSlotUnavailable(slot: string): boolean {
+    if (!this.formData.fecha_cita) return false;
+    const normalizedSlot = normalizeTime(slot);
+    if (this.formData.fecha_cita === this.today) {
+      const [hours, minutes] = normalizedSlot.split(':').map(Number);
+      const slotDate = new Date();
+      slotDate.setHours(hours ?? 0, minutes ?? 0, 0, 0);
+      if (slotDate.getTime() <= new Date().getTime()) return true;
+    }
+    const record = this.availabilityMap.get(this.formData.fecha_cita);
+    if (record?.status === 'full') return true;
+    if (record?.horaCierre && normalizedSlot >= record.horaCierre) return true;
+    return !!record?.takenSlots.has(normalizedSlot);
+  }
+
+  changeMonth(direction: number): void {
+    this.currentMonth = startOfMonth(new Date(this.currentMonth.getFullYear(), this.currentMonth.getMonth() + direction, 1));
+    this.availabilityMap = new Map();
+    this.buildCalendar();
+    this.loadAvailability();
+  }
+
+  selectCalendarDay(day: CalendarDay): void {
+    if (day.isPast || !day.isCurrentMonth || day.availability === 'full') return;
+    this.formData.fecha_cita = day.date;
+    if (this.formData.hora_cita && this.isSlotUnavailable(this.formData.hora_cita)) {
+      this.formData.hora_cita = '';
+    }
+    this.submitMessage = null;
+    this.buildCalendar();
+  }
+
+  selectTimeSlot(slot: string): void {
+    if (!this.formData.fecha_cita || this.isSlotUnavailable(slot)) return;
+    this.formData.hora_cita = normalizeTime(slot);
+    this.submitMessage = null;
+  }
+
+  stepNext(): void {
+    if (this.createStep === 1) {
+      if (!this.formData.numero_control?.trim()) {
+        this.submitMessage = 'Ingresa el número de control del alumno.';
+        return;
+      }
+      this.submitMessage = null;
+      this.createStep = 2;
+    } else if (this.createStep === 2) {
+      if (!this.formData.fecha_cita) {
+        this.submitMessage = 'Selecciona una fecha.';
+        return;
+      }
+      if (!this.formData.hora_cita) {
+        this.submitMessage = 'Selecciona una hora.';
+        return;
+      }
+      this.submitMessage = null;
+      this.createStep = 3;
+    }
+  }
+
+  stepBack(): void {
+    if (this.createStep > 1) this.createStep = (this.createStep - 1) as 1 | 2 | 3;
+    this.submitMessage = null;
+  }
+
+  onCreateCita(_form: NgForm): void {
+    const noCtrl = this.formData.numero_control?.trim();
+    if (!noCtrl || !this.formData.fecha_cita || !this.formData.hora_cita) {
+      this.submitMessage = 'Completa todos los campos requeridos.';
+      return;
+    }
+    const normalizedTime = normalizeTime(this.formData.hora_cita!);
+    if (this.isSlotUnavailable(normalizedTime)) {
+      this.submitMessage = 'La hora seleccionada ya está ocupada.';
+      return;
+    }
+    const payload: CreateCitaPayload = {
+      fecha_cita: this.formData.fecha_cita!,
+      hora_cita: normalizedTime,
+      motivo: this.formData.motivo || undefined,
+      numero_control: noCtrl,
+    };
+    this.isSubmitting = true;
+    this.submitMessage = null;
+
+    this.citaService.createCita(payload)
+      .pipe(
+        takeUntil(this.destroy$),
+        catchError(error => {
+          const errores = error?.error?.errors;
+          if (errores && typeof errores === 'object') {
+            const first = Object.keys(errores)[0];
+            const msgs = (errores as { [k: string]: string[] })[first];
+            if (Array.isArray(msgs) && msgs.length > 0) { this.submitMessage = msgs[0]; return of(null); }
+          }
+          this.submitMessage = error?.error?.message || 'No se pudo agendar la cita.';
+          return of(null);
+        }),
+        finalize(() => { this.isSubmitting = false; })
+      )
+      .subscribe(response => {
+        if (response?.cita) {
+          this.created.emit(response.cita);
+          this.resetForm();
+          this.close.emit();
+        }
+      });
+  }
+
+  onClose(): void {
+    this.resetForm();
+    this.close.emit();
+  }
+
+  formatTime = formatTime;
+  formatDateDisplay = formatDateDisplay;
+  normalizeTime = normalizeTime;
+
+  private resetForm(): void {
+    this.formData = { fecha_cita: '', hora_cita: '', motivo: '', numero_control: '' };
+    this.createStep = 1;
+  }
+
+  private loadAvailability(): void {
+    const month = this.currentMonth.getMonth() + 1;
+    const year = this.currentMonth.getFullYear();
+    this.citaService.getAvailability(month, year)
+      .pipe(takeUntil(this.destroy$), catchError(() => of(null)))
+      .subscribe(response => {
+        if (response?.days) {
+          this.applyAvailability(response.days);
+        } else {
+          this.availabilityMap = new Map();
+        }
+        this.buildCalendar();
+      });
+  }
+
+  private applyAvailability(days: CitaAvailabilityDay[]): void {
+    const map = new Map<string, DayAvailabilityRecord>();
+    days.forEach(day => {
+      const takenSlots = new Set<string>((day.taken_slots || []).map(s => normalizeTime(s)));
+      let status: AvailabilityStatus;
+      if (day.special?.status) {
+        status = day.special.status;
+      } else if (takenSlots.size === 0) {
+        status = 'available';
+      } else if (takenSlots.size >= this.totalSlotsPerDay) {
+        status = 'full';
+      } else {
+        status = 'partial';
+      }
+      map.set(day.date, { takenSlots, status, color: day.special?.color ?? undefined, label: day.special?.label ?? null, horaCierre: day.special?.hora_cierre ?? null });
+    });
+    this.availabilityMap = map;
+  }
+
+  private buildCalendar(): void {
+    const reference = startOfMonth(this.currentMonth);
+    const firstDayIndex = reference.getDay();
+    const calendarStart = new Date(reference);
+    calendarStart.setDate(calendarStart.getDate() - firstDayIndex);
+
+    const today = startOfDay(new Date());
+    const weeks: CalendarDay[][] = [];
+    const cursor = new Date(calendarStart);
+
+    for (let week = 0; week < 6; week++) {
+      const weekDays: CalendarDay[] = [];
+      for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
+        const date = new Date(cursor);
+        const dateStr = formatDate(date);
+        const isCurrentMonth = date.getMonth() === reference.getMonth();
+        const isPast = startOfDay(date).getTime() < today.getTime();
+        const isToday = startOfDay(date).getTime() === today.getTime();
+        const meta = this.resolveCalendarMetadata(dateStr, isCurrentMonth, isPast);
+        weekDays.push({ date: dateStr, label: date.getDate(), isCurrentMonth, isToday, isPast, ...meta });
+        cursor.setDate(cursor.getDate() + 1);
+      }
+      weeks.push(weekDays);
+    }
+    this.calendarWeeks = weeks;
+  }
+
+  private resolveCalendarMetadata(dateStr: string, isCurrentMonth: boolean, isPast: boolean): { availability: CalendarAvailability; color: string | null; labelText: string | null } {
+    if (!isCurrentMonth || isPast) return { availability: 'none', color: null, labelText: null };
+    if (toDateFromString(dateStr).getDay() === 0) return { availability: 'full', color: '#ef5350', labelText: 'Cerrado' };
+    const record = this.availabilityMap.get(dateStr);
+    if (!record) return { availability: 'available', color: getStatusColor('available'), labelText: null };
+    return { availability: record.status, color: record.color ?? getStatusColor(record.status), labelText: record.label ?? null };
+  }
+}

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/week-grid/doctor-citas-week-grid.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/week-grid/doctor-citas-week-grid.component.html
@@ -1,0 +1,36 @@
+<div class="week-grid-card">
+  <div class="week-grid-header">
+    <h2>{{ weekLabel }}</h2>
+    <div class="week-nav">
+      <button class="btn-week" (click)="goToThisWeek()">Hoy</button>
+      <button class="btn-week" (click)="changeWeek(-1)">‹</button>
+      <button class="btn-week" (click)="changeWeek(1)">›</button>
+    </div>
+  </div>
+  <div class="week-grid-table-wrap">
+    <table class="week-grid-table">
+      <thead>
+        <tr>
+          <th class="col-hora">Hora</th>
+          <th *ngFor="let day of weekGridDays" [class.col-today]="day.isToday">
+            {{ day.label }}<span *ngIf="day.isToday" class="today-dot">hoy</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let hour of hourGridSlots">
+          <td class="cell-hora">{{ hour | number:'2.0-0' }}:00</td>
+          <td *ngFor="let day of weekGridDays" class="cell-slot" [class.cell-today]="day.isToday">
+            <div *ngFor="let cita of getCitasForSlot(day.date, hour); trackBy: trackByCita"
+                 class="grid-cita"
+                 [ngClass]="getGridCitaClass(cita)"
+                 [class.grid-cita-dim]="hayFiltroActivo && !citaMatchaFiltro(cita)"
+                 (click)="openCita.emit(cita)">
+              {{ getCitaName(cita) }}
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/week-grid/doctor-citas-week-grid.component.ts
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/week-grid/doctor-citas-week-grid.component.ts
@@ -1,0 +1,66 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Cita } from '../../../../../services/cita.service';
+import {
+  buildWeekDays,
+  formatDate,
+  getCitaName,
+  getGridCitaClass,
+  getMonday,
+  trackByCita,
+  weekLabelFromStart,
+} from '../doctor-citas-utils';
+
+@Component({
+  selector: 'app-doctor-citas-week-grid',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './doctor-citas-week-grid.component.html',
+})
+export class DoctorCitasWeekGridComponent {
+  @Input() citas: Cita[] = [];
+  @Input() weekStart: Date = getMonday(new Date());
+  @Input() hayFiltroActivo = false;
+  @Input() citaMatchaFiltro: (c: Cita) => boolean = () => true;
+
+  @Output() openCita = new EventEmitter<Cita>();
+  @Output() weekStartChange = new EventEmitter<Date>();
+
+  readonly hourGridSlots: number[] = [8, 9, 10, 11, 12, 13, 14, 15, 16];
+  readonly trackByCita = trackByCita;
+  readonly getCitaName = getCitaName;
+  readonly getGridCitaClass = getGridCitaClass;
+
+  get today(): string {
+    return formatDate(new Date());
+  }
+
+  get weekGridDays(): { date: string; label: string; isToday: boolean }[] {
+    return buildWeekDays(this.weekStart, this.today);
+  }
+
+  get weekLabel(): string {
+    return weekLabelFromStart(this.weekStart);
+  }
+
+  changeWeek(direction: number): void {
+    const next = new Date(this.weekStart);
+    next.setDate(next.getDate() + direction * 7);
+    this.weekStart = next;
+    this.weekStartChange.emit(next);
+  }
+
+  goToThisWeek(): void {
+    const monday = getMonday(new Date());
+    this.weekStart = monday;
+    this.weekStartChange.emit(monday);
+  }
+
+  getCitasForSlot(date: string, hour: number): Cita[] {
+    return this.citas.filter(c => {
+      if (c.fecha_cita !== date) return false;
+      const h = parseInt(c.hora_cita.split(':')[0], 10);
+      return h === hour;
+    });
+  }
+}


### PR DESCRIPTION
## Resumen

Tercer paso de Fase 5. `doctor-citas.component.ts` tenía 816 líneas + HTML 557 + CSS 1468. Se extrae a 4 sub-componentes standalone + utils.

### Reducción del padre

| | Antes | Después |
|---|---|---|
| `doctor-citas.component.ts` | 816 | **379** |
| `doctor-citas.component.html` | 557 | **300** |

### Sub-componentes creados

| Componente | TS | HTML | Responsabilidad |
|---|---|---|---|
| `app-doctor-citas-filtros` | 26 | 29 | Buscador + filtros estatus/fechas |
| `app-doctor-citas-week-grid` | 66 | 36 | Agenda semanal con citas por slot |
| `app-doctor-citas-detail-drawer` | 44 | 71 | Drawer lateral de detalle |
| `app-nueva-cita-modal` | 304 | 145 | Wizard 3 pasos (autosuficiente — gestiona su propio calendar/availability) |

### Auxiliares compartidos

- `doctor-citas-utils.ts` — 138 líneas, funciones puras (normalizeTime, formatTime, getCitaName, getStatusColor, generateTimeSlots, etc.)
- `doctor-citas-types.ts` — 29 líneas, interfaces (CalendarDay, DayAvailabilityRecord, CitasFiltro)

### Detalles técnicos

- Padre usa `ViewEncapsulation.None` — sus estilos pasan a globales para alcanzar a los hijos sin duplicar CSS.
- CSS del padre intacto (1468 líneas), por refactorizar en PR futuro.
- Modales pequeños restantes (consulta, perfil alumno, reprogramar) siguen en el padre — no eran candidatos prioritarios del plan.
- `nueva-cita-modal` ahora es autosuficiente: maneja su propio CitaService, availability, calendar y form. El padre solo escucha `(created)` para refrescar.

## Test plan

- [x] `ng build` — OK
- [ ] Filtros (estatus, fechas, buscador) — filtra lista y week-grid
- [ ] Week-grid — navegar semanas (anterior/hoy/siguiente), click en cita abre drawer
- [ ] Drawer — atender / cancelar / no asistió / reprogramar / ver expediente
- [ ] Modal nueva cita — wizard 3 pasos completo (paso 1 alumno, paso 2 fecha+hora, paso 3 confirmar)
- [ ] Modal consulta, modal perfil alumno, modal reprogramar — siguen funcionando