### PR TITLE
feat(sesiones): filtrar vencidos + comando purga + endpoint admin

### DIFF
--- a/backend/app/Console/Commands/PurgeStaleTokens.php
+++ b/backend/app/Console/Commands/PurgeStaleTokens.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class PurgeStaleTokens extends Command
+{
+    protected $signature = 'tokens:purge';
+    protected $description = 'Elimina tokens Sanctum vencidos (older than sanctum.expiration)';
+
+    public function handle(): void
+    {
+        $cutoff = now()->subMinutes((int) config('sanctum.expiration', 1440));
+
+        $affected = PersonalAccessToken::where('created_at', '<', $cutoff)->delete();
+
+        $this->info("Tokens eliminados: {$affected}");
+    }
+}

--- a/backend/app/Http/Controllers/PerfilController.php
+++ b/backend/app/Http/Controllers/PerfilController.php
@@ -60,21 +60,26 @@ class PerfilController extends Controller
         ]);
     }
 
-    // Listar sesiones activas (tokens Sanctum)
+    // Listar sesiones activas (tokens Sanctum) — filtra tokens vencidos segun sanctum.expiration
     public function sesiones(Request $request)
     {
         $user = $request->user();
         $currentTokenId = $user->currentAccessToken()->id;
+        $cutoff = now()->subMinutes((int) config('sanctum.expiration', 1440));
 
-        $sesiones = $user->tokens()->orderByDesc('last_used_at')->get()->map(function ($token) use ($currentTokenId) {
-            return [
-                'id'           => $token->id,
-                'nombre'       => $token->name,
-                'ultimo_uso'   => $token->last_used_at,
-                'creada_en'    => $token->created_at,
-                'es_actual'    => $token->id === $currentTokenId,
-            ];
-        });
+        $sesiones = $user->tokens()
+            ->where('created_at', '>=', $cutoff)
+            ->orderByDesc('last_used_at')
+            ->get()
+            ->map(function ($token) use ($currentTokenId) {
+                return [
+                    'id'           => $token->id,
+                    'nombre'       => $token->name,
+                    'ultimo_uso'   => $token->last_used_at,
+                    'creada_en'    => $token->created_at,
+                    'es_actual'    => $token->id === $currentTokenId,
+                ];
+            });
 
         return response()->json(['sesiones' => $sesiones]);
     }

--- a/backend/app/Http/Controllers/SesionAdminController.php
+++ b/backend/app/Http/Controllers/SesionAdminController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class SesionAdminController extends Controller
+{
+    // GET /api/admin/sesiones — solo sesiones activas globales con info de usuario
+    // Query params: search (nombre/email/numero_control), only_used (1 = excluir tokens nunca usados)
+    public function index(Request $request)
+    {
+        $this->purgarVencidosLazy();
+
+        $cutoff   = now()->subMinutes((int) config('sanctum.expiration', 1440));
+        $search   = trim((string) $request->input('search', ''));
+        $onlyUsed = $request->boolean('only_used', false);
+
+        $query = PersonalAccessToken::where('created_at', '>=', $cutoff)
+            ->with('tokenable:id,nombre,apellido,email,numero_control,tipo');
+
+        if ($onlyUsed) {
+            $query->whereNotNull('last_used_at');
+        }
+
+        if ($search !== '') {
+            $query->whereHasMorph('tokenable', ['App\\Models\\User'], function ($q) use ($search) {
+                $q->where('nombre', 'ILIKE', "%{$search}%")
+                  ->orWhere('apellido', 'ILIKE', "%{$search}%")
+                  ->orWhere('email', 'ILIKE', "%{$search}%")
+                  ->orWhere('numero_control', 'ILIKE', "%{$search}%");
+            });
+        }
+
+        $sesiones = $query->orderByDesc('last_used_at')->orderByDesc('created_at')->limit(200)->get()
+            ->map(function ($token) {
+                $u = $token->tokenable;
+                return [
+                    'id'          => $token->id,
+                    'nombre'      => $token->name,
+                    'creada_en'   => $token->created_at,
+                    'ultimo_uso'  => $token->last_used_at,
+                    'usuario'     => $u ? [
+                        'id'             => $u->id,
+                        'nombre'         => $u->nombre,
+                        'apellido'       => $u->apellido,
+                        'email'          => $u->email,
+                        'numero_control' => $u->numero_control,
+                        'tipo'           => $u->tipo,
+                    ] : null,
+                ];
+            });
+
+        return response()->json([
+            'total'    => $sesiones->count(),
+            'sesiones' => $sesiones,
+        ]);
+    }
+
+    // DELETE /api/admin/sesiones/{id} — revocar sesion especifica
+    public function destroy($id)
+    {
+        $token = PersonalAccessToken::find($id);
+
+        if (!$token) {
+            return response()->json(['message' => 'Sesion no encontrada'], 404);
+        }
+
+        $token->delete();
+        return response()->json(['message' => 'Sesion revocada.']);
+    }
+
+    // POST /api/admin/sesiones/purgar — forzar limpieza inmediata de vencidos
+    public function purgar()
+    {
+        $cutoff   = now()->subMinutes((int) config('sanctum.expiration', 1440));
+        $affected = PersonalAccessToken::where('created_at', '<', $cutoff)->delete();
+        Cache::put('tokens_purged_lock', true, 3600);
+
+        return response()->json(['eliminados' => $affected]);
+    }
+
+    // Render free tier no corre scheduler — fallback throttled cada hora
+    private function purgarVencidosLazy(): void
+    {
+        if (Cache::has('tokens_purged_lock')) {
+            return;
+        }
+        Cache::put('tokens_purged_lock', true, 3600);
+
+        $cutoff = now()->subMinutes((int) config('sanctum.expiration', 1440));
+        PersonalAccessToken::where('created_at', '<', $cutoff)->delete();
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -35,6 +35,9 @@ return Application::configure(basePath: dirname(__DIR__))
 
         // Marcar como "no asistió" las citas programadas que ya pasaron — cada 5 min
         $schedule->command('citas:auto-cancelar-pasadas')->everyFiveMinutes();
+
+        // Eliminar tokens Sanctum vencidos (>24h) — diario a las 03:00
+        $schedule->command('tokens:purge')->dailyAt('03:00');
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         // Para rutas API, retornar siempre JSON en lugar de páginas HTML

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\CalendarioAdminController;
 use App\Http\Controllers\ConsultaController;
 use App\Http\Controllers\PerfilMedicoController;
 use App\Http\Controllers\SeedDemoController;
+use App\Http\Controllers\SesionAdminController;
 
 // Health check (Y20I-93)
 Route::get('/health', function () {
@@ -122,6 +123,10 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('/doctores',         [AdminController::class, 'storeDoctor']);
         Route::put('/doctores/{id}',     [AdminController::class, 'updateDoctor']);
         Route::delete('/doctores/{id}',  [AdminController::class, 'destroyDoctor']);
+
+        Route::get('/sesiones',          [SesionAdminController::class, 'index']);
+        Route::delete('/sesiones/{id}',  [SesionAdminController::class, 'destroy']);
+        Route::post('/sesiones/purgar',  [SesionAdminController::class, 'purgar']);
     });
 
     // ===== IA 1: Clasificador de Prioridad — solo doctor =====


### PR DESCRIPTION
## Problema

Las sesiones se acumulaban indefinidamente. La tabla `personal_access_tokens` crecia sin limite, y el perfil del alumno mostraba lista interminable con \"Ultimo uso: Nunca\" (tokens vencidos hace dias).

En local habia **49 tokens vencidos** (validados con `php artisan tokens:purge`).

Causa: `PerfilController::sesiones` listaba *todos* los tokens del usuario, ignorando que `sanctum.expiration=1440` (24h).

## Cambios

### 1. PerfilController::sesiones — filtra por `created_at >= now() - 24h`
Antes mostraba todo. Ahora solo muestra sesiones validas segun la config global de Sanctum.

### 2. Comando `php artisan tokens:purge`
Elimina tokens con `created_at < now() - sanctum.expiration`. Registrado en `bootstrap/app.php` para ejecutarse diariamente a las 03:00.

### 3. Endpoint admin `/api/admin/sesiones`
- `GET /api/admin/sesiones` — listado global. Query params: `search` (nombre/email/numero_control), `only_used=1` (excluir nunca usados). Incluye datos del usuario.
- `DELETE /api/admin/sesiones/{id}` — revocar sesion individual.
- `POST /api/admin/sesiones/purgar` — forzar purga inmediata.

### 4. Lazy purge en Render (free tier no corre scheduler)
Mismo patron que `marcarPasadasComoNoAsistio()`: si el lock de Cache no existe, ejecuta purga al consultar el listado admin (throttled 1 vez/hora).

## Test plan
- [x] `php artisan tokens:purge` -> elimino 49 tokens vencidos en local
- [x] `php artisan route:list --path=admin/sesiones` -> 3 rutas registradas
- [x] `php -l` sin errores
- [ ] Render: admin consulta `GET /api/admin/sesiones?only_used=1` -> ve solo sesiones activas
- [ ] Render: perfil de alumno muestra solo sesiones activas (no historial acumulado)

## Notas

- Sin UI nueva — el endpoint admin es consumible via Postman/curl o futura tab. El usuario eligio alcance \"Medio\" en el plan.
- Limit de 200 en el listado para evitar memoria en consultas masivas.