### PR TITLE
fix(prod): citas 500 + recetas paginadas en panel doctor

### DIFF
--- a/backend/app/Http/Controllers/CitaController.php
+++ b/backend/app/Http/Controllers/CitaController.php
@@ -23,14 +23,14 @@ class CitaController extends Controller
             ? Cita::where('alumno_id', $user->id)
                 ->with([
                     'doctor:id,nombre,apellido,username',
-                    'consulta:id,cita_id,diagnostico',
-                    'receta:id,cita_id,medicamento,dosis,indicaciones',
+                    'consulta:id,cita_id,diagnostico,tratamiento,observaciones',
+                    'receta:id,cita_id,medicamentos,indicaciones',
                 ])
                 ->orderBy('fecha_cita', 'desc')->orderBy('hora_cita', 'desc')->get()
             : Cita::with([
                     'alumno:id,nombre,apellido,numero_control',
                     'consulta:id,cita_id,diagnostico',
-                    'receta:id,cita_id,medicamento',
+                    'receta:id,cita_id,medicamentos',
                 ])
                 ->orderBy('fecha_cita', 'desc')->orderBy('hora_cita', 'desc')->get();
 

--- a/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-citas/doctor-citas.component.html
@@ -261,7 +261,7 @@
           <div *ngIf="historialAlumnoExpandido === item.id" class="historial-mini-detalle">
             <p *ngIf="item.consulta"><strong>Diagnóstico:</strong> {{ item.consulta.diagnostico }}</p>
             <p *ngIf="item.consulta"><strong>Tratamiento:</strong> {{ item.consulta.tratamiento }}</p>
-            <p *ngIf="item.receta"><strong>Receta:</strong> {{ item.receta.medicamento }} — {{ item.receta.dosis }}</p>
+            <p *ngIf="item.receta"><strong>Receta:</strong> {{ item.receta.medicamentos }}</p>
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/doctor/components-doctor/doctor-ficha-paciente/doctor-ficha-paciente.component.html
+++ b/frontend/src/app/components/doctor/components-doctor/doctor-ficha-paciente/doctor-ficha-paciente.component.html
@@ -100,8 +100,8 @@
               <p *ngIf="item.consulta.observaciones"><strong>Observaciones:</strong> {{ item.consulta.observaciones }}</p>
             </div>
             <div *ngIf="!item.consulta" class="tab-empty">Sin formulario de consulta registrado.</div>
-            <div *ngIf="item.receta?.medicamento || item.receta?.indicaciones" class="historial-receta">
-              <strong>Receta:</strong> {{ item.receta?.medicamento || item.receta?.indicaciones }}
+            <div *ngIf="item.receta?.medicamentos || item.receta?.indicaciones" class="historial-receta">
+              <strong>Receta:</strong> {{ item.receta?.medicamentos || item.receta?.indicaciones }}
             </div>
           </div>
         </div>

--- a/frontend/src/app/components/student/student-dashboard/components/sd-historial/sd-historial.component.html
+++ b/frontend/src/app/components/student/student-dashboard/components/sd-historial/sd-historial.component.html
@@ -25,7 +25,7 @@
         </div>
         <ng-template #sinConsulta><p class="sin-datos">Sin registro de consulta.</p></ng-template>
         <div *ngIf="item.receta" class="historial-receta">
-          <strong>Receta:</strong> {{ item.receta.medicamento }} — {{ item.receta.dosis }}
+          <strong>Receta:</strong> {{ item.receta.medicamentos }}
           <p *ngIf="item.receta.indicaciones">{{ item.receta.indicaciones }}</p>
         </div>
       </div>

--- a/frontend/src/app/services/perfil-medico.service.ts
+++ b/frontend/src/app/services/perfil-medico.service.ts
@@ -26,7 +26,7 @@ export interface ConsultaHistorial {
   motivo: string;
   doctor: { nombre: string; apellido: string } | null;
   consulta: { diagnostico: string; tratamiento: string; observaciones: string | null } | null;
-  receta: { medicamento: string; dosis: string; indicaciones: string } | null;
+  receta: { medicamentos: string; indicaciones: string } | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/services/receta.service.ts
+++ b/frontend/src/app/services/receta.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { API_BASE_URL } from './api-config';
 
 export interface Receta {
@@ -52,11 +52,13 @@ export class RecetaService {
 
   constructor(private http: HttpClient) {}
 
+  // Backend devuelve array plano para alumno y paginado {data:[...]} para doctor — normalizar aqui
   getRecetas(): Observable<Receta[]> {
     if (this.recetasCache && Date.now() < this.recetasCacheExpiry) {
       return of(this.recetasCache);
     }
-    return this.http.get<Receta[]>(this.baseUrl).pipe(
+    return this.http.get<Receta[] | { data: Receta[] }>(this.baseUrl).pipe(
+      map(res => Array.isArray(res) ? res : (res?.data ?? [])),
       tap(recetas => {
         this.recetasCache = recetas;
         this.recetasCacheExpiry = Date.now() + this.CACHE_TTL_MS;


### PR DESCRIPTION
## Causa raiz

### 1. `GET /api/citas` -> 500 (alumno y doctor)
`CitaController::index` hacia eager load con columnas que no existen en la tabla `recetas`:
- `medicamento` (la migracion creo `medicamentos`, plural)
- `dosis` (nunca existio)

Postgres devolvia "column does not exist" -> 500 en cualquier listado de citas. Esto rompia ambos dashboards principales.

### 2. `TypeError: t.slice is not a function` en doctor panel
`RecetaController::index` devuelve formas distintas:
- alumno: `Receta[]` (array plano)
- doctor: `LengthAwarePaginator` (objeto `{data:[...], current_page, ...}`)

Pero `RecetaService.getRecetas()` tipaba la respuesta como `Receta[]` y los componentes (`doctor-inicio`, `doctor-ficha-paciente`) hacian `recetas.slice(-2)` / `recetas.length`. Al ser objeto paginado revienta.

### 3. Datos faltantes en historial
`with('consulta:id,cita_id,diagnostico')` solo seleccionaba `diagnostico` pero los templates pintan `tratamiento` y `observaciones`. Agregadas al select.

## Cambios

- **backend/CitaController.php**: select correcto en eager load (`medicamentos`, `+tratamiento`, `+observaciones`)
- **frontend/receta.service.ts**: `map(res => Array.isArray(res) ? res : (res?.data ?? []))` para normalizar
- **frontend/perfil-medico.service.ts**: `ConsultaHistorial.receta` ahora `{ medicamentos, indicaciones }`
- **3 templates** (sd-historial, doctor-citas, doctor-ficha-paciente): `medicamento`/`dosis` -> `medicamentos`

## Test plan
- [ ] Render: alumno entra a Mis citas -> sin Server Error
- [ ] Render: doctor entra a Panel -> KPIs cargan + sin error `t.slice`
- [ ] Render: doctor entra a Citas -> calendario carga
- [ ] Historial muestra diagnostico+tratamiento+observaciones y receta con medicamentos+indicaciones