### PR TITLE
refactor(frontend): centralizar logout + extraer IdleService (fase 5c)

### DIFF
--- a/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/frontend/src/app/components/admin/admin-dashboard/admin-dashboard.component.ts
@@ -120,8 +120,7 @@ export class AdminDashboardComponent implements OnInit, OnDestroy {
   }
 
   logout(): void {
-    this.authService.logout();
-    this.router.navigate(['/login']);
+    this.authService.logout('/acceso-gestion');
   }
 
   private loadStats(): void {

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.component.ts
@@ -207,7 +207,6 @@ export class DiasEspecialesComponent implements OnInit, OnDestroy {
   }
 
   logout(): void {
-    this.authService.logout();
-    this.router.navigate(['/acceso-gestion']);
+    this.authService.logout('/acceso-gestion');
   }
 }

--- a/frontend/src/app/components/admin/usuarios/usuarios.component.ts
+++ b/frontend/src/app/components/admin/usuarios/usuarios.component.ts
@@ -255,7 +255,6 @@ export class UsuariosComponent implements OnInit, OnDestroy {
   }
 
   logout(): void {
-    this.authService.logout();
-    this.router.navigate(['/acceso-gestion']);
+    this.authService.logout('/acceso-gestion');
   }
 }

--- a/frontend/src/app/components/doctor/doctor-dashboard/doctor-dashboard.component.ts
+++ b/frontend/src/app/components/doctor/doctor-dashboard/doctor-dashboard.component.ts
@@ -71,6 +71,5 @@ export class DoctorDashboardComponent implements OnInit {
 
   logout(): void {
     this.authService.logout();
-    this.router.navigate(['/login']);
   }
 }

--- a/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
+++ b/frontend/src/app/components/student/student-dashboard/student-dashboard.component.ts
@@ -75,6 +75,5 @@ export class StudentDashboardComponent implements OnInit, OnDestroy {
 
   logout(): void {
     this.authService.logout();
-    this.router.navigate(['/login']);
   }
 }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { BehaviorSubject, Observable, throwError } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { API_BASE_URL } from './api-config';
+import { IdleService } from './idle.service';
 
 interface User {
   id: number;
@@ -24,101 +25,40 @@ interface LoginResponse {
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthService implements OnDestroy {
   private apiUrl = API_BASE_URL;
   private tokenKey = 'auth_token';
   private userKey = 'user_data';
-  private lastActivityKey = 'last_activity';
-  private idleTimeoutMs = 30 * 60 * 1000; // 30 minutos
-  private idleWarningMs = 5 * 60 * 1000;  // mostrar aviso 5 min antes de cerrar sesión
-  private idleCheckInterval: ReturnType<typeof setInterval> | null = null;
   private userSubject = new BehaviorSubject<User | null>(null);
   private isAuthenticatedSubject = new BehaviorSubject<boolean>(false);
-  private idleWarningSubject = new BehaviorSubject<number>(0); // minutos restantes (0 = sin aviso)
 
-  // Exponer observables
   public currentUser$ = this.userSubject.asObservable();
   public isAuthenticated$ = this.isAuthenticatedSubject.asObservable();
-  public idleWarning$ = this.idleWarningSubject.asObservable();
+  public idleWarning$: Observable<number>;
 
-  private activityEvents = ['mousemove', 'keydown', 'click', 'scroll', 'touchstart'];
-  private boundOnActivity = this.onActivity.bind(this);
-
-  constructor(private http: HttpClient, private router: Router, private ngZone: NgZone) {
+  constructor(private http: HttpClient, private router: Router, private idle: IdleService) {
+    this.idleWarning$ = this.idle.warning$;
     const user = this.getStoredUser();
     if (user) {
-      if (this.isSessionExpiredByIdle()) {
+      if (this.idle.isExpired()) {
         this.clearAuthData();
       } else {
         this.userSubject.next(user);
         this.isAuthenticatedSubject.next(true);
-        this.startIdleTracking();
+        this.idle.start(() => this.logout());
       }
     }
   }
 
   ngOnDestroy(): void {
-    this.stopIdleTracking();
-  }
-
-  private onActivity(): void {
-    localStorage.setItem(this.lastActivityKey, Date.now().toString());
-  }
-
-  private isSessionExpiredByIdle(): boolean {
-    const last = localStorage.getItem(this.lastActivityKey);
-    if (!last) return false;
-    return (Date.now() - parseInt(last, 10)) > this.idleTimeoutMs;
-  }
-
-  private startIdleTracking(): void {
-    this.onActivity();
-    this.activityEvents.forEach(evt =>
-      document.addEventListener(evt, this.boundOnActivity, { passive: true })
-    );
-    this.ngZone.runOutsideAngular(() => {
-      this.idleCheckInterval = setInterval(() => {
-        if (this.isSessionExpiredByIdle()) {
-          this.ngZone.run(() => {
-            this.idleWarningSubject.next(0);
-            this.logout();
-            this.router.navigate(['/login']);
-          });
-          return;
-        }
-        const remainingMs = this.remainingIdleMs();
-        const shouldWarn = remainingMs > 0 && remainingMs <= this.idleWarningMs;
-        const minutes = shouldWarn ? Math.max(1, Math.ceil(remainingMs / 60_000)) : 0;
-        if (minutes !== this.idleWarningSubject.value) {
-          this.ngZone.run(() => this.idleWarningSubject.next(minutes));
-        }
-      }, 30_000);
-    });
-  }
-
-  private remainingIdleMs(): number {
-    const last = localStorage.getItem(this.lastActivityKey);
-    if (!last) return this.idleTimeoutMs;
-    return this.idleTimeoutMs - (Date.now() - parseInt(last, 10));
+    this.idle.stop();
   }
 
   // Llamado desde el modal de aviso para extender la sesión sin esperar otra actividad real.
   extendSession(): void {
-    this.onActivity();
-    this.idleWarningSubject.next(0);
-  }
-
-  private stopIdleTracking(): void {
-    this.activityEvents.forEach(evt =>
-      document.removeEventListener(evt, this.boundOnActivity)
-    );
-    if (this.idleCheckInterval) {
-      clearInterval(this.idleCheckInterval);
-      this.idleCheckInterval = null;
-    }
-    this.idleWarningSubject.next(0);
+    this.idle.extend();
   }
 
   login(identificador: string, password: string, tipoUsuario: 'alumno' | 'doctor' | 'admin'): Observable<LoginResponse> {
@@ -135,12 +75,12 @@ export class AuthService implements OnDestroy {
             this.setUser(response.user);
             this.isAuthenticatedSubject.next(true);
             this.userSubject.next(response.user);
-            this.startIdleTracking();
+            this.idle.start(() => this.logout());
             this.redirectUser(response.user.tipo);
           } else if (response && response.requires_2fa) {
             sessionStorage.setItem('pending_2fa', JSON.stringify({
               user_id: response.user_id,
-              email_masked: response.email_masked
+              email_masked: response.email_masked,
             }));
             this.router.navigate(['/verify-2fa']);
           }
@@ -148,8 +88,7 @@ export class AuthService implements OnDestroy {
         catchError(error => this.handleError(error))
       );
   }
-  
-  // Método privado para manejar errores
+
   private handleError(error: HttpErrorResponse) {
     let errorMessage = 'Ocurrió un error al procesar la solicitud.';
 
@@ -188,64 +127,55 @@ export class AuthService implements OnDestroy {
     return null;
   }
 
-  logout(): void {
-    // Realizar la petición de cierre de sesión
+  // redirectTo permite que admin vaya a /acceso-gestion en lugar de /login
+  logout(redirectTo: string = '/login'): void {
     this.http.post(`${this.apiUrl}/logout`, {}).subscribe({
       next: () => {
         this.clearAuthData();
-        this.router.navigate(['/login']);
+        this.router.navigate([redirectTo]);
       },
-      error: (error) => {
-        // Limpiar datos de autenticación incluso si hay error
+      error: () => {
         this.clearAuthData();
-        this.router.navigate(['/login']);
-      }
+        this.router.navigate([redirectTo]);
+      },
     });
   }
-  
+
   private clearAuthData(): void {
-    this.stopIdleTracking();
+    this.idle.stop();
     localStorage.removeItem(this.tokenKey);
     localStorage.removeItem(this.userKey);
-    localStorage.removeItem(this.lastActivityKey);
     this.isAuthenticatedSubject.next(false);
     this.userSubject.next(null);
   }
 
-  // Obtener el estado de autenticación actual
   isAuthenticated(): boolean {
     return this.isAuthenticatedSubject.value;
   }
 
-  // Obtener el token del almacenamiento local
   getToken(): string | null {
     return localStorage.getItem(this.tokenKey);
   }
-  
-  // Obtener la información del usuario actual
+
   getCurrentUser(): any {
     const userJson = localStorage.getItem(this.userKey);
     return userJson ? JSON.parse(userJson) : null;
   }
-  
-  // Verificar si el usuario actual tiene un rol específico
+
   hasRole(role: string): boolean {
     const user = this.getCurrentUser();
     return !!user && user.tipo === role;
   }
 
-  // Obtener el tipo de usuario actual (alumno/doctor)
   getUserType(): string | null {
     const user = this.getCurrentUser();
     return user ? user.tipo : null;
   }
 
-  // Guardar el token en el almacenamiento local
   private setToken(token: string): void {
     localStorage.setItem(this.tokenKey, token);
   }
-  
-  // Guardar la información del usuario en el almacenamiento local
+
   private setUser(user: User): void {
     localStorage.setItem(this.userKey, JSON.stringify(user));
   }
@@ -258,8 +188,7 @@ export class AuthService implements OnDestroy {
     this.setUser(updated);
     this.userSubject.next(updated);
   }
-  
-  // Obtener el usuario almacenado en el almacenamiento local
+
   private getStoredUser(): User | null {
     const userJson = localStorage.getItem(this.userKey);
     if (!userJson) return null;
@@ -270,8 +199,7 @@ export class AuthService implements OnDestroy {
       return null;
     }
   }
-  
-  // Redirigir al usuario según su tipo
+
   private redirectUser(userType: string): void {
     switch (userType) {
       case 'alumno':

--- a/frontend/src/app/services/idle.service.ts
+++ b/frontend/src/app/services/idle.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+// Cierra sesion por inactividad. AuthService delega el tracking aqui para no mezclar
+// responsabilidades. El callback de timeout permite que el consumidor decida que hacer
+// (tipicamente: logout + navegar a /login).
+@Injectable({ providedIn: 'root' })
+export class IdleService implements OnDestroy {
+  private readonly TIMEOUT_MS = 30 * 60 * 1000;
+  private readonly WARNING_MS = 5 * 60 * 1000;
+  private readonly LAST_ACTIVITY_KEY = 'last_activity';
+  private readonly ACTIVITY_EVENTS = ['mousemove', 'keydown', 'click', 'scroll', 'touchstart'];
+
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private warningSubject = new BehaviorSubject<number>(0);
+  private onTimeoutCallback: (() => void) | null = null;
+
+  warning$: Observable<number> = this.warningSubject.asObservable();
+
+  constructor(private ngZone: NgZone) {}
+
+  ngOnDestroy(): void {
+    this.stop();
+  }
+
+  start(onTimeout: () => void): void {
+    if (this.interval) return;
+    this.onTimeoutCallback = onTimeout;
+    this.recordActivity();
+    this.ACTIVITY_EVENTS.forEach(evt =>
+      document.addEventListener(evt, this.handleActivity, { passive: true })
+    );
+    this.ngZone.runOutsideAngular(() => {
+      this.interval = setInterval(() => this.tick(), 30_000);
+    });
+  }
+
+  stop(): void {
+    this.ACTIVITY_EVENTS.forEach(evt =>
+      document.removeEventListener(evt, this.handleActivity)
+    );
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.warningSubject.next(0);
+    this.onTimeoutCallback = null;
+  }
+
+  extend(): void {
+    this.recordActivity();
+    this.warningSubject.next(0);
+  }
+
+  isExpired(): boolean {
+    const last = localStorage.getItem(this.LAST_ACTIVITY_KEY);
+    if (!last) return false;
+    return (Date.now() - parseInt(last, 10)) > this.TIMEOUT_MS;
+  }
+
+  private handleActivity = (): void => {
+    this.recordActivity();
+  };
+
+  private recordActivity(): void {
+    localStorage.setItem(this.LAST_ACTIVITY_KEY, Date.now().toString());
+  }
+
+  private remainingMs(): number {
+    const last = localStorage.getItem(this.LAST_ACTIVITY_KEY);
+    if (!last) return this.TIMEOUT_MS;
+    return this.TIMEOUT_MS - (Date.now() - parseInt(last, 10));
+  }
+
+  private tick(): void {
+    if (this.isExpired()) {
+      this.ngZone.run(() => {
+        this.warningSubject.next(0);
+        this.onTimeoutCallback?.();
+      });
+      return;
+    }
+    const remaining = this.remainingMs();
+    const shouldWarn = remaining > 0 && remaining <= this.WARNING_MS;
+    const minutes = shouldWarn ? Math.max(1, Math.ceil(remaining / 60_000)) : 0;
+    if (minutes !== this.warningSubject.value) {
+      this.ngZone.run(() => this.warningSubject.next(minutes));
+    }
+  }
+}


### PR DESCRIPTION
## Resumen

Séptimo paso de Fase 5. Centralización de lógica duplicada.

### 5C-8: logout centralizado

**Bug encontrado de paso**: `AuthService.logout()` navegaba a `/login` con un `subscribe` async; los 5 componentes que envolvían el logout también navegaban manualmente — race condition entre los dos `router.navigate`. Admin sufría especialmente porque navegaban a `/acceso-gestion`.

**Fix**: `AuthService.logout(redirectTo: string = '/login')` acepta ruta opcional. Componentes eliminaron su `router.navigate` manual:
- `student-dashboard`, `doctor-dashboard` → `this.authService.logout()` (default `/login`)
- `admin-dashboard`, `admin/usuarios`, `admin/dias-especiales` → `this.authService.logout('/acceso-gestion')`

### 5C-9: IdleService extraído

`AuthService` tenía mezclada lógica de auth + idle tracking. Extraído a `idle.service.ts`:

| | Antes | Después |
|---|---|---|
| `auth.service.ts` | 289 | **218** |
| `idle.service.ts` | — | 90 |

`IdleService` expone: `start(onTimeout)`, `stop()`, `extend()`, `isExpired()`, `warning$`. AuthService delega y re-expone `idleWarning$` para compatibilidad — `idle-warning` component no requiere cambios.

### 5C-7: skip

`loadCitas` no es duplicación real — cada componente tiene su propio método que llama al service apropiado para su pantalla. El service ya está centralizado.

## Test plan

- [x] `ng build` — OK
- [ ] Logout student → redirige a `/login`
- [ ] Logout doctor → redirige a `/login`
- [ ] Logout admin → redirige a `/acceso-gestion` (no race condition)
- [ ] Modal idle warning aparece a los 25 min de inactividad
- [ ] Botón "Continuar sesión" extiende el timer
- [ ] Sesión expira a los 30 min y cierra sesión