### PR TITLE
refactor(frontend): centralizar localStorage via AuthService (fase 5d-12)

### DIFF
--- a/frontend/src/app/components/admin/admin-login/admin-login.component.ts
+++ b/frontend/src/app/components/admin/admin-login/admin-login.component.ts
@@ -6,6 +6,7 @@ import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil, finalize } from 'rxjs/operators';
 import { API_BASE_URL } from '../../../services/api-config';
+import { AuthService } from '../../../services/auth.service';
 
 @Component({
   selector: 'app-admin-login',
@@ -23,7 +24,7 @@ export class AdminLoginComponent implements OnDestroy {
   toast: string | null = null;
   private toastTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private fb: FormBuilder, private router: Router, private http: HttpClient) {
+  constructor(private fb: FormBuilder, private router: Router, private http: HttpClient, private authService: AuthService) {
     this.form = this.fb.group({
       usuario: ['', Validators.required],
       password: ['', Validators.required]
@@ -46,7 +47,7 @@ export class AdminLoginComponent implements OnDestroy {
       tipo_usuario: 'admin'
     };
 
-    this.http.post<{ token?: string; user?: { tipo: string }; requires_2fa?: boolean; user_id?: number; email_masked?: string }>(`${API_BASE_URL}/login`, body)
+    this.http.post<{ token?: string; user?: { id: number; nombre: string; apellido: string; email: string; tipo: string }; requires_2fa?: boolean; user_id?: number; email_masked?: string }>(`${API_BASE_URL}/login`, body)
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => { this.isLoading = false; })
@@ -62,8 +63,7 @@ export class AdminLoginComponent implements OnDestroy {
             return;
           }
           if (res.token && res.user) {
-            localStorage.setItem('auth_token', res.token);
-            localStorage.setItem('user_data', JSON.stringify(res.user));
+            this.authService.setAuthData(res.token, res.user);
             this.router.navigate(['/admin-dashboard']);
           } else {
             this.mostrarToast('Respuesta inesperada del servidor');

--- a/frontend/src/app/components/admin/dashboard/admin-dashboard.service.ts
+++ b/frontend/src/app/components/admin/dashboard/admin-dashboard.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 
@@ -21,10 +21,8 @@ export class AdminDashboardService {
 
   constructor(private http: HttpClient) {}
 
-  // GET /api/admin/stats — métricas generales del sistema
+  // GET /api/admin/stats — métricas generales del sistema. AuthInterceptor agrega Bearer.
   getStats(): Observable<AdminStats> {
-    const token = localStorage.getItem('auth_token');
-    const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
-    return this.http.get<AdminStats>(`${this.base}/admin/stats`, { headers });
+    return this.http.get<AdminStats>(`${this.base}/admin/stats`);
   }
 }

--- a/frontend/src/app/components/admin/dias-especiales/dias-especiales.service.ts
+++ b/frontend/src/app/components/admin/dias-especiales/dias-especiales.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../environments/environment';
@@ -25,26 +25,19 @@ export class DiasEspecialesService {
 
   constructor(private http: HttpClient) {}
 
-  private headers(): { headers: HttpHeaders } {
-    const token = localStorage.getItem('auth_token');
-    return { headers: new HttpHeaders({ Authorization: `Bearer ${token}` }) };
-  }
-
-  // GET /api/admin/calendario?month=X&year=Y → días del mes
+  // GET /api/admin/calendario?month=X&year=Y → días del mes. AuthInterceptor agrega Bearer.
   getDias(month: number, year: number): Observable<DiaEspecialItem[]> {
     const params = new HttpParams().set('month', month).set('year', year);
-    return this.http.get<{ dias: DiaEspecialItem[] }>(this.base, { ...this.headers(), params })
+    return this.http.get<{ dias: DiaEspecialItem[] }>(this.base, { params })
       .pipe(map(res => res.dias));
   }
 
-  // POST /api/admin/calendario → registra/actualiza día especial
   agregar(payload: DiaEspecialPayload): Observable<DiaEspecialItem> {
-    return this.http.post<{ dia: DiaEspecialItem }>(this.base, payload, this.headers())
+    return this.http.post<{ dia: DiaEspecialItem }>(this.base, payload)
       .pipe(map(res => res.dia));
   }
 
-  // DELETE /api/admin/calendario/{id} → eliminar
   eliminar(id: number): Observable<void> {
-    return this.http.delete<void>(`${this.base}/${id}`, this.headers());
+    return this.http.delete<void>(`${this.base}/${id}`);
   }
 }

--- a/frontend/src/app/components/admin/usuarios/usuarios.service.ts
+++ b/frontend/src/app/components/admin/usuarios/usuarios.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 
@@ -31,38 +31,29 @@ export class UsuariosService {
 
   constructor(private http: HttpClient) {}
 
-  private headers(): { headers: HttpHeaders } {
-    const token = localStorage.getItem('auth_token');
-    return { headers: new HttpHeaders({ Authorization: `Bearer ${token}` }) };
-  }
-
-  // GET /api/admin/usuarios — lista paginada con filtros
+  // AuthInterceptor agrega Bearer a todas las peticiones — no se requieren headers manuales.
   getUsuarios(params: { rol?: string; suspendido?: boolean; page?: number; search?: string }): Observable<UsuariosPaginados> {
     let p = new HttpParams();
     if (params.rol) p = p.set('rol', params.rol);
     if (params.suspendido !== undefined) p = p.set('suspendido', String(params.suspendido));
     if (params.page) p = p.set('page', String(params.page));
     if (params.search) p = p.set('search', params.search);
-    return this.http.get<UsuariosPaginados>(`${this.base}/usuarios`, { ...this.headers(), params: p });
+    return this.http.get<UsuariosPaginados>(`${this.base}/usuarios`, { params: p });
   }
 
-  // PUT /api/admin/usuarios/{id}/suspender
   suspender(id: number): Observable<any> {
-    return this.http.put(`${this.base}/usuarios/${id}/suspender`, {}, this.headers());
+    return this.http.put(`${this.base}/usuarios/${id}/suspender`, {});
   }
 
-  // PUT /api/admin/usuarios/{id}/reactivar
   reactivar(id: number): Observable<any> {
-    return this.http.put(`${this.base}/usuarios/${id}/reactivar`, {}, this.headers());
+    return this.http.put(`${this.base}/usuarios/${id}/reactivar`, {});
   }
 
-  // POST /api/admin/usuarios
   crearUsuario(payload: any): Observable<any> {
-    return this.http.post(`${this.base}/usuarios`, payload, this.headers());
+    return this.http.post(`${this.base}/usuarios`, payload);
   }
 
-  // PUT /api/admin/usuarios/{id}
   actualizarUsuario(id: number, payload: any): Observable<any> {
-    return this.http.put(`${this.base}/usuarios/${id}`, payload, this.headers());
+    return this.http.put(`${this.base}/usuarios/${id}`, payload);
   }
 }

--- a/frontend/src/app/components/login/verify-2fa/verify-2fa.component.ts
+++ b/frontend/src/app/components/login/verify-2fa/verify-2fa.component.ts
@@ -6,6 +6,7 @@ import { HttpClient } from '@angular/common/http';
 import { Subject } from 'rxjs';
 import { takeUntil, finalize } from 'rxjs/operators';
 import { API_BASE_URL } from '../../../services/api-config';
+import { AuthService } from '../../../services/auth.service';
 
 @Component({
   selector: 'app-verify-2fa',
@@ -36,7 +37,7 @@ export class Verify2faComponent implements OnInit, OnDestroy {
   userId: number | null = null;
   emailMasked = '';
 
-  constructor(private http: HttpClient, private router: Router) {}
+  constructor(private http: HttpClient, private router: Router, private authService: AuthService) {}
 
   ngOnInit() {
     const pending = sessionStorage.getItem('pending_2fa');
@@ -73,9 +74,7 @@ export class Verify2faComponent implements OnInit, OnDestroy {
         if (response.device_token) {
           localStorage.setItem(`${response.tipo}_device_token`, response.device_token);
         }
-        // Guardar token y usuario
-        localStorage.setItem('auth_token', response.token);
-        localStorage.setItem('user_data', JSON.stringify(response.user));
+        this.authService.setAuthData(response.token, response.user);
         sessionStorage.removeItem('pending_2fa');
 
         // Redirigir según rol

--- a/frontend/src/app/guards/auth.guard.ts
+++ b/frontend/src/app/guards/auth.guard.ts
@@ -1,68 +1,42 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
+import { AuthService } from '../services/auth.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthGuard implements CanActivate {
-  constructor(private router: Router) {}
+  private router = inject(Router);
+  private auth = inject(AuthService);
 
   canActivate(
     route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
+    state: RouterStateSnapshot,
   ): boolean | UrlTree | Observable<boolean | UrlTree> | Promise<boolean | UrlTree> {
-    // Obtener el token del almacenamiento local
-    const token = localStorage.getItem('auth_token');
-    
-    // Si no hay token, redirigir al login
+    const token = this.auth.getToken();
     if (!token) {
-      return this.router.createUrlTree(['/login'], {
-        queryParams: { returnUrl: state.url }
-      });
+      return this.router.createUrlTree(['/login'], { queryParams: { returnUrl: state.url } });
     }
-    
-    // Obtener los roles permitidos de la ruta
+
     const allowedRoles = route.data['roles'] as Array<string>;
-    
-    // Si no hay roles específicos requeridos, permitir el acceso
     if (!allowedRoles || allowedRoles.length === 0) {
       return true;
     }
-    
-    // Obtener el usuario del almacenamiento local
-    const userJson = localStorage.getItem('user_data');
-    
-    if (!userJson) {
-      // Si no hay información del usuario, redirigir al login
-      return this.router.createUrlTree(['/login'], {
-        queryParams: { returnUrl: state.url }
-      });
+
+    const user = this.auth.getCurrentUser();
+    if (!user) {
+      return this.router.createUrlTree(['/login'], { queryParams: { returnUrl: state.url } });
     }
-    
-    try {
-      const user = JSON.parse(userJson);
-      
-      // Verificar si el usuario tiene alguno de los roles permitidos
-      if (user && user.tipo && allowedRoles.includes(user.tipo)) {
-        return true;
-      }
-      
-      // Si el usuario no tiene los permisos necesarios, redirigir a una página de acceso denegado
-      // o de vuelta al dashboard correspondiente
-      if (user.tipo === 'alumno') {
-        return this.router.createUrlTree(['/student-dashboard']);
-      } else if (user.tipo === 'doctor') {
-        return this.router.createUrlTree(['/doctor-dashboard']);
-      } else if (user.tipo === 'admin') {
-        return this.router.createUrlTree(['/admin-dashboard']);
-      }
-      
-      // Por defecto, redirigir al login
-      return this.router.createUrlTree(['/login']);
-      
-    } catch (error) {
-      return this.router.createUrlTree(['/login']);
+
+    if (user.tipo && allowedRoles.includes(user.tipo)) {
+      return true;
     }
+
+    if (user.tipo === 'alumno') return this.router.createUrlTree(['/student-dashboard']);
+    if (user.tipo === 'doctor') return this.router.createUrlTree(['/doctor-dashboard']);
+    if (user.tipo === 'admin') return this.router.createUrlTree(['/admin-dashboard']);
+
+    return this.router.createUrlTree(['/login']);
   }
 }

--- a/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.ts
@@ -34,12 +34,9 @@ export class AuthInterceptor implements HttpInterceptor {
           : throwError(() => err)
       }),
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401) {
-          if (this.router.url !== '/login') {
-            this.authService.logout();
-            this.router.navigate(['/login']);
-          }
-          return throwError(() => error);
+        if (error.status === 401 && this.router.url !== '/login') {
+          // AuthService.logout ya navega — no se requiere router.navigate manual
+          this.authService.logout();
         }
         return throwError(() => error);
       })

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -162,6 +162,16 @@ export class AuthService implements OnDestroy {
     return userJson ? JSON.parse(userJson) : null;
   }
 
+  // Llamado desde flujos especiales (admin-login, verify-2fa) que ya hicieron auth fuera
+  // del flujo normal login() y solo necesitan persistir + activar idle tracking.
+  setAuthData(token: string, user: User): void {
+    this.setToken(token);
+    this.setUser(user);
+    this.isAuthenticatedSubject.next(true);
+    this.userSubject.next(user);
+    this.idle.start(() => this.logout());
+  }
+
   hasRole(role: string): boolean {
     const user = this.getCurrentUser();
     return !!user && user.tipo === role;

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
@@ -23,40 +23,25 @@ export class UserService {
 
   constructor(private http: HttpClient) {}
 
-  private getHeaders(): HttpHeaders {
-    const token = localStorage.getItem('auth_token');
-    return new HttpHeaders({
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
-    });
-  }
-
-  // Obtener todos los usuarios (solo doctores y admins)
+  // AuthInterceptor agrega Bearer + Content-Type automaticamente.
   getUsers(): Observable<User[]> {
-    return this.http.get<User[]>(this.apiUrl, { headers: this.getHeaders() })
-      .pipe(catchError(this.handleError));
+    return this.http.get<User[]>(this.apiUrl).pipe(catchError(this.handleError));
   }
 
-  // Obtener pacientes (alumnos)
   getPacientes(): Observable<User[]> {
-    return this.http.get<User[]>(`${this.apiUrl}/pacientes`, { headers: this.getHeaders() })
-      .pipe(catchError(this.handleError));
+    return this.http.get<User[]>(`${this.apiUrl}/pacientes`).pipe(catchError(this.handleError));
   }
 
-  // Obtener doctores
   getDoctores(): Observable<User[]> {
-    return this.http.get<User[]>(`${this.apiUrl}/doctores`, { headers: this.getHeaders() })
-      .pipe(catchError(this.handleError));
+    return this.http.get<User[]>(`${this.apiUrl}/doctores`).pipe(catchError(this.handleError));
   }
 
-  // Obtener alumnos (pacientes)
   getAlumnos(): Observable<{alumnos: User[]}> {
-    return this.http.get<{alumnos: User[]}>(`${this.apiUrl}/alumnos`, { headers: this.getHeaders() })
-      .pipe(catchError(this.handleError));
+    return this.http.get<{alumnos: User[]}>(`${this.apiUrl}/alumnos`).pipe(catchError(this.handleError));
   }
+
   getUser(id: number): Observable<User> {
-    return this.http.get<User>(`${this.apiUrl}/${id}`, { headers: this.getHeaders() })
-      .pipe(catchError(this.handleError));
+    return this.http.get<User>(`${this.apiUrl}/${id}`).pipe(catchError(this.handleError));
   }
 
   private handleError(error: any): Observable<never> {


### PR DESCRIPTION
## Resumen

Octavo paso de Fase 5. Última pieza del refactor estructural.

### 5D-10: applicationId Flutter
**Ya estaba hecho** — el `applicationId` en `mobile/android/app/build.gradle.kts` es `com.yoltec.app` (no `com.example.yoltec_mobile` como decía el plan). El plan estaba desactualizado. ✅

### 5D-12: AuthService centralizado

Antes había **8 lugares** tocando `localStorage.getItem('auth_token')` / `'user_data'` directamente, fuera de `AuthService`. Esto rompía el encapsulado del servicio de auth.

**AuthService**: nuevo método público `setAuthData(token, user)` que:
- Guarda token + user en localStorage
- Actualiza subjects (`isAuthenticated$`, `currentUser$`)
- Arranca idle tracking
- No navega (quien llama decide a dónde ir)

**Componentes que ahora delegan**:
- `admin-login.component.ts` → `authService.setAuthData()`
- `verify-2fa.component.ts` → `authService.setAuthData()`
- `auth.guard.ts` → `authService.getToken()` y `authService.getCurrentUser()`

**Servicios sin headers manuales** (el `AuthInterceptor` ya agrega Bearer globalmente):
- `admin-dashboard.service.ts`
- `dias-especiales.service.ts`
- `usuarios.service.ts`
- `user.service.ts`

**Bonus**: `auth.interceptor.ts` ya no llama `router.navigate(['/login'])` después de `logout()` — el service navega solo.

Net: **-118 líneas** (eliminación de duplicación de headers + clearAuthData), **+65 líneas** (setAuthData + imports).

## Test plan

- [x] `ng build` — OK
- [ ] Login admin → llega a admin-dashboard
- [ ] Login alumno/doctor con 2FA → llega a su dashboard
- [ ] Guard funciona (acceso denegado redirige a login)
- [ ] 401 de backend → logout automático
- [ ] Las llamadas admin/* siguen autenticando correctamente